### PR TITLE
fix: resolve packaging issues for production builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,15 @@ Checking `node.children.length >= 3` only prevents direct siblings but allows ne
 ### Auto-spawn: Let PaneView own its lifecycle
 Moving auto-spawn from `App.tsx useEffect` to `PaneView` eliminates timing issues where layout-store state wasn't ready when App's effect fired. The component that renders the terminal should be responsible for ensuring it has content.
 
+### Packaging: Only externalize native modules in Vite
+Vite's `external` list means "don't bundle, resolve at runtime." But electron-forge's Vite plugin does NOT copy `node_modules` into the asar — only `.vite/build/` output goes in. So any pure JS package marked external (e.g., `electron-store`, `chokidar`) will be missing at runtime. **Only native modules (`node-pty`, `fsevents`) and `electron` should be external.** Pure JS deps get bundled by Vite automatically. Native modules need `afterCopy` hook in `forge.config.ts` to copy them into the build path.
+
+### Packaging: Packaged apps don't inherit shell PATH
+Electron apps launched from Finder (not terminal) get a minimal `PATH` (`/usr/bin:/bin`). CLI tools like `claude`, `zsh` in `/usr/local/bin` or `/opt/homebrew/bin` won't be found. **`fix-env.ts` runs the login shell to load the full environment before any pty spawn.** This only runs when `app.isPackaged` is true.
+
+### Packaging: macOS fsevents EBADF on /dev/fd/
+In packaged apps, the `fsevents` native module reports `/dev/fd/N` paths. When chokidar tries to `lstat` them, the FD is already closed → `EBADF`. The `ignored` option doesn't help because the error occurs before filtering. **A process-level `uncaughtException` handler suppresses this specific error** (see `src/main/index.ts`).
+
 ## Platform Notes
 
 - macOS: bash/zsh default shell, .dmg/.zip packaging

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -1,9 +1,24 @@
 import type { ForgeConfig } from '@electron-forge/shared-types';
 import { MakerSquirrel } from '@electron-forge/maker-squirrel';
 import { MakerZIP } from '@electron-forge/maker-zip';
+import { AutoUnpackNativesPlugin } from '@electron-forge/plugin-auto-unpack-natives';
 import { VitePlugin } from '@electron-forge/plugin-vite';
 import { FusesPlugin } from '@electron-forge/plugin-fuses';
 import { FuseV1Options, FuseVersion } from '@electron/fuses';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+
+const nativeModules = ['node-pty'];
+
+function copyNativeModules(buildPath: string) {
+  for (const mod of nativeModules) {
+    const src = path.resolve(__dirname, 'node_modules', mod);
+    const dest = path.join(buildPath, 'node_modules', mod);
+    if (fs.existsSync(src)) {
+      fs.cpSync(src, dest, { recursive: true });
+    }
+  }
+}
 
 const config: ForgeConfig = {
   packagerConfig: {
@@ -11,6 +26,12 @@ const config: ForgeConfig = {
       unpack: '**/node_modules/node-pty/**/*',
     },
     name: 'AIDE',
+    afterCopy: [
+      (buildPath, _electronVersion, _platform, _arch, callback) => {
+        copyNativeModules(buildPath);
+        callback();
+      },
+    ],
   },
   rebuildConfig: {},
   makers: [
@@ -18,6 +39,7 @@ const config: ForgeConfig = {
     new MakerZIP({}, ['darwin']),
   ],
   plugins: [
+    new AutoUnpackNativesPlugin({}),
     new VitePlugin({
       build: [
         {

--- a/src/main/fix-env.ts
+++ b/src/main/fix-env.ts
@@ -1,0 +1,35 @@
+import { app } from 'electron';
+import { execSync } from 'child_process';
+
+/**
+ * Packaged Electron apps on macOS launched from Finder don't inherit
+ * the user's shell environment (PATH, SHELL, etc.).
+ * This loads the login shell env so CLI tools (claude, zsh, etc.) are found.
+ */
+export function fixPackagedEnv(): void {
+  if (!app.isPackaged || process.platform === 'win32') return;
+
+  try {
+    const shell = process.env.SHELL || '/bin/zsh';
+    const output = execSync(`${shell} -ilc 'env'`, {
+      encoding: 'utf-8',
+      timeout: 5000,
+    });
+
+    for (const line of output.split('\n')) {
+      const idx = line.indexOf('=');
+      if (idx <= 0) continue;
+      const key = line.slice(0, idx);
+      const value = line.slice(idx + 1);
+      // Only set if not already present or if it's PATH (always override with full version)
+      if (key === 'PATH' || !process.env[key]) {
+        process.env[key] = value;
+      }
+    }
+  } catch {
+    // Fallback: ensure minimal PATH exists
+    if (!process.env.PATH?.includes('/usr/local/bin')) {
+      process.env.PATH = `/usr/local/bin:/opt/homebrew/bin:${process.env.PATH || '/usr/bin:/bin'}`;
+    }
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, ipcMain } from 'electron';
 import path from 'path';
+import { fixPackagedEnv } from './fix-env';
 import { registerIpcHandlers } from './ipc/handlers';
 import { registerWorkspaceHandlers } from './ipc/workspace-handlers';
 import { registerFsHandlers } from './ipc/fs-handlers';
@@ -8,10 +9,26 @@ import { registerGitHandlers } from './ipc/git-handlers';
 import { registerGithubHandlers } from './ipc/github-handlers';
 import { registerPluginHandlers } from './ipc/plugin-handlers';
 
+fixPackagedEnv();
+
+// Suppress harmless EBADF errors on /dev/fd/ paths.
+// macOS fsevents reports these in packaged Electron apps when file descriptors
+// are closed before lstat can read them. Safe to ignore.
+process.on('uncaughtException', (err) => {
+  if (err.message?.includes('EBADF') && err.message?.includes('/dev/fd/')) return;
+  throw err;
+});
+
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-if (require('electron-squirrel-startup')) {
-  app.quit();
+if (process.platform === 'win32') {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    if (require('electron-squirrel-startup')) {
+      app.quit();
+    }
+  } catch {
+    // Not available outside Squirrel installer context
+  }
 }
 
 const createWindow = (): void => {

--- a/src/main/ipc/fs-handlers.ts
+++ b/src/main/ipc/fs-handlers.ts
@@ -66,6 +66,7 @@ export function registerFsHandlers(ipcMain: IpcMain, cwd: string): void {
     .watch(cwd, {
       ignoreInitial: true,
       depth: 3,
+      ignored: /\/dev\/fd\//,
     })
     .on('all', () => {
       if (debounceTimer) clearTimeout(debounceTimer);

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -7,11 +7,8 @@ export default defineConfig({
       external: [
         'electron',
         'node-pty',
-        'electron-store',
-        'simple-git',
-        'chokidar',
         'fsevents',
-        '@octokit/rest',
+        'electron-squirrel-startup',
       ],
     },
   },

--- a/vite.preload.config.ts
+++ b/vite.preload.config.ts
@@ -6,7 +6,6 @@ export default defineConfig({
     rollupOptions: {
       external: [
         'electron',
-        'electron-store',
       ],
       output: {
         entryFileNames: 'preload.js',


### PR DESCRIPTION
- Only externalize native modules (node-pty, fsevents) in Vite; bundle pure JS deps (electron-store, chokidar, simple-git, etc.) so they ship inside the asar
- Add afterCopy hook in forge.config.ts to copy node-pty into build path
- Add fix-env.ts to restore shell PATH in packaged apps launched from Finder (CLI tools like claude/zsh need full PATH)
- Suppress harmless EBADF errors on /dev/fd/ from macOS fsevents
- Guard electron-squirrel-startup behind platform check (Windows only)
- Add chokidar ignored pattern for /dev/fd/ paths
- Document packaging pitfalls in CLAUDE.md