### PR TITLE
feat: dynamic plugin loading + hot reload

### DIFF
--- a/src/main/ipc/channels.ts
+++ b/src/main/ipc/channels.ts
@@ -35,6 +35,8 @@ export const IPC_CHANNELS = {
   PLUGIN_DELETE: 'plugin:delete',
   PLUGIN_INVOKE: 'plugin:invoke',
   PLUGIN_GET_HTML: 'plugin:get-html',
+  PLUGIN_HTML_CHANGED: 'plugin:html-changed',
+  PLUGIN_RELOAD: 'plugin:reload',
   PLUGINS_CHANGED: 'plugins:changed',
 
   // Settings

--- a/src/main/ipc/plugin-handlers.ts
+++ b/src/main/ipc/plugin-handlers.ts
@@ -43,6 +43,29 @@ function loadDirIntoRegistry(dir: string, scope: 'local' | 'global'): void {
   }
 }
 
+/**
+ * Incremental rescan — called from chokidar events. Registers newly added
+ * plugins and unregisters plugins whose directory no longer exists. Unlike
+ * refreshLocalPlugins, this runs even when the workspace path hasn't changed,
+ * so plugins created at runtime (e.g. via MCP aide_create_plugin) are picked
+ * up without restarting the app.
+ */
+function rescanPluginsDir(dir: string, scope: 'local' | 'global'): void {
+  // 1. Register any new plugins found on disk
+  loadDirIntoRegistry(dir, scope);
+
+  // 2. Unregister plugins whose pluginDir no longer exists or whose spec
+  //    has disappeared (plugin deleted by user or MCP)
+  const scoped = registry.list().filter((p) => p.scope === scope);
+  for (const plugin of scoped) {
+    if (!plugin.pluginDir.startsWith(dir)) continue;
+    const specExists = fs.existsSync(path.join(plugin.pluginDir, 'plugin.spec.json'));
+    if (!specExists) {
+      registry.unregister(plugin.id);
+    }
+  }
+}
+
 function ensurePluginsDirs(cwd: string): void {
   try {
     const globalDir = getGlobalPluginsDir();
@@ -71,8 +94,16 @@ function broadcastPluginsChanged(): void {
   }
 }
 
+function broadcastHtmlChanged(pluginName: string): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send(IPC_CHANNELS.PLUGIN_HTML_CHANGED, pluginName);
+  }
+}
+
 let localPluginsWatcher: ReturnType<typeof chokidar.watch> | null = null;
+let localHtmlWatcher: ReturnType<typeof chokidar.watch> | null = null;
 let lastLocalDir: string | null = null;
+const localHtmlDebounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 // Clears local plugins and reloads from the new workspace directory.
 // No-op if the workspace hasn't changed.
@@ -83,11 +114,30 @@ function refreshLocalPlugins(cwd: string): void {
   lastLocalDir = localDir;
   ensurePluginsDirs(cwd);
   loadDirIntoRegistry(localDir, 'local');
-  // Re-watch local plugins dir for the new workspace
+  // Re-watch local plugins dir for add/remove changes.
+  // On any filesystem event, rescan the directory to register newly added
+  // plugins (e.g. created by MCP aide_create_plugin at runtime) and drop
+  // plugins whose spec no longer exists.
   localPluginsWatcher?.close();
   localPluginsWatcher = chokidar
     .watch(localDir, { ignoreInitial: true, depth: 2, ignored: /\/dev\/fd\// })
-    .on('all', broadcastPluginsChanged);
+    .on('all', () => {
+      rescanPluginsDir(localDir, 'local');
+      broadcastPluginsChanged();
+    });
+  // Re-watch local plugins dir for index.html changes (debounced 300ms)
+  localHtmlWatcher?.close();
+  localHtmlWatcher = chokidar
+    .watch(path.join(localDir, '**/index.html'), { ignoreInitial: true, ignored: /\/dev\/fd\// })
+    .on('change', (filePath: string) => {
+      const pluginName = path.basename(path.dirname(filePath));
+      const existing = localHtmlDebounceTimers.get(pluginName);
+      if (existing) clearTimeout(existing);
+      localHtmlDebounceTimers.set(pluginName, setTimeout(() => {
+        localHtmlDebounceTimers.delete(pluginName);
+        broadcastHtmlChanged(pluginName);
+      }, 300));
+    });
 }
 
 function makeEmitterFactory(getCwd: () => string) {
@@ -119,11 +169,33 @@ function makeEmitterFactory(getCwd: () => string) {
 export function registerPluginHandlers(ipcMain: IpcMain, cwd: string): void {
   loadRegistryFromDisk(cwd);
   registry.setEmitterFactory(makeEmitterFactory(getEffectiveCwd.bind(null, cwd)));
-  // Watch global plugins dir for changes
+
+  // Broadcast existing plugins immediately so the UI shows them on launch
+  broadcastPluginsChanged();
+
+  // Watch global plugins dir for add/remove changes.
+  // Rescan on any event so runtime-added plugins become visible without restart.
   const globalDir = getGlobalPluginsDir();
   chokidar
     .watch(globalDir, { ignoreInitial: true, depth: 2, ignored: /\/dev\/fd\// })
-    .on('all', broadcastPluginsChanged);
+    .on('all', () => {
+      rescanPluginsDir(globalDir, 'global');
+      broadcastPluginsChanged();
+    });
+
+  // Watch global plugins dir for index.html changes (debounced 300ms)
+  const htmlDebounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  chokidar
+    .watch(path.join(globalDir, '**/index.html'), { ignoreInitial: true, ignored: /\/dev\/fd\// })
+    .on('change', (filePath: string) => {
+      const pluginName = path.basename(path.dirname(filePath));
+      const existing = htmlDebounceTimers.get(pluginName);
+      if (existing) clearTimeout(existing);
+      htmlDebounceTimers.set(pluginName, setTimeout(() => {
+        htmlDebounceTimers.delete(pluginName);
+        broadcastHtmlChanged(pluginName);
+      }, 300));
+    });
 
   // Spec-only: generate and return spec without writing to disk
   ipcMain.handle(IPC_CHANNELS.PLUGIN_GENERATE_SPEC, async (_event, name: string, description: string) => {
@@ -210,6 +282,25 @@ export function registerPluginHandlers(ipcMain: IpcMain, cwd: string): void {
     const htmlPath = path.join(pluginDir, 'index.html');
     if (!fs.existsSync(htmlPath)) return null;
     return fs.readFileSync(htmlPath, 'utf-8');
+  });
+
+  ipcMain.handle(IPC_CHANNELS.PLUGIN_RELOAD, async (_event, pluginId: string) => {
+    const plugin = registry.get(pluginId);
+    if (!plugin) return false;
+    const wasActive = plugin.active;
+    if (wasActive) registry.deactivate(pluginId);
+    // Re-read spec from disk in case it changed
+    const freshSpec = readPluginSpec(plugin.pluginDir);
+    if (freshSpec) {
+      registry.unregister(pluginId);
+      registry.register(freshSpec, plugin.pluginDir, plugin.scope);
+      if (wasActive) {
+        const effectiveCwd = getEffectiveCwd(cwd);
+        registry.activate(freshSpec.id, effectiveCwd);
+      }
+    }
+    broadcastPluginsChanged();
+    return true;
   });
 
   ipcMain.handle(IPC_CHANNELS.PLUGIN_DELETE, async (_event, pluginName: string) => {

--- a/src/main/plugin/registry.ts
+++ b/src/main/plugin/registry.ts
@@ -89,11 +89,12 @@ export class PluginRegistry {
     return true;
   }
 
-  list(): Array<PluginSpec & { active: boolean; scope: 'local' | 'global' }> {
+  list(): Array<PluginSpec & { active: boolean; scope: 'local' | 'global'; pluginDir: string }> {
     return Array.from(this.plugins.values()).map((p) => ({
       ...p.spec,
       active: p.active,
       scope: p.scope,
+      pluginDir: p.pluginDir,
     }));
   }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -121,6 +121,13 @@ const aideAPI: AideAPI = {
       ipcRenderer.on(IPC_CHANNELS.PLUGINS_CHANGED, listener);
       return () => ipcRenderer.removeListener(IPC_CHANNELS.PLUGINS_CHANGED, listener);
     },
+    onHtmlChanged: (callback: (pluginName: string) => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, pluginName: string) => callback(pluginName);
+      ipcRenderer.on(IPC_CHANNELS.PLUGIN_HTML_CHANGED, listener);
+      return () => ipcRenderer.removeListener(IPC_CHANNELS.PLUGIN_HTML_CHANGED, listener);
+    },
+    reload: (pluginId: string): Promise<boolean> =>
+      ipcRenderer.invoke(IPC_CHANNELS.PLUGIN_RELOAD, pluginId),
   },
 
   mcp: {

--- a/src/renderer/components/plugin/PluginPanel.tsx
+++ b/src/renderer/components/plugin/PluginPanel.tsx
@@ -82,6 +82,13 @@ export function PluginPanel() {
           {plugin.active ? 'ON' : 'OFF'}
         </button>
         <button
+          onClick={() => window.aide.plugin.reload(plugin.id)}
+          className="px-1.5 py-0.5 rounded text-[10px] font-mono text-aide-text-tertiary hover:text-aide-text-primary hover:bg-aide-surface-hover transition-colors"
+          title="Reload plugin"
+        >
+          ↻
+        </button>
+        <button
           onClick={() => handleOpenTab(plugin)}
           className="px-1.5 py-0.5 rounded text-[10px] font-mono text-aide-text-tertiary hover:text-aide-text-primary hover:bg-aide-surface-hover transition-colors"
           title="Open as tab"

--- a/src/renderer/components/plugin/PluginView.tsx
+++ b/src/renderer/components/plugin/PluginView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef, useCallback, useState } from 'react';
 
 interface PluginViewProps {
   pluginId: string;
@@ -7,6 +7,7 @@ interface PluginViewProps {
 
 export function PluginView({ pluginId, pluginName }: PluginViewProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [iframeKey, setIframeKey] = useState(0);
 
   // Forward file events to plugin iframe via postMessage
   useEffect(() => {
@@ -46,6 +47,16 @@ export function PluginView({ pluginId, pluginName }: PluginViewProps) {
     return () => window.removeEventListener('message', handler);
   }, []);
 
+  // Reload iframe when its index.html changes on disk
+  useEffect(() => {
+    const unsub = window.aide.plugin.onHtmlChanged((changedName: string) => {
+      if (changedName === pluginName || changedName === pluginId) {
+        setIframeKey((k) => k + 1);
+      }
+    });
+    return unsub;
+  }, [pluginId, pluginName]);
+
   // Send theme to iframe when it loads or theme changes
   const sendTheme = useCallback(() => {
     const isDark = !document.documentElement.classList.contains('light');
@@ -63,6 +74,7 @@ export function PluginView({ pluginId, pluginName }: PluginViewProps) {
 
   return (
     <iframe
+      key={iframeKey}
       ref={iframeRef}
       src={`aide-plugin://${pluginId}/index.html`}
       sandbox="allow-scripts"

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -263,6 +263,8 @@ export interface AideAPI {
     invoke(pluginId: string, toolName: string, args: Record<string, unknown>): Promise<unknown>;
     getHtml: (id: string) => Promise<string | null>;
     onChanged(callback: () => void): () => void;
+    onHtmlChanged(callback: (pluginName: string) => void): () => void;
+    reload(pluginId: string): Promise<boolean>;
   };
   mcp: {
     status(): Promise<McpStatus>;


### PR DESCRIPTION
## Summary
Plugins created at runtime (via MCP `aide_create_plugin` or edited on disk) are now picked up automatically without restarting AIDE.

## Root cause of the original bug
Chokidar detected new plugin directories and broadcast `PLUGINS_CHANGED`, but the UI's subsequent `PLUGIN_LIST` call went through `refreshLocalPlugins()` which has a no-op guard when the workspace hasn't changed — so the registry was never re-scanned and `list()` returned stale state. Result: users had to restart AIDE to see plugins created by the LLM.

## Changes

### Dynamic discovery (the critical fix)
- New `rescanPluginsDir(dir, scope)` helper performs an incremental scan:
  - Register plugins whose `plugin.spec.json` exists on disk but not in the registry
  - Unregister plugins whose spec has disappeared
- Chokidar `all` handlers for both local and global plugin dirs now call `rescanPluginsDir()` BEFORE broadcasting, so the registry is always fresh when the UI refreshes
- `registry.list()` now includes `pluginDir` so rescan can iterate registered plugins by scope

### Hot reload enhancements
- **Startup broadcast**: `PLUGINS_CHANGED` fires immediately after the initial disk scan so existing plugins show without user action
- **iframe HTML hot reload**: new `PLUGIN_HTML_CHANGED` IPC event fires when a plugin's `index.html` changes (300ms debounced), iframe auto-reloads via React key remount
- **Explicit PLUGIN_RELOAD handler**: deactivate → re-read spec → re-register → reactivate (if was active)
- **UI reload button**: ↻ Reload button added to PluginPanel next to each plugin's toggle

## End-to-end flow (no restart required)

```
LLM → MCP aide_create_plugin → files written to .aide/plugins/my-plugin/
   → chokidar 'add' event
   → rescanPluginsDir() registers the new spec
   → broadcastPluginsChanged() → IPC to renderer
   → PluginPanel reloads the list
   → new plugin visible in UI
```

## Files changed
- `src/main/ipc/channels.ts` — `PLUGIN_HTML_CHANGED`, `PLUGIN_RELOAD` channels
- `src/main/ipc/plugin-handlers.ts` — rescanPluginsDir, HTML watchers, PLUGIN_RELOAD handler, startup broadcast
- `src/main/plugin/registry.ts` — `list()` now includes `pluginDir`
- `src/preload/index.ts` — `onHtmlChanged`, `reload` exposed
- `src/renderer/components/plugin/PluginView.tsx` — iframe remount on HTML change
- `src/renderer/components/plugin/PluginPanel.tsx` — ↻ Reload button
- `src/types/ipc.ts` — API type extensions

## Test plan
- [ ] Open AIDE, ask Claude to create a plugin via `aide_create_plugin` MCP → verify the new plugin appears in the Plugins panel **without restart**
- [ ] Edit an existing plugin's `src/index.js` → invoke a tool → verify the new code runs
- [ ] Edit a plugin's `index.html` → open plugin as tab → verify iframe reflects changes within 300ms
- [ ] Click the ↻ Reload button on an active plugin → verify it deactivates/reactivates cleanly
- [ ] Delete a plugin directory manually → verify it disappears from the list
- [ ] Launch app with existing plugins on disk → verify they appear immediately (no click required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)