### PR TITLE
feat: implement Empty State with agent selection cards

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -266,7 +266,7 @@ $ npm test
 
 ### In Scope (MVP)
 - [x] Welcome Page (히어로, Open Repository, New Project, 최근 프로젝트 5개)
-- [ ] Empty State (모든 탭 닫힘 시 로고 + 에이전트 선택 카드 표시)
+- [x] Empty State (모든 탭 닫힘 시 로고 + 에이전트 선택 카드 표시)
 - [x] Workspace 관리 (멀티 프로젝트, Navbar collapsed, electron-store 영속화)
 - [x] Electron 앱 기본 셸 (프로젝트 구조, 빌드 파이프라인)
 - [x] 터미널 에뮬레이터 (xterm.js 기반, 멀티 탭, ANSI 256색, 탭 보존, 워크스페이스별 탭 상태 보존)

--- a/src/renderer/components/layout/EmptyState.tsx
+++ b/src/renderer/components/layout/EmptyState.tsx
@@ -1,0 +1,148 @@
+import { useEffect } from 'react';
+import { useTerminalStore } from '../../stores/terminal-store';
+import { useAgentStore } from '../../stores/agent-store';
+import { useWorkspaceStore } from '../../stores/workspace-store';
+import { useLayoutStore } from '../../stores/layout-store';
+
+interface AgentCard {
+  id: string;
+  label: string;
+  hint: string;
+  color: string;
+  type: 'agent' | 'shell';
+  command?: string;
+}
+
+const AGENT_CARDS: AgentCard[] = [
+  {
+    id: 'claude',
+    label: 'claude',
+    hint: 'Claude Code',
+    color: 'var(--agent-claude)',
+    type: 'agent',
+    command: 'claude',
+  },
+  {
+    id: 'gemini',
+    label: 'gemini',
+    hint: 'Gemini CLI',
+    color: 'var(--agent-gemini)',
+    type: 'agent',
+    command: 'gemini',
+  },
+  {
+    id: 'codex',
+    label: 'codex',
+    hint: 'Codex CLI',
+    color: 'var(--agent-codex)',
+    type: 'agent',
+    command: 'codex',
+  },
+  {
+    id: 'shell',
+    label: '$ shell',
+    hint: '$ shell',
+    color: 'var(--text-tertiary)',
+    type: 'shell',
+  },
+];
+
+interface EmptyStateProps {
+  paneId: string;
+}
+
+export function EmptyState({ paneId }: EmptyStateProps) {
+  const { addTab, setActiveTab } = useTerminalStore();
+  const { installedAgents, setInstalledAgents } = useAgentStore();
+  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
+  const workspaces = useWorkspaceStore((s) => s.workspaces);
+
+  useEffect(() => {
+    window.aide.agent.detect().then(setInstalledAgents).catch(() => {});
+  }, [setInstalledAgents]);
+
+  const isInstalled = (agentId: string) => {
+    if (agentId === 'shell') return true;
+    return installedAgents.some((a) => a.id === agentId);
+  };
+
+  const handleSelect = async (card: AgentCard) => {
+    if (!isInstalled(card.id)) return;
+
+    try {
+      const ws = workspaces.find((w) => w.id === activeWorkspaceId);
+      const sessionId = await window.aide.terminal.spawn(
+        card.command ? { shell: card.command, cwd: ws?.path } : { cwd: ws?.path }
+      );
+
+      const tab = {
+        id: crypto.randomUUID(),
+        type: card.type,
+        agentId: card.type === 'agent' ? card.id : undefined,
+        sessionId,
+        title: card.label,
+      };
+
+      addTab(tab);
+      setActiveTab(tab.id);
+      useLayoutStore.getState().addTabToPane(paneId, tab);
+    } catch {
+      // ignore spawn errors
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full w-full gap-6 select-none">
+      {/* Hero logo */}
+      <div
+        className="font-mono font-bold text-[48px] leading-none"
+        style={{ color: 'var(--accent)' }}
+      >
+        {'> aide_'}
+      </div>
+
+      {/* Subtitle */}
+      <p className="text-[14px] text-aide-text-secondary">
+        Select an agent to start a new session
+      </p>
+
+      {/* Agent cards */}
+      <div className="flex flex-row gap-4">
+        {AGENT_CARDS.map((card) => {
+          const installed = isInstalled(card.id);
+          return (
+            <button
+              key={card.id}
+              onClick={() => handleSelect(card)}
+              disabled={!installed}
+              className={`flex flex-col gap-2 p-4 rounded-lg border border-aide-border transition-colors ${
+                installed
+                  ? 'bg-aide-surface-elevated hover:bg-aide-surface cursor-pointer'
+                  : 'bg-aide-surface-elevated cursor-not-allowed'
+              }`}
+              style={{
+                width: '180px',
+                height: '120px',
+                borderTop: `3px solid ${card.color}`,
+                opacity: installed ? 1 : 0.4,
+              }}
+            >
+              <div className="flex items-center gap-2">
+                <span
+                  className="w-2 h-2 rounded-full shrink-0"
+                  style={{ backgroundColor: card.color }}
+                />
+                <span className="text-[13px] font-mono font-bold text-aide-text-primary">
+                  {card.label}
+                </span>
+              </div>
+              <span className="text-[11px] font-mono text-aide-text-secondary text-left">
+                {installed ? card.hint : 'Not installed'}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/layout/PaneView.tsx
+++ b/src/renderer/components/layout/PaneView.tsx
@@ -188,7 +188,7 @@ export function PaneView({ pane, showHeader = false }: PaneViewProps) {
               tab={tab}
               paneId={pane.id}
               isActive={tab.id === pane.activeTabId}
-              canClose={pane.tabs.length > 1 || showHeader}
+              canClose={true}
               onActivate={() => setActiveTab(pane.id, tab.id)}
               onClose={(e) => handleCloseTab(tab, e)}
               onContextMenu={(e) => handleContextMenu(e, tab.id)}

--- a/src/renderer/components/layout/PaneView.tsx
+++ b/src/renderer/components/layout/PaneView.tsx
@@ -1,13 +1,12 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { useDroppable, useDndMonitor } from '@dnd-kit/core';
 import { SortableContext, horizontalListSortingStrategy, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { TerminalPanel } from '../terminal/TerminalPanel';
 import { AgentDropdown } from '../terminal/AgentDropdown';
 import { PluginView } from '../plugin/PluginView';
+import { EmptyState } from './EmptyState';
 import { useLayoutStore } from '../../stores/layout-store';
-import { useTerminalStore } from '../../stores/terminal-store';
-import { useWorkspaceStore } from '../../stores/workspace-store';
 import type { Pane, TerminalTab } from '../../../types/ipc';
 
 const AGENT_COLORS: Record<string, string> = {
@@ -103,36 +102,9 @@ export function PaneView({ pane, showHeader = false }: PaneViewProps) {
   const removeTabFromPane = useLayoutStore((s) => s.removeTabFromPane);
   const splitPane = useLayoutStore((s) => s.splitPane);
   const closePaneAndMergeTabs = useLayoutStore((s) => s.closePaneAndMergeTabs);
-  const addTabToPane = useLayoutStore((s) => s.addTabToPane);
+
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [contextMenu, setContextMenu] = useState<ContextMenu | null>(null);
-  const autoSpawnedRef = useRef(false);
-
-  // Auto-spawn a shell when pane has no tabs
-  useEffect(() => {
-    console.log('[PaneView] auto-spawn check', { paneId: pane.id, tabCount: pane.tabs.length, autoSpawned: autoSpawnedRef.current });
-    if (pane.tabs.length > 0 || autoSpawnedRef.current) return;
-    autoSpawnedRef.current = true;
-
-    const wsId = useWorkspaceStore.getState().activeWorkspaceId;
-    if (!wsId) { console.log('[PaneView] no activeWorkspaceId, skip spawn'); return; }
-    const ws = useWorkspaceStore.getState().workspaces.find((w) => w.id === wsId);
-    console.log('[PaneView] spawning shell', { wsId, cwd: ws?.path });
-
-    window.aide.terminal.spawn({ cwd: ws?.path }).then((sessionId) => {
-      console.log('[PaneView] spawn success', { sessionId });
-      const tab: TerminalTab = {
-        id: crypto.randomUUID(),
-        type: 'shell',
-        sessionId,
-        title: '$ shell',
-      };
-      useTerminalStore.getState().addTab(tab);
-      addTabToPane(pane.id, tab);
-    }).catch(() => {
-      autoSpawnedRef.current = false;
-    });
-  }, [pane.tabs.length, pane.id, addTabToPane]);
 
   // Edge detection for drag-to-split
   type DropEdge = 'left' | 'right' | 'top' | 'bottom' | 'center' | null;
@@ -278,21 +250,25 @@ export function PaneView({ pane, showHeader = false }: PaneViewProps) {
             </span>
           </div>
         )}
-        {pane.tabs.map((tab) => {
-          const isVisible = tab.id === pane.activeTabId;
-          if (tab.type === 'plugin') {
+        {pane.tabs.length === 0 ? (
+          <EmptyState paneId={pane.id} />
+        ) : (
+          pane.tabs.map((tab) => {
+            const isVisible = tab.id === pane.activeTabId;
+            if (tab.type === 'plugin') {
+              return (
+                <div key={tab.id} className="absolute inset-0" style={{ display: isVisible ? 'block' : 'none' }}>
+                  <PluginView pluginId={tab.pluginId ?? tab.id} pluginName={tab.title} />
+                </div>
+              );
+            }
             return (
               <div key={tab.id} className="absolute inset-0" style={{ display: isVisible ? 'block' : 'none' }}>
-                <PluginView pluginId={tab.pluginId ?? tab.id} pluginName={tab.title} />
+                {tab.sessionId && <TerminalPanel sessionId={tab.sessionId} visible={isVisible && isFocused} />}
               </div>
             );
-          }
-          return (
-            <div key={tab.id} className="absolute inset-0" style={{ display: isVisible ? 'block' : 'none' }}>
-              {tab.sessionId && <TerminalPanel sessionId={tab.sessionId} visible={isVisible && isFocused} />}
-            </div>
-          );
-        })}
+          })
+        )}
       </div>
 
       {/* Context Menu */}


### PR DESCRIPTION
## Summary

- New `EmptyState` component with `> aide_` hero logo and 4 agent selection cards
- Shown when pane has no tabs (replaces auto-spawn behavior)
- Agent detection integration (uninstalled agents disabled at 40% opacity)
- Spawn-first pattern: pty spawns before tab creation
- PRD Empty State marked as completed

## Test plan

- [x] pnpm lint — 0 errors
- [x] pnpm test — 22/22 passing
- [ ] Manual: open project → Empty State shown (not auto-spawned shell)
- [ ] Manual: click agent card → terminal spawns
- [ ] Manual: close all tabs → Empty State reappears
- [ ] Manual: uninstalled agent card disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)