### PR TITLE
feat: agent session save/restore with --continue fallback

### DIFF
--- a/src/main/ipc/channels.ts
+++ b/src/main/ipc/channels.ts
@@ -52,6 +52,7 @@ export const IPC_CHANNELS = {
 
   // Session
   SESSION_SAVE: 'session:save',
+  SESSION_SAVE_SYNC: 'session:save-sync',
   SESSION_LOAD: 'session:load',
 
   // GitHub

--- a/src/main/ipc/session-handlers.ts
+++ b/src/main/ipc/session-handlers.ts
@@ -12,6 +12,12 @@ export function registerSessionHandlers(ipcMain: IpcMain): void {
     store.set(session.workspaceId, session);
   });
 
+  // Synchronous save used in beforeunload — guarantees write before window closes
+  ipcMain.on(IPC_CHANNELS.SESSION_SAVE_SYNC, (event, session: SavedSession) => {
+    store.set(session.workspaceId, session);
+    event.returnValue = true;
+  });
+
   ipcMain.handle(IPC_CHANNELS.SESSION_LOAD, (_event, workspaceId: string): SavedSession | null => {
     const session = store.get(workspaceId) as SavedSession | undefined;
     if (!session || session.version !== CURRENT_VERSION) return null;

--- a/src/main/ipc/terminal-handlers.ts
+++ b/src/main/ipc/terminal-handlers.ts
@@ -1,5 +1,7 @@
 import { type IpcMain, BrowserWindow } from 'electron';
 import * as pty from 'node-pty';
+import * as fs from 'fs';
+import * as path from 'path';
 import os from 'os';
 import { IPC_CHANNELS } from './channels';
 import { AgentStatusDetector } from '../agent/status-detector';
@@ -16,29 +18,62 @@ function getResumeArgs(agentType: string, sessionId: string): string[] {
   }
 }
 
-function parseAgentSessionId(agentType: string, data: string): string | null {
+/** Args to resume the most recent session (no specific ID needed) */
+function getContinueArgs(agentType: string): string[] {
   switch (agentType) {
-    case 'claude': {
-      // Claude session IDs are ULIDs (26-char Crockford Base32)
-      const match = data.match(/session[:\s]+([0-9A-HJKMNP-TV-Z]{26})\b/i);
-      return match ? match[1] : null;
-    }
-    case 'gemini': {
-      const match = data.match(/session[:\s]+([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/i);
-      return match ? match[1] : null;
-    }
-    case 'codex': {
-      const match = data.match(/session[:\s]+(\S+\.jsonl)/i);
-      return match ? match[1] : null;
-    }
-    default: return null;
+    case 'claude': return ['--continue'];
+    case 'gemini': return ['--resume'];         // bare --resume = most recent
+    case 'codex': return ['resume', '--last'];
+    default: return [];
   }
+}
+
+/**
+ * Detect the agent's session ID from its session files on disk.
+ * Each agent stores sessions in a known directory; we find the most recently modified file.
+ */
+/**
+ * Detect session ID from the agent's session files on disk.
+ * Claude and Codex store sessions in known directories.
+ * Gemini uses an unknown project hash — relies on --resume (bare) instead.
+ */
+function detectSessionIdFromFs(agentType: string, cwd: string): string | null {
+  const home = process.env.HOME || os.homedir();
+  try {
+    switch (agentType) {
+      case 'claude': {
+        // ~/.claude/projects/<cwd-with-separators-replaced-by-hyphens>/
+        const encoded = cwd.replace(/[\\/]/g, '-');
+        const dir = path.join(home, '.claude', 'projects', encoded);
+        return newestJsonlId(dir);
+      }
+      case 'codex': {
+        const dir = path.join(home, '.codex', 'sessions');
+        return newestJsonlId(dir);
+      }
+      default: return null;
+    }
+  } catch {
+    return null;
+  }
+}
+
+function newestJsonlId(dir: string): string | null {
+  if (!fs.existsSync(dir)) return null;
+  let best: { name: string; mtime: number } | null = null;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.jsonl')) continue;
+    const mtime = fs.statSync(path.join(dir, entry.name)).mtimeMs;
+    if (!best || mtime > best.mtime) best = { name: entry.name, mtime };
+  }
+  return best ? best.name.replace(/\.jsonl$/, '') : null;
 }
 
 interface PtySession {
   pty: pty.IPty;
   webContentsId: number;
   agentSessionId?: string;
+  sessionDetectTimer?: ReturnType<typeof setInterval>;
 }
 
 const sessions = new Map<string, PtySession>();
@@ -72,6 +107,7 @@ function broadcastToRenderer(webContentsId: number, channel: string, ...args: un
 
 export function killAllSessions(): void {
   for (const [, session] of sessions) {
+    if (session.sessionDetectTimer) clearInterval(session.sessionDetectTimer);
     try {
       session.pty.kill();
     } catch {
@@ -84,7 +120,7 @@ export function killAllSessions(): void {
 export function registerTerminalHandlers(ipcMain: IpcMain): void {
   ipcMain.handle(
     IPC_CHANNELS.TERMINAL_SPAWN,
-    (event, options?: { shell?: string; cwd?: string; agentType?: AgentType; resumeSessionId?: string }) => {
+    (event, options?: { shell?: string; cwd?: string; agentType?: AgentType; resumeSessionId?: string; continueSession?: boolean }) => {
       const defaultShell = getDefaultShell();
       const cwd = options?.cwd || os.homedir();
       const sessionId = `term-${++sessionCounter}`;
@@ -106,8 +142,12 @@ export function registerTerminalHandlers(ipcMain: IpcMain): void {
       }
 
       let spawnArgs = [...agentConfig.args];
-      if (options?.resumeSessionId && options?.agentType && options.agentType !== 'shell') {
-        spawnArgs = [...spawnArgs, ...getResumeArgs(options.agentType, options.resumeSessionId)];
+      if (options?.agentType && options.agentType !== 'shell') {
+        if (options.resumeSessionId) {
+          spawnArgs = [...spawnArgs, ...getResumeArgs(options.agentType, options.resumeSessionId)];
+        } else if (options.continueSession) {
+          spawnArgs = [...spawnArgs, ...getContinueArgs(options.agentType)];
+        }
       }
 
       const ptyProcess = pty.spawn(shell, spawnArgs, {
@@ -136,19 +176,32 @@ export function registerTerminalHandlers(ipcMain: IpcMain): void {
           data
         );
         statusDetector.feed(sessionId, data);
-        if (options?.agentType && options.agentType !== 'shell') {
-          const agentSid = parseAgentSessionId(options.agentType, data);
-          if (agentSid && agentSid !== session.agentSessionId) {
-            session.agentSessionId = agentSid;
-            broadcastToRenderer(session.webContentsId, IPC_CHANNELS.AGENT_SESSION_ID, sessionId, agentSid);
-          }
-        }
       });
 
       ptyProcess.onExit(() => {
+        if (session.sessionDetectTimer) clearInterval(session.sessionDetectTimer);
         sessions.delete(sessionId);
         statusDetector.remove(sessionId);
       });
+
+      // Poll filesystem to detect the agent's session ID (1s interval, up to 15 attempts)
+      if (options?.agentType && options.agentType !== 'shell') {
+        let attempts = 0;
+        session.sessionDetectTimer = setInterval(() => {
+          if (!sessions.has(sessionId) || ++attempts > 15) {
+            clearInterval(session.sessionDetectTimer!);
+            session.sessionDetectTimer = undefined;
+            return;
+          }
+          const fsSessionId = detectSessionIdFromFs(options.agentType!, cwd);
+          if (fsSessionId && fsSessionId !== session.agentSessionId) {
+            session.agentSessionId = fsSessionId;
+            broadcastToRenderer(session.webContentsId, IPC_CHANNELS.AGENT_SESSION_ID, sessionId, fsSessionId);
+            clearInterval(session.sessionDetectTimer!);
+            session.sessionDetectTimer = undefined;
+          }
+        }, 1000);
+      }
 
       return sessionId;
     }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -147,6 +147,8 @@ const aideAPI: AideAPI = {
   session: {
     save: (session: SavedSession): Promise<void> =>
       ipcRenderer.invoke(IPC_CHANNELS.SESSION_SAVE, session),
+    saveSync: (session: SavedSession): void =>
+      ipcRenderer.sendSync(IPC_CHANNELS.SESSION_SAVE_SYNC, session),
     load: (workspaceId: string): Promise<SavedSession | null> =>
       ipcRenderer.invoke(IPC_CHANNELS.SESSION_LOAD, workspaceId),
   },

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -32,12 +32,13 @@ export function App() {
     useLayoutStore.getState().restoreSession(activeWorkspaceId);
   }, [activeWorkspaceId]);
 
-  // Save session on app quit
+  // Save session on app quit — use sendSync to guarantee write before window closes
   useEffect(() => {
     const handler = () => {
       const wsId = useWorkspaceStore.getState().activeWorkspaceId;
       if (wsId) {
-        useLayoutStore.getState().saveSession(wsId);
+        const session = useLayoutStore.getState().buildSavedSession(wsId);
+        window.aide.session.saveSync(session);
       }
     };
     window.addEventListener('beforeunload', handler);

--- a/src/renderer/stores/layout-store.ts
+++ b/src/renderer/stores/layout-store.ts
@@ -140,6 +140,7 @@ interface LayoutState {
 
   // Session save/restore (persistent via electron-store)
   saveSession: (workspaceId: string) => Promise<void>;
+  buildSavedSession: (workspaceId: string) => SavedSession;
   restoreSession: (workspaceId: string) => Promise<void>;
 
   // Helpers
@@ -510,6 +511,11 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
   },
 
   saveSession: async (workspaceId) => {
+    const session = get().buildSavedSession(workspaceId);
+    await window.aide.session.save(session);
+  },
+
+  buildSavedSession: (workspaceId) => {
     const { layout, focusedPaneId } = get();
 
     function serializeNode(node: LayoutNode): SerializableLayoutNode {
@@ -544,7 +550,7 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
       .map((p) => p.id);
     const sidePanelTab = useWorkspaceStore.getState().sidePanelTab;
 
-    const session: SavedSession = {
+    return {
       version: 1,
       workspaceId,
       savedAt: Date.now(),
@@ -552,9 +558,7 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
       focusedPaneId,
       activePlugins,
       sidePanelTab,
-    };
-
-    await window.aide.session.save(session);
+    } as SavedSession;
   },
 
   restoreSession: async (workspaceId) => {
@@ -614,11 +618,13 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
           // shell or agent — spawn new PTY
           let sessionId: string | null = null;
           try {
+            const isAgent = savedTab.type === 'agent';
             sessionId = await window.aide.terminal.spawn({
               shell: savedTab.agentId || undefined,
               cwd: wsPath,
-              agentType: savedTab.type === 'agent' ? (savedTab.agentId as 'claude' | 'gemini' | 'codex' | undefined) : undefined,
+              agentType: isAgent ? (savedTab.agentId as 'claude' | 'gemini' | 'codex' | undefined) : undefined,
               resumeSessionId: savedTab.agentSessionId,
+              continueSession: isAgent && !savedTab.agentSessionId,
             });
           } catch {
             // agent not installed — fall back to plain shell

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -3,7 +3,8 @@ export interface TerminalSpawnOptions {
   shell?: string;
   cwd?: string;
   agentType?: 'claude' | 'gemini' | 'codex' | 'shell';
-  resumeSessionId?: string;  // Agent session ID for resume
+  resumeSessionId?: string;  // Agent session ID for resume (--resume <id>)
+  continueSession?: boolean; // Resume most recent session (--continue / --resume bare)
 }
 
 /** File tree node */
@@ -283,6 +284,7 @@ export interface AideAPI {
   };
   session: {
     save(session: SavedSession): Promise<void>;
+    saveSync(session: SavedSession): void;
     load(workspaceId: string): Promise<SavedSession | null>;
   };
 }


### PR DESCRIPTION
## Summary
- Agent sessions (Claude/Gemini/Codex) are preserved across app restarts
- Filesystem-based session ID detection replaces fragile PTY output parsing
- `--continue` / `--resume` / `resume --last` fallback when no saved session ID
- Sync IPC (`sendSync`) guarantees session save completes before window closes
- MCP server registered globally for all three agents (Claude, Gemini, Codex)

## Changes
- **terminal-handlers.ts**: `getContinueArgs()`, `detectSessionIdFromFs()` with polling (1s × 15), timer cleanup on exit
- **layout-store.ts**: `buildSavedSession()` extracted for sync serialization, `updateTabAgentSessionId` Zustand action, `continueSession` flag on restore
- **App.tsx**: `beforeunload` uses `saveSync`, debounced save on session ID capture
- **config-writer.ts**: `registerJsonMcpConfig()` shared helper, Gemini (`~/.gemini/settings.json`) and Codex (`~/.codex/config.toml`) global MCP registration
- **session-handlers.ts**: `SESSION_SAVE_SYNC` channel with `ipcMain.on` for sync save
- **ipc.ts**: `continueSession`, `saveSync` types, removed dead `paneId` from `SavedTab`
- **CLAUDE.md**: 5 new Known Pitfalls documented

## Test plan
- [ ] Open AIDE → create Claude tab → chat → close app → reopen → verify conversation history appears
- [ ] Verify `~/.claude.json`, `~/.gemini/settings.json`, `~/.codex/config.toml` contain `aide` MCP entry
- [ ] Multiple agent tabs → close → reopen → each resumes correctly
- [ ] Kill agent mid-session → verify no stale timer errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)