### PR TITLE
fix: clear local plugins when workspace changes

### DIFF
--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -204,6 +204,43 @@ interface ToolRegistry {
 
 에이전트가 tool을 호출하면 AIDE가 중간에서 해당 플러그인의 샌드박스 함수를 실행하고 결과를 반환한다.
 
+#### 2.5 Plugin Scope & Workspace Isolation
+
+플러그인은 두 가지 스코프로 관리된다.
+
+| 스코프 | 저장 위치 | 가시성 |
+|--------|-----------|--------|
+| `local` | `{workspace}/.aide/plugins/` | 해당 워크스페이스에서만 표시 |
+| `global` | `~/.aide/plugins/` | 모든 워크스페이스에서 표시 |
+
+**워크스페이스 전환 시 플러그인 갱신 흐름**:
+
+```
+사용자: 사이드바에서 워크스페이스 B 클릭
+    │
+    ▼
+WorkspaceNav → setActive(ws-b)
+    │
+    ▼
+window.aide.workspace.open(ws-b.path)   ← Main: activeWorkspacePath = ws-b
+    │ (await)
+    ▼
+usePluginStore.loadPlugins()            ← IPC: PLUGIN_LIST
+    │
+    ▼
+Main: refreshLocalPlugins(ws-b)
+    │  if (lastLocalDir !== ws-b local dir)
+    │    registry.clearLocalPlugins()   ← ws-a 로컬 플러그인 제거
+    │    loadDirIntoRegistry(ws-b, 'local')
+    ▼
+렌더러: 플러그인 목록 갱신 (ws-b 로컬 + 글로벌)
+```
+
+**구현 규칙**:
+- `window.aide.workspace.open()` IPC가 완료된 후에 `loadPlugins()`를 호출해야 한다 — 순서가 바뀌면 메인 프로세스가 구 경로를 기준으로 플러그인을 반환한다.
+- `PluginRegistry.clearLocalPlugins()`는 scope가 `local`인 플러그인만 제거하며, `global` 플러그인과 활성 sandbox는 유지된다.
+- 동일 워크스페이스로 재전환 시 (`lastLocalDir` 동일) 불필요한 스캔을 생략한다.
+
 ### 3. Terminal Panel (Renderer)
 
 xterm.js 기반 다중 탭 터미널.

--- a/src/main/ipc/plugin-handlers.ts
+++ b/src/main/ipc/plugin-handlers.ts
@@ -71,6 +71,19 @@ function loadRegistryFromDisk(cwd: string): void {
   loadDirIntoRegistry(getLocalPluginsDir(cwd), 'local');
 }
 
+let lastLocalDir: string | null = null;
+
+// Clears local plugins and reloads from the new workspace directory.
+// No-op if the workspace hasn't changed.
+function refreshLocalPlugins(cwd: string): void {
+  const localDir = getLocalPluginsDir(cwd);
+  if (lastLocalDir === localDir) return;
+  registry.clearLocalPlugins();
+  lastLocalDir = localDir;
+  ensurePluginsDirs(cwd);
+  loadDirIntoRegistry(localDir, 'local');
+}
+
 export function registerPluginHandlers(ipcMain: IpcMain, cwd: string): void {
   loadRegistryFromDisk(cwd);
 
@@ -100,9 +113,9 @@ export function registerPluginHandlers(ipcMain: IpcMain, cwd: string): void {
   });
 
   ipcMain.handle(IPC_CHANNELS.PLUGIN_LIST, async () => {
-    // 활성 워크스페이스가 바뀌었을 수 있으므로 로컬 플러그인을 다시 스캔
     const effectiveCwd = getEffectiveCwd(cwd);
-    loadDirIntoRegistry(getLocalPluginsDir(effectiveCwd), 'local');
+    // Clears stale local plugins when workspace changes, then reloads from current workspace
+    refreshLocalPlugins(effectiveCwd);
     return registry.list();
   });
 

--- a/src/main/plugin/registry.ts
+++ b/src/main/plugin/registry.ts
@@ -73,6 +73,17 @@ export class PluginRegistry {
     return this.plugins.get(id);
   }
 
+  clearLocalPlugins(): void {
+    for (const [id, plugin] of this.plugins) {
+      if (plugin.scope !== 'local') continue;
+      if (plugin.active && plugin.sandbox) {
+        plugin.sandbox.stop();
+      }
+      this._deregisterTools(id);
+      this.plugins.delete(id);
+    }
+  }
+
   getRegisteredTools(): PluginTool[] {
     return Array.from(this.tools.values()).map((t) => t.tool);
   }

--- a/src/renderer/stores/workspace-store.ts
+++ b/src/renderer/stores/workspace-store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import type { WorkspaceInfo } from '../../types/ipc';
 import { useTerminalStore } from './terminal-store';
 import { useLayoutStore } from './layout-store';
+import { usePluginStore } from './plugin-store';
 
 type SidePanelTab = 'files' | 'plugins';
 
@@ -41,6 +42,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       useTerminalStore.getState().switchWorkspace(prevId, id);
       // Restore layout for new workspace
       useLayoutStore.getState().restoreWorkspaceLayout(id);
+      // Reload plugins scoped to the new workspace
+      usePluginStore.getState().loadPlugins();
     }
     set({ activeWorkspaceId: id });
   },

--- a/tests/unit/plugin-registry.test.ts
+++ b/tests/unit/plugin-registry.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { PluginRegistry } from '../../src/main/plugin/registry';
+import type { PluginSpec } from '../../src/main/plugin/spec-generator';
+
+function makeSpec(id: string, name: string): PluginSpec {
+  return {
+    id,
+    name,
+    description: `${name} plugin`,
+    version: '0.1.0',
+    permissions: [],
+    entryPoint: 'src/index.js',
+    tools: [],
+  };
+}
+
+describe('PluginRegistry', () => {
+  let registry: PluginRegistry;
+
+  beforeEach(() => {
+    registry = new PluginRegistry();
+  });
+
+  describe('register / list', () => {
+    it('lists registered plugins with scope', () => {
+      registry.register(makeSpec('id-1', 'local-plugin'), '/tmp/local-plugin', 'local');
+      registry.register(makeSpec('id-2', 'global-plugin'), '/tmp/global-plugin', 'global');
+      const list = registry.list();
+      expect(list).toHaveLength(2);
+      expect(list.find((p) => p.id === 'id-1')?.scope).toBe('local');
+      expect(list.find((p) => p.id === 'id-2')?.scope).toBe('global');
+    });
+  });
+
+  describe('clearLocalPlugins', () => {
+    it('removes all local plugins and keeps global plugins', () => {
+      registry.register(makeSpec('local-1', 'local-a'), '/tmp/local-a', 'local');
+      registry.register(makeSpec('local-2', 'local-b'), '/tmp/local-b', 'local');
+      registry.register(makeSpec('global-1', 'global-a'), '/tmp/global-a', 'global');
+
+      registry.clearLocalPlugins();
+
+      const list = registry.list();
+      expect(list).toHaveLength(1);
+      expect(list[0].id).toBe('global-1');
+      expect(list[0].scope).toBe('global');
+    });
+
+    it('is a no-op when there are no local plugins', () => {
+      registry.register(makeSpec('global-1', 'global-a'), '/tmp/global-a', 'global');
+      expect(() => registry.clearLocalPlugins()).not.toThrow();
+      expect(registry.list()).toHaveLength(1);
+    });
+
+    it('is a no-op on an empty registry', () => {
+      expect(() => registry.clearLocalPlugins()).not.toThrow();
+      expect(registry.list()).toHaveLength(0);
+    });
+
+    it('allows re-registering local plugins after clearing', () => {
+      registry.register(makeSpec('local-1', 'local-a'), '/tmp/local-a', 'local');
+      registry.clearLocalPlugins();
+      registry.register(makeSpec('local-1', 'local-a'), '/tmp/local-a', 'local');
+      expect(registry.list()).toHaveLength(1);
+      expect(registry.list()[0].scope).toBe('local');
+    });
+
+    it('does not affect active status of global plugins', () => {
+      registry.register(makeSpec('local-1', 'local-a'), '/tmp/local-a', 'local');
+      registry.register(makeSpec('global-1', 'global-a'), '/tmp/global-a', 'global');
+
+      registry.clearLocalPlugins();
+
+      const global = registry.list().find((p) => p.id === 'global-1');
+      expect(global).toBeDefined();
+      expect(global?.active).toBe(false);
+    });
+  });
+
+  describe('unregister', () => {
+    it('removes a plugin by id', () => {
+      registry.register(makeSpec('id-1', 'plugin-a'), '/tmp/plugin-a', 'local');
+      registry.unregister('id-1');
+      expect(registry.list()).toHaveLength(0);
+    });
+
+    it('returns false for unknown id', () => {
+      expect(registry.unregister('nonexistent')).toBe(false);
+    });
+  });
+});

--- a/tests/unit/stores.test.ts
+++ b/tests/unit/stores.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { useWorkspaceStore } from '../../src/renderer/stores/workspace-store';
 import { useTerminalStore } from '../../src/renderer/stores/terminal-store';
 import { useAgentStore } from '../../src/renderer/stores/agent-store';
+import { usePluginStore } from '../../src/renderer/stores/plugin-store';
 import type { WorkspaceInfo, TerminalTab } from '../../src/types/ipc';
 
 const mockWorkspace: WorkspaceInfo = {
@@ -179,5 +180,77 @@ describe('useAgentStore', () => {
     const statuses = useAgentStore.getState().sessionStatuses;
     expect(statuses['s1']).toBe('idle');
     expect(statuses['s2']).toBe('awaiting-input');
+  });
+});
+
+// ─── Plugin reload on workspace switch ───────────────────────────────────────
+
+const wsA: WorkspaceInfo = { id: 'ws-a', name: 'aide', path: '/projects/aide', color: '#6366f1', lastOpened: 1 };
+const wsB: WorkspaceInfo = { id: 'ws-b', name: 'rogue-shelf', path: '/projects/rogue-shelf', color: '#ec4899', lastOpened: 2 };
+
+describe('useWorkspaceStore – plugin reload on workspace switch', () => {
+  let workspaceOpenMock: ReturnType<typeof vi.fn>;
+  let pluginListMock: ReturnType<typeof vi.fn>;
+  let loadPluginsSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    workspaceOpenMock = vi.fn().mockResolvedValue('/projects/aide');
+    pluginListMock = vi.fn().mockResolvedValue([]);
+
+    vi.stubGlobal('window', {
+      aide: {
+        workspace: { open: workspaceOpenMock },
+        plugin: { list: pluginListMock },
+      },
+    });
+
+    loadPluginsSpy = vi.spyOn(usePluginStore.getState(), 'loadPlugins');
+
+    useWorkspaceStore.setState({
+      workspaces: [wsA, wsB],
+      activeWorkspaceId: null,
+      recentProjects: [],
+      navExpanded: true,
+    });
+    usePluginStore.setState({ plugins: [], loading: false, error: null, generating: false, generateError: null });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('calls window.aide.workspace.open with the workspace path on switch', async () => {
+    await useWorkspaceStore.getState().setActive('ws-a');
+    expect(workspaceOpenMock).toHaveBeenCalledWith('/projects/aide');
+  });
+
+  it('calls loadPlugins after workspace.open resolves', async () => {
+    await useWorkspaceStore.getState().setActive('ws-a');
+    expect(loadPluginsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls workspace.open with the new workspace path when switching', async () => {
+    await useWorkspaceStore.getState().setActive('ws-a');
+    await useWorkspaceStore.getState().setActive('ws-b');
+    expect(workspaceOpenMock).toHaveBeenLastCalledWith('/projects/rogue-shelf');
+    expect(loadPluginsSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not call workspace.open or loadPlugins when switching to the same workspace', async () => {
+    await useWorkspaceStore.getState().setActive('ws-a');
+    workspaceOpenMock.mockClear();
+    loadPluginsSpy.mockClear();
+
+    await useWorkspaceStore.getState().setActive('ws-a');
+    expect(workspaceOpenMock).not.toHaveBeenCalled();
+    expect(loadPluginsSpy).not.toHaveBeenCalled();
+  });
+
+  it('still sets activeWorkspaceId even without a matching workspace in list', async () => {
+    await useWorkspaceStore.getState().setActive('ws-unknown');
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe('ws-unknown');
+    // No matching workspace path → workspace.open should not be called
+    expect(workspaceOpenMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- `PluginRegistry`가 싱글턴으로 로컬 플러그인을 누적하는 버그 수정
- 워크스페이스 전환 시 이전 워크스페이스의 로컬 플러그인이 그대로 남아있던 문제 해결

## 변경 내용
- `PluginRegistry.clearLocalPlugins()` 추가 — scope가 `local`인 플러그인 전체 제거 (sandbox 정리 포함)
- `refreshLocalPlugins(cwd)` 추가 — 워크스페이스 경로가 바뀔 때만 로컬 플러그인 초기화 후 재로드 (no-op if same workspace)
- `PLUGIN_LIST` 핸들러가 매 호출마다 `refreshLocalPlugins`를 통해 워크스페이스 변경 감지

## Test plan
- [ ] 워크스페이스 A에서 로컬 플러그인 생성 확인
- [ ] 워크스페이스 B로 전환 후 A의 로컬 플러그인이 목록에 없는지 확인
- [ ] 글로벌 플러그인은 양쪽 워크스페이스에서 모두 보이는지 확인
- [ ] 워크스페이스 A로 다시 전환 시 A의 로컬 플러그인 재표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)