### PR TITLE
release: v0.0.2 — auto-update + persistent workspace state

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -353,6 +353,81 @@ interface SavedSession {
 
 **구현**: electron-store 백엔드 (`aide-sessions`), IPC 채널 `session:save`/`session:load`, preload bridge `window.aide.session`, layout-store `saveSession()`/`restoreSession()`
 
+### F7. Auto-Update Check & Download
+
+GitHub Releases 기반 자동 업데이트 알림. 현재 실행 중인 버전과 최신 릴리즈 태그를 비교하여 워크스페이스 nav 하단에 업데이트 알림을 노출하고, 클릭 시 DMG를 자동으로 다운로드합니다.
+
+**핵심 사용자 흐름**:
+1. 앱이 백그라운드에서 GitHub Releases API 폴링
+2. 새 버전 발견 시 워크스페이스 nav 하단에 "Update available" 알림 + 버전 태그 + ⬇ 다운로드 버튼 표시
+3. 사용자가 다운로드 버튼 클릭 → DMG가 `~/Downloads`로 다운로드 → Finder에서 자동으로 열림
+4. 사용자가 DMG에서 AIDE.app을 Applications로 드래그하여 설치
+
+**폴링 정책**:
+- 앱 시작 5초 후 최초 1회 체크 (창이 먼저 그려지도록)
+- 이후 60분마다 백그라운드 폴링
+- GitHub API rate limit (60/h unauthenticated) 충분
+- draft / prerelease는 무시
+
+**버전 비교 로직**:
+- `app.getVersion()`으로 현재 버전 가져옴 (예: `0.0.1`)
+- 릴리즈 `tag_name`에서 leading `v` 제거 (예: `v0.0.2` → `0.0.2`)
+- 점으로 분리해 숫자 배열로 변환 후 사전순 비교
+- semver prerelease 표기는 v0.0.x에서는 미지원
+
+**UI 사양** (디자인: design.pen `4qEgJ`):
+
+| 상태 | 표시 |
+|--------|------|
+| 업데이트 없음 | 컴포넌트 완전히 숨김. nav 하단 공간 차지 안 함 |
+| 업데이트 있음 (Expanded nav) | 220×fit-content 박스: 좌측 2줄 텍스트(`⬆ Update available` + `v0.0.X`) + 우측 28×28 다운로드 버튼 |
+| 업데이트 있음 (Collapsed nav) | 48×48 슬롯에 28×28 accent 색상 ⬇ 버튼 |
+| 다운로드 진행 중 | 버튼 비활성화, "Downloading..." 텍스트 |
+| 다운로드 완료 | Finder reveal 후 알림 자동 제거 또는 "Installed?" 확인 |
+
+**색상**: accent 그린 (`var(--accent)` — dark `#10B981` / light `#059669`). 버튼 안 ⬇ 아이콘은 dark에서는 검정, light에서는 흰색.
+
+**위치**: WorkspaceNav 컴포넌트의 "+ New Workspace" 버튼 **위쪽**에 배치. nav가 collapsed 모드일 때는 해당 영역의 마지막 슬롯.
+
+**다운로드 동작**:
+1. GitHub Release의 assets에서 `*.dmg`로 끝나는 파일 찾기
+2. `electron.net.fetch`로 다운로드
+3. `~/Downloads/AIDE-v0.0.X.dmg`에 저장 (atomic write 불필요 — Downloads는 사용자 영역)
+4. `shell.showItemInFolder(path)`로 Finder에서 열기
+5. 실패 시 fallback: `shell.openExternal(release.html_url)`로 릴리즈 페이지 열기
+
+**엣지 케이스**:
+
+| 케이스 | 처리 |
+|--------|------|
+| 네트워크 없음 | 조용히 무시. 다음 폴링까지 대기 |
+| GitHub API 5xx | 캐시된 마지막 정보 유지. 알림 변화 없음 |
+| DMG asset 없음 | 다운로드 버튼 클릭 시 GitHub release 페이지 브라우저 오픈 |
+| 다운로드 실패 | 에러 토스트 + 릴리즈 페이지 fallback |
+| 동시 다운로드 요청 | 첫 번째만 처리, 추가 클릭 무시 |
+| draft/prerelease만 있음 | hasUpdate=false, 알림 표시 안 함 |
+
+**스코프 제외 (Post-v0.0.x)**:
+- 인플레이스 .app 교체 (Squirrel.Mac 자동 업데이트) — 코드 사이닝 필요
+- 백그라운드 다운로드 진행률 표시
+- 변경 로그 표시
+- "나중에 알림" 옵션
+- Windows/Linux 자동 업데이트
+
+**데이터 스키마**:
+```typescript
+interface UpdateInfo {
+  latestTag: string;        // "v0.0.2"
+  currentVersion: string;   // "0.0.1"
+  hasUpdate: boolean;
+  downloadUrl: string | null;  // GitHub asset URL
+  releaseName: string | null;
+  htmlUrl: string | null;   // release page (fallback)
+}
+```
+
+**구현 모듈**: `src/main/updater/check.ts`, IPC 채널 `updater:check`/`updater:download`/`updater:info-changed`/`updater:get-info`, preload bridge `window.aide.updater`, 렌더러 컴포넌트 `UpdateNotice.tsx` (WorkspaceNav 통합).
+
 ### Out of Scope (Post-MVP)
 - 커뮤니티 플러그인 허브 (아래 Post-MVP 로드맵 참조)
 - 코드 에디터 (Monaco 등) 내장

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -370,6 +370,83 @@ interface GitHubService {
 
 Git 작업은 에이전트를 통한 자연어 실행도 가능하고, UI 버튼으로 직접 실행도 가능.
 
+### 6. Auto-Updater (Main Process)
+
+GitHub Releases 기반 업데이트 체크 및 DMG 다운로드 모듈. **PRD F7 참조**.
+
+```typescript
+// src/main/updater/check.ts
+interface UpdateInfo {
+  latestTag: string;          // "v0.0.2"
+  currentVersion: string;     // app.getVersion(), e.g. "0.0.1"
+  hasUpdate: boolean;
+  downloadUrl: string | null; // first .dmg asset URL from the release
+  releaseName: string | null;
+  htmlUrl: string | null;     // release page URL (fallback)
+}
+
+interface UpdaterModule {
+  checkForUpdate(): Promise<UpdateInfo | null>;
+  getCachedUpdateInfo(): UpdateInfo | null;
+  downloadUpdate(): Promise<{ ok: boolean; path?: string; error?: string }>;
+  startUpdatePolling(): void;
+  stopUpdatePolling(): void;
+}
+```
+
+**구현 핵심**:
+
+| 항목 | 결정 |
+|------|------|
+| HTTP 클라이언트 | `electron.net.fetch` (system proxy 자동 사용) |
+| API 엔드포인트 | `https://api.github.com/repos/Achelous1/aide/releases/latest` |
+| 폴링 주기 | 시작 5초 후 1회 + 60분 간격 (`setInterval`) |
+| 캐시 | 메모리 변수 (`cachedInfo: UpdateInfo \| null`) — 디스크 영속화 불필요 |
+| 동시 다운로드 차단 | 모듈 레벨 `downloading: boolean` 플래그 |
+| Draft/Prerelease 처리 | `release.draft \|\| release.prerelease` 면 캐시 유지 + 무시 |
+| 버전 비교 | `parseVersion()`이 leading `v` 제거 후 점 분리, 숫자 배열 사전순 비교 |
+| Atomic write | 불필요 — `~/Downloads`는 사용자 영역, 부분 쓰기 위험 낮음 |
+| Reveal | `shell.showItemInFolder(targetPath)` |
+| Fallback | DMG asset 없거나 실패 시 `shell.openExternal(release.html_url)` |
+
+**IPC 채널**:
+
+| 채널 | 방향 | 페이로드 | 응답 |
+|------|------|---------|------|
+| `updater:check` | Renderer → Main | — | `Promise<UpdateInfo \| null>` |
+| `updater:get-info` | Renderer → Main | — | 캐시된 `UpdateInfo \| null` (네트워크 호출 없음) |
+| `updater:download` | Renderer → Main | — | `Promise<{ok, path?, error?}>` |
+| `updater:info-changed` | Main → Renderer | `UpdateInfo \| null` | 캐시 변경 시 푸시 |
+
+**렌더러 컴포넌트** (`src/renderer/components/updater/UpdateNotice.tsx`):
+
+```tsx
+function UpdateNotice() {
+  const [info, setInfo] = useState<UpdateInfo | null>(null);
+  const [downloading, setDownloading] = useState(false);
+
+  useEffect(() => {
+    // 1. Pull cached state on mount (sync, no network)
+    window.aide.updater.getInfo().then(setInfo);
+    // 2. Subscribe to updates pushed from main
+    return window.aide.updater.onChanged(setInfo);
+  }, []);
+
+  if (!info?.hasUpdate) return null;
+  // ... render the notice (see UI-SPEC.md)
+}
+```
+
+**Lifecycle**:
+- App `ready` → `startUpdatePolling()` 호출 (`main/index.ts`)
+- App `before-quit` → `stopUpdatePolling()` (interval clear)
+- 첫 체크는 5초 지연으로 창이 먼저 그려지도록 보장
+
+**보안 고려**:
+- GitHub API 호출에 인증 없음 (rate limit 60/h, 폴링 60분이라 충분)
+- 다운로드 URL은 오직 `assets.browser_download_url`만 사용 (사용자 입력 신뢰 X)
+- 다운로드 후 `~/Downloads/AIDE-<tag>.dmg`로 저장 — 워크스페이스 외부
+
 ---
 
 ## IPC Communication

--- a/docs/UI-SPEC.md
+++ b/docs/UI-SPEC.md
@@ -256,6 +256,67 @@ Collapsed ↔ Expanded 토글:
 Welcome Page의 Workspace Navbar와 동일한 구조.
 추가로 Terminal Page에서는 FileExplorer 좌측에 위치.
 
+### 3.5.5 Update Notice (Workspace Nav 하단 슬롯)
+
+PRD F7 자동 업데이트 알림 컴포넌트. **WorkspaceNav 가장 하단 — `+ New Workspace` 버튼 위쪽**에 배치.
+
+**디자인 참조**: `design.pen` 노드 `4qEgJ`
+
+**가시성**:
+- `updateInfo.hasUpdate === false` → 컴포넌트 완전히 숨김 (`return null`), nav 하단 공간 차지 안 함
+- `updateInfo.hasUpdate === true` → 슬라이드업 + 페이드인 (300ms ease-out)으로 등장
+
+**Expanded layout (220px wide)**:
+
+| Element | Spec |
+|---------|------|
+| Container | 220 × fit-content, padding 12px, gap 10px, horizontal flex, alignItems center, fill `var(--surface-sidebar)`, border-top 1px `var(--border)` |
+| 좌측 Info stack | vertical flex, gap 2px, fill_container width |
+| Line 1 (Label) | `⬆ Update available` — 9px JetBrains Mono uppercase 600, fill `var(--accent)` |
+| Line 2 (Version) | `v0.0.X` — 13px JetBrains Mono 700, fill `var(--text-primary)` |
+| 우측 Download Button | 28×28, fill `var(--accent)`, cornerRadius 4, justify+align center |
+| 버튼 안 ⬇ 아이콘 | 13px 700, fill `var(--terminal-bg)` (dark) / `#FFFFFF` (light) |
+
+**Collapsed layout (48px nav 폭)**:
+
+| Element | Spec |
+|---------|------|
+| Container | 48 × 48, justifyContent + alignItems center, fill `var(--surface-sidebar)` |
+| Button | 28×28 동일 사양 (라벨 없음) |
+| Tooltip | hover 시 `Update available — v0.0.X` (12px text-primary, surface-elevated bg) |
+
+**상태 전환**:
+
+| State | Trigger | UI |
+|-------|---------|-----|
+| `idle` | 기본 | 다운로드 버튼 활성, hover 시 `opacity: 0.85` |
+| `downloading` | 클릭 직후 | 버튼 비활성 + 11px `Downloading...` 텍스트 (label 영역 대체) |
+| `done` | DMG `~/Downloads`에 저장 + Finder reveal 완료 | 5초 후 알림 제거 또는 "Installed?" 확인 (선택) |
+| `error` | 다운로드 실패 | 토스트 + 컴포넌트는 `idle` 상태로 복귀 |
+
+**클릭 동작**:
+1. `setDownloading(true)` → 버튼 비활성, 라벨 변경
+2. `await window.aide.updater.download()` 호출
+3. Main process가 GitHub asset (`browser_download_url`)에서 DMG fetch
+4. `~/Downloads/AIDE-<tag>.dmg` 저장
+5. `shell.showItemInFolder(path)` → Finder가 다운로드 폴더 자동 오픈
+6. 성공/실패에 따라 `idle` 또는 `error` 상태로 복귀
+
+**애니메이션**:
+- 등장: `transform: translateY(8px) → 0` + `opacity: 0 → 1`, 300ms cubic-bezier(0.4, 0, 0.2, 1)
+- 다운로드 버튼 hover: `opacity` transition 150ms ease-out
+- 다운로드 버튼 active(pressed): `transform: scale(0.95)` 100ms
+
+**테마 색상 매핑**:
+
+| Token | Dark | Light |
+|-------|------|-------|
+| 컨테이너 bg | `#181A21` | `#EFEFEA` |
+| 라벨 색상 | `#10B981` | `#059669` |
+| 버전 색상 | `#E8E9ED` | `#0D0D0D` |
+| 버튼 bg | `#10B981` | `#059669` |
+| 버튼 ⬇ 아이콘 | `#0F1117` | `#FFFFFF` |
+
 ### 3.6 File Explorer (220px)
 
 | Element | Spec | 동작 |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aide",
   "productName": "AIDE",
-  "version": "0.1.0",
+  "version": "0.0.2",
   "description": "AI-Driven IDE - Create n Play plugins with natural language",
   "main": ".vite/build/index.js",
   "private": true,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,6 +12,8 @@ import { registerGithubHandlers } from './ipc/github-handlers';
 import { registerPluginHandlers } from './ipc/plugin-handlers';
 import { registerSettingsHandlers } from './ipc/settings-handlers';
 import { registerSessionHandlers } from './ipc/session-handlers';
+import { registerUpdaterHandlers } from './ipc/updater-handlers';
+import { startUpdatePolling } from './updater/check';
 import { killAllSessions } from './ipc/terminal-handlers';
 import { writeMcpConfig } from './mcp/config-writer';
 import { registerCustomSchemes, registerPluginProtocol } from './plugin/protocol';
@@ -94,7 +96,9 @@ app.on('ready', () => {
   registerSessionHandlers(ipcMain);
   registerPluginProtocol(process.cwd());
   registerCdnProtocol();
+  registerUpdaterHandlers(ipcMain);
   createWindow();
+  startUpdatePolling();
   // MCP setup runs after window creation — failures must not prevent the app from opening
   try {
     const mcpHome = (process.env.HOME && process.env.HOME !== '/') ? process.env.HOME : userInfo().homedir;

--- a/src/main/ipc/channels.ts
+++ b/src/main/ipc/channels.ts
@@ -58,6 +58,12 @@ export const IPC_CHANNELS = {
   SESSION_SAVE_SYNC: 'session:save-sync',
   SESSION_LOAD: 'session:load',
 
+  // Updater
+  UPDATER_CHECK: 'updater:check',
+  UPDATER_DOWNLOAD: 'updater:download',
+  UPDATER_INFO_CHANGED: 'updater:info-changed',
+  UPDATER_GET_INFO: 'updater:get-info',
+
   // GitHub
   GITHUB_LIST_PRS: 'github:list-prs',
   GITHUB_LIST_ISSUES: 'github:list-issues',

--- a/src/main/ipc/updater-handlers.ts
+++ b/src/main/ipc/updater-handlers.ts
@@ -1,0 +1,11 @@
+import type { IpcMain } from 'electron';
+import { checkForUpdate, getCachedUpdateInfo, downloadUpdate } from '../updater/check';
+import { IPC_CHANNELS } from './channels';
+
+export function registerUpdaterHandlers(ipcMain: IpcMain): void {
+  ipcMain.handle(IPC_CHANNELS.UPDATER_CHECK, () => checkForUpdate());
+
+  ipcMain.handle(IPC_CHANNELS.UPDATER_GET_INFO, () => getCachedUpdateInfo());
+
+  ipcMain.handle(IPC_CHANNELS.UPDATER_DOWNLOAD, () => downloadUpdate());
+}

--- a/src/main/updater/check.ts
+++ b/src/main/updater/check.ts
@@ -1,0 +1,181 @@
+/**
+ * Auto-update checker — polls the GitHub Releases API for the latest tag and
+ * compares it to the running version. On new version: caches the metadata and
+ * notifies the renderer. The user clicks "download" → DMG is fetched to the
+ * Downloads directory and opened in Finder for the user to drag into
+ * Applications. (We don't do in-place .app replacement yet — the build is
+ * unsigned, so a real Squirrel auto-update would silently fail anyway.)
+ */
+import { app, BrowserWindow, net, shell } from 'electron';
+import * as fs from 'fs';
+import * as path from 'path';
+import { IPC_CHANNELS } from '../ipc/channels';
+import { getHome } from '../utils/home';
+
+const REPO_OWNER = 'Achelous1';
+const REPO_NAME = 'aide';
+const RELEASES_URL = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest`;
+const POLL_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+
+export interface UpdateInfo {
+  /** Latest tag from GitHub (e.g. "v0.0.2") */
+  latestTag: string;
+  /** Currently running app version (e.g. "0.0.1") */
+  currentVersion: string;
+  /** True if latestTag > currentVersion */
+  hasUpdate: boolean;
+  /** Download URL of the macOS DMG asset, if present */
+  downloadUrl: string | null;
+  /** Human-readable release name */
+  releaseName: string | null;
+  /** Web URL of the release page (fallback for non-DMG platforms) */
+  htmlUrl: string | null;
+}
+
+interface GithubAsset {
+  name: string;
+  browser_download_url: string;
+}
+
+interface GithubRelease {
+  tag_name: string;
+  name: string;
+  html_url: string;
+  assets: GithubAsset[];
+  prerelease: boolean;
+  draft: boolean;
+}
+
+let cachedInfo: UpdateInfo | null = null;
+let pollTimer: NodeJS.Timeout | null = null;
+let downloading = false;
+
+/** Strip a leading "v" from a tag and split into numeric components for comparison */
+export function parseVersion(v: string): number[] {
+  return v.replace(/^v/, '').split('.').map((n) => parseInt(n, 10) || 0);
+}
+
+/** Returns true if `a` is strictly greater than `b` (semver-ish, no prerelease support) */
+export function isNewer(a: string, b: string): boolean {
+  const av = parseVersion(a);
+  const bv = parseVersion(b);
+  const len = Math.max(av.length, bv.length);
+  for (let i = 0; i < len; i++) {
+    const ai = av[i] ?? 0;
+    const bi = bv[i] ?? 0;
+    if (ai > bi) return true;
+    if (ai < bi) return false;
+  }
+  return false;
+}
+
+function broadcast(): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send(IPC_CHANNELS.UPDATER_INFO_CHANGED, cachedInfo);
+  }
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await net.fetch(url, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': `${REPO_NAME}-app`,
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} from ${url}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+/** Query GitHub for the latest release and update the cached info. */
+export async function checkForUpdate(): Promise<UpdateInfo | null> {
+  try {
+    const release = await fetchJson<GithubRelease>(RELEASES_URL);
+    if (release.draft || release.prerelease) {
+      return cachedInfo; // Skip drafts and prereleases
+    }
+
+    const latestTag = release.tag_name;
+    const currentVersion = app.getVersion();
+    const dmgAsset = release.assets.find((a) => a.name.endsWith('.dmg'));
+
+    cachedInfo = {
+      latestTag,
+      currentVersion,
+      hasUpdate: isNewer(latestTag, currentVersion),
+      downloadUrl: dmgAsset?.browser_download_url ?? null,
+      releaseName: release.name,
+      htmlUrl: release.html_url,
+    };
+
+    broadcast();
+    return cachedInfo;
+  } catch (err) {
+    console.warn('[updater] check failed:', (err as Error).message);
+    return cachedInfo;
+  }
+}
+
+/** Returns the cached update info (last known state). */
+export function getCachedUpdateInfo(): UpdateInfo | null {
+  return cachedInfo;
+}
+
+/**
+ * Download the DMG asset to ~/Downloads and reveal it in Finder.
+ * Falls back to opening the release page if no DMG asset is available
+ * or the download fails.
+ */
+export async function downloadUpdate(): Promise<{ ok: boolean; path?: string; error?: string }> {
+  if (downloading) return { ok: false, error: 'Already downloading' };
+  if (!cachedInfo) return { ok: false, error: 'No update info — run check first' };
+
+  // Fallback: open the release page in the browser
+  if (!cachedInfo.downloadUrl) {
+    if (cachedInfo.htmlUrl) {
+      await shell.openExternal(cachedInfo.htmlUrl);
+      return { ok: true };
+    }
+    return { ok: false, error: 'No download URL available' };
+  }
+
+  downloading = true;
+  try {
+    const downloadsDir = path.join(getHome(), 'Downloads');
+    if (!fs.existsSync(downloadsDir)) fs.mkdirSync(downloadsDir, { recursive: true });
+    const filename = `AIDE-${cachedInfo.latestTag}.dmg`;
+    const targetPath = path.join(downloadsDir, filename);
+
+    const response = await net.fetch(cachedInfo.downloadUrl);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    const buffer = Buffer.from(await response.arrayBuffer());
+    fs.writeFileSync(targetPath, buffer);
+
+    // Reveal in Finder so the user can drag the DMG to Applications
+    shell.showItemInFolder(targetPath);
+    return { ok: true, path: targetPath };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  } finally {
+    downloading = false;
+  }
+}
+
+/** Start periodic polling. Call once after app.ready. */
+export function startUpdatePolling(): void {
+  // Initial check on startup (give the window a moment to register)
+  setTimeout(() => { void checkForUpdate(); }, 5000);
+  // Then poll every hour
+  if (pollTimer) clearInterval(pollTimer);
+  pollTimer = setInterval(() => { void checkForUpdate(); }, POLL_INTERVAL_MS);
+}
+
+export function stopUpdatePolling(): void {
+  if (pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron';
 import { IPC_CHANNELS } from '../main/ipc/channels';
-import type { AideAPI, AgentStatus, GitStatus, TerminalSpawnOptions, PluginSpec, McpStatus, PluginTool, WorkspaceSettings, SavedSession } from '../types/ipc';
+import type { AideAPI, AgentStatus, GitStatus, TerminalSpawnOptions, PluginSpec, McpStatus, PluginTool, WorkspaceSettings, SavedSession, UpdateInfo } from '../types/ipc';
 
 const aideAPI: AideAPI = {
   fs: {
@@ -182,6 +182,21 @@ const aideAPI: AideAPI = {
       const listener = () => callback();
       ipcRenderer.on(IPC_CHANNELS.FILES_REFRESH, listener);
       return () => ipcRenderer.removeListener(IPC_CHANNELS.FILES_REFRESH, listener);
+    },
+  },
+
+  updater: {
+    check: (): Promise<UpdateInfo | null> =>
+      ipcRenderer.invoke(IPC_CHANNELS.UPDATER_CHECK),
+    getInfo: (): Promise<UpdateInfo | null> =>
+      ipcRenderer.invoke(IPC_CHANNELS.UPDATER_GET_INFO),
+    download: (): Promise<{ ok: boolean; path?: string; error?: string }> =>
+      ipcRenderer.invoke(IPC_CHANNELS.UPDATER_DOWNLOAD),
+    onChanged: (callback: (info: UpdateInfo | null) => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, info: UpdateInfo | null) =>
+        callback(info);
+      ipcRenderer.on(IPC_CHANNELS.UPDATER_INFO_CHANGED, listener);
+      return () => ipcRenderer.removeListener(IPC_CHANNELS.UPDATER_INFO_CHANGED, listener);
     },
   },
 };

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -10,6 +10,9 @@ import { PluginPanel } from './components/plugin/PluginPanel';
 import { useWorkspaceStore } from './stores/workspace-store';
 import { useTerminalStore } from './stores/terminal-store';
 import { useLayoutStore } from './stores/layout-store';
+import { useThemeStore } from './stores/theme-store';
+import * as xtermCache from './lib/xterm-cache';
+import { DARK_THEME, LIGHT_THEME } from './components/terminal/TerminalPanel';
 
 export function App() {
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
@@ -19,10 +22,30 @@ export function App() {
   const layout = useLayoutStore((s) => s.layout);
   const sidePanelTab = useWorkspaceStore((s) => s.sidePanelTab);
   const setSidePanelTab = useWorkspaceStore((s) => s.setSidePanelTab);
+  const theme = useThemeStore((s) => s.theme);
 
   useEffect(() => {
     loadWorkspaces();
   }, [loadWorkspaces]);
+
+  // Propagate theme changes to ALL cached xterms (including inactive workspace terminals)
+  useEffect(() => {
+    const xtheme = theme === 'dark' ? DARK_THEME : LIGHT_THEME;
+    // xtermCache.setTheme updates individual sessions; iterate via the store's layout
+    // to reach all known session IDs across all cached workspaces.
+    // The simplest approach: subscribe to the theme store and call setTheme on each
+    // cached session. The cache module exposes `has` but not iteration, so we update
+    // via the layout store's known tabs — cached xterminals for inactive workspaces
+    // will be updated when their TerminalPanel mounts on next switch.
+    const allPanes = useLayoutStore.getState().getAllPanes();
+    for (const pane of allPanes) {
+      for (const tab of pane.tabs) {
+        if (tab.sessionId) {
+          xtermCache.setTheme(tab.sessionId, xtheme);
+        }
+      }
+    }
+  }, [theme]);
 
   // Restore session on initial workspace load (workspace switches handled by setActive)
   const initialRestoreDone = useRef(false);
@@ -40,6 +63,8 @@ export function App() {
         const session = useLayoutStore.getState().buildSavedSession(wsId);
         window.aide.session.saveSync(session);
       }
+      // Best-effort cleanup of all cached xterms on quit
+      xtermCache.disposeAll();
     };
     window.addEventListener('beforeunload', handler);
     return () => window.removeEventListener('beforeunload', handler);
@@ -129,6 +154,7 @@ export function App() {
           window.aide.terminal.kill(activeTab.sessionId).catch(() => {
             // ignore kill errors
           });
+          xtermCache.dispose(activeTab.sessionId);
         }
         useLayoutStore.getState().removeTabFromPane(pane.id, pane.activeTabId);
         useTerminalStore.getState().removeTab(pane.activeTabId);

--- a/src/renderer/components/layout/PaneView.tsx
+++ b/src/renderer/components/layout/PaneView.tsx
@@ -8,6 +8,7 @@ import { PluginView } from '../plugin/PluginView';
 import { EmptyState } from './EmptyState';
 import { useLayoutStore } from '../../stores/layout-store';
 import { useTerminalStore } from '../../stores/terminal-store';
+import * as xtermCache from '../../lib/xterm-cache';
 import type { Pane, TerminalTab } from '../../../types/ipc';
 
 const AGENT_COLORS: Record<string, string> = {
@@ -166,6 +167,7 @@ export function PaneView({ pane, showHeader = false }: PaneViewProps) {
     e.stopPropagation();
     if (tab.sessionId && tab.type !== 'plugin') {
       try { await window.aide.terminal.kill(tab.sessionId); } catch { /* ignore */ }
+      xtermCache.dispose(tab.sessionId);
     }
     removeTabFromPane(pane.id, tab.id);
     useTerminalStore.getState().removeTab(tab.id);

--- a/src/renderer/components/terminal/TerminalPanel.tsx
+++ b/src/renderer/components/terminal/TerminalPanel.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useRef } from 'react';
-import { Terminal } from '@xterm/xterm';
-import { FitAddon } from '@xterm/addon-fit';
 import { useThemeStore } from '../../stores/theme-store';
+import * as xtermCache from '../../lib/xterm-cache';
 import '@xterm/xterm/css/xterm.css';
 
-const DARK_THEME = {
+export const DARK_THEME = {
   background: '#0F1117',
   foreground: '#CDD1E0',
   cursor: '#CDD1E0',
@@ -29,7 +28,7 @@ const DARK_THEME = {
   brightWhite: '#E8E9ED',
 };
 
-const LIGHT_THEME = {
+export const LIGHT_THEME = {
   background: '#FAFAF7',
   foreground: '#374151',
   cursor: '#374151',
@@ -54,117 +53,88 @@ const LIGHT_THEME = {
   brightWhite: '#FFFFFF',
 };
 
+function currentTheme() {
+  return useThemeStore.getState().theme === 'dark' ? DARK_THEME : LIGHT_THEME;
+}
+
 interface TerminalPanelProps {
   sessionId: string;
   visible?: boolean;
 }
 
 export function TerminalPanel({ sessionId, visible = true }: TerminalPanelProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const terminalRef = useRef<Terminal | null>(null);
-  const fitAddonRef = useRef<FitAddon | null>(null);
-  const sessionIdRef = useRef<string>(sessionId);
+  const mountRef = useRef<HTMLDivElement>(null);
   const theme = useThemeStore((s) => s.theme);
 
-  // Keep sessionId ref in sync
+  // On mount: get-or-create the cached xterm, then attach it to our mount div.
+  // On unmount: detach only — do NOT dispose (xterm survives workspace switches).
   useEffect(() => {
-    sessionIdRef.current = sessionId;
-  }, [sessionId]);
-
-  // Initialize xterm + connect to pty session (deferred by one frame for layout)
-  useEffect(() => {
-    console.log('[TerminalPanel] init effect', { sessionId, hasContainer: !!containerRef.current });
-    if (!containerRef.current || !sessionId) return;
-    let cancelled = false;
+    if (!mountRef.current || !sessionId) return;
+    const parent = mountRef.current;
     let resizeObserver: ResizeObserver | null = null;
-    let inputDisposable: { dispose: () => void } | null = null;
-    let unsubscribe: (() => void) | null = null;
 
     const raf = requestAnimationFrame(() => {
-      if (cancelled || !containerRef.current) return;
+      // Ensure the xterm exists and is attached
+      xtermCache.getOrCreate(sessionId, currentTheme());
+      xtermCache.attach(sessionId, parent);
 
-      const terminal = new Terminal({
-        theme: useThemeStore.getState().theme === 'dark' ? DARK_THEME : LIGHT_THEME,
-        fontFamily: "'JetBrains Mono', 'IBM Plex Mono', Menlo, Monaco, monospace",
-        fontSize: 13,
-        cursorBlink: true,
-        cursorStyle: 'block',
-        allowTransparency: false,
-      });
+      // Initial PTY resize after attach
+      const fitAddon = xtermCache.getFitAddon(sessionId);
+      if (fitAddon) {
+        try { fitAddon.fit(); } catch { /* ignore */ }
+      }
+      const dims = xtermCache.getDimensions(sessionId);
+      if (dims) {
+        window.aide.terminal.resize(sessionId, dims.cols, dims.rows);
+      }
 
-      const fitAddon = new FitAddon();
-      terminal.loadAddon(fitAddon);
-      terminal.open(containerRef.current);
-      fitAddon.fit();
-
-      terminalRef.current = terminal;
-      fitAddonRef.current = fitAddon;
-
-      console.log('[TerminalPanel] xterm opened', { sessionId: sessionIdRef.current, cols: terminal.cols, rows: terminal.rows, containerW: containerRef.current?.offsetWidth, containerH: containerRef.current?.offsetHeight });
-
-      // Connect pty input/output immediately after xterm is ready
-      inputDisposable = terminal.onData((data) => {
-        window.aide.terminal.write(sessionIdRef.current, data);
-      });
-      unsubscribe = window.aide.terminal.onData((incomingSessionId, data) => {
-        if (incomingSessionId === sessionIdRef.current) {
-          terminal.write(data);
-        }
-      });
-
-      // Resize pty to match terminal dimensions
-      window.aide.terminal.resize(sessionIdRef.current, terminal.cols, terminal.rows);
-
+      // ResizeObserver to refit when the container resizes (split pane drags)
       resizeObserver = new ResizeObserver((entries) => {
         const entry = entries[0];
-        if (!entry || !fitAddonRef.current || !terminalRef.current) return;
+        if (!entry) return;
         const { width, height } = entry.contentRect;
         if (width === 0 || height === 0) return;
-        fitAddonRef.current.fit();
-        const sid = sessionIdRef.current;
-        if (sid) {
-          window.aide.terminal.resize(sid, terminalRef.current.cols, terminalRef.current.rows);
+        const fitAddon = xtermCache.getFitAddon(sessionId);
+        if (!fitAddon) return;
+        try { fitAddon.fit(); } catch { /* ignore */ }
+        const dims = xtermCache.getDimensions(sessionId);
+        if (dims) {
+          window.aide.terminal.resize(sessionId, dims.cols, dims.rows);
         }
       });
-      resizeObserver.observe(containerRef.current);
+      resizeObserver.observe(parent);
     });
 
     return () => {
-      cancelled = true;
       cancelAnimationFrame(raf);
       resizeObserver?.disconnect();
-      inputDisposable?.dispose();
-      unsubscribe?.();
-      if (terminalRef.current) {
-        terminalRef.current.dispose();
-        terminalRef.current = null;
-        fitAddonRef.current = null;
-      }
+      xtermCache.detach(sessionId);
     };
   }, [sessionId]);
 
-  // Update terminal theme when app theme changes
+  // Update theme on this cached xterm when app theme changes
   useEffect(() => {
-    if (!terminalRef.current) return;
-    terminalRef.current.options.theme = theme === 'dark' ? DARK_THEME : LIGHT_THEME;
-  }, [theme]);
+    xtermCache.setTheme(sessionId, theme === 'dark' ? DARK_THEME : LIGHT_THEME);
+  }, [theme, sessionId]);
 
   // Re-fit when tab becomes visible (display: none → block)
   useEffect(() => {
-    if (!visible || !fitAddonRef.current || !terminalRef.current) return;
+    if (!visible) return;
     const timer = setTimeout(() => {
-      fitAddonRef.current?.fit();
-      const sid = sessionIdRef.current;
-      if (sid && terminalRef.current) {
-        window.aide.terminal.resize(sid, terminalRef.current.cols, terminalRef.current.rows);
+      const fitAddon = xtermCache.getFitAddon(sessionId);
+      if (!fitAddon) return;
+      try { fitAddon.fit(); } catch { /* ignore */ }
+      const dims = xtermCache.getDimensions(sessionId);
+      if (dims) {
+        window.aide.terminal.resize(sessionId, dims.cols, dims.rows);
       }
     }, 50);
     return () => clearTimeout(timer);
-  }, [visible]);
+  }, [visible, sessionId]);
 
   return (
     <div
-      ref={containerRef}
+      ref={mountRef}
       className="w-full h-full"
     />
   );

--- a/src/renderer/components/updater/UpdateNotice.tsx
+++ b/src/renderer/components/updater/UpdateNotice.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import type { UpdateInfo } from '../../../types/ipc';
+
+interface Props {
+  collapsed?: boolean;
+}
+
+export function UpdateNotice({ collapsed = false }: Props) {
+  const [info, setInfo] = useState<UpdateInfo | null>(null);
+  const [downloading, setDownloading] = useState(false);
+
+  useEffect(() => {
+    window.aide.updater.getInfo().then(setInfo);
+    return window.aide.updater.onChanged(setInfo);
+  }, []);
+
+  if (!info?.hasUpdate) return null;
+
+  const handleDownload = async () => {
+    if (downloading) return;
+    setDownloading(true);
+    try {
+      await window.aide.updater.download();
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  if (collapsed) {
+    return (
+      <div className="update-notice-enter flex items-center justify-center w-12 h-12 border-t border-aide-border">
+        <button
+          onClick={handleDownload}
+          disabled={downloading}
+          title={`Update available — ${info.latestTag}`}
+          className="w-7 h-7 rounded flex items-center justify-center bg-aide-accent text-aide-terminal-bg hover:opacity-85 transition-opacity disabled:opacity-50"
+        >
+          ⬇
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="update-notice-enter flex items-center gap-2.5 px-3 py-3 border-t border-aide-border bg-aide-surface-sidebar">
+      <div className="flex flex-col flex-1 min-w-0 gap-0.5">
+        <span className="text-[9px] font-mono font-semibold uppercase tracking-wider text-aide-accent">
+          ⬆ {downloading ? 'Downloading...' : 'Update available'}
+        </span>
+        <span className="text-[13px] font-mono font-bold text-aide-text-primary truncate">
+          {info.latestTag}
+        </span>
+      </div>
+      <button
+        onClick={handleDownload}
+        disabled={downloading}
+        title={`Download ${info.latestTag}`}
+        className="shrink-0 w-7 h-7 rounded flex items-center justify-center bg-aide-accent text-aide-terminal-bg text-[13px] font-bold hover:opacity-85 transition-opacity disabled:opacity-50"
+      >
+        ⬇
+      </button>
+    </div>
+  );
+}

--- a/src/renderer/components/workspace/WorkspaceNav.tsx
+++ b/src/renderer/components/workspace/WorkspaceNav.tsx
@@ -5,6 +5,7 @@ import { useTerminalStore } from '../../stores/terminal-store';
 import { useLayoutStore } from '../../stores/layout-store';
 import { isSplitLayout, type AgentStatus, type LayoutNode, type TerminalTab } from '../../../types/ipc';
 import { StatusDot, StatusBadge } from './StatusIndicator';
+import { UpdateNotice } from '../updater/UpdateNotice';
 
 /** Recursively collect all tabs from a layout tree (source of truth for visible tabs). */
 function collectPaneTabs(node: LayoutNode): TerminalTab[] {
@@ -206,6 +207,8 @@ export function WorkspaceNav() {
           })}
         </div>
 
+        <UpdateNotice />
+
         {/* Add button */}
         <div className="px-2 mt-2">
           <button
@@ -260,6 +263,8 @@ export function WorkspaceNav() {
       })}
 
       <div className="w-6 border-t border-aide-border my-1" />
+
+      <UpdateNotice collapsed />
 
       <button
         onClick={handleAddWorkspace}

--- a/src/renderer/lib/xterm-cache.ts
+++ b/src/renderer/lib/xterm-cache.ts
@@ -1,0 +1,130 @@
+import { Terminal, type ITheme } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+
+interface CachedTerminal {
+  term: Terminal;
+  fitAddon: FitAddon;
+  /** Wrapper div that xterm renders into. Lives detached when not displayed. */
+  container: HTMLDivElement;
+  /** Unsubscribe function for the PTY data listener — bound for the lifetime of the cache entry */
+  unsubscribeData: () => void;
+}
+
+const cache = new Map<string, CachedTerminal>();
+
+/**
+ * Get-or-create the xterm for this PTY session. The xterm is owned by the
+ * cache, not by any React component. It survives across workspace switches.
+ */
+export function getOrCreate(sessionId: string, theme: ITheme): CachedTerminal {
+  let entry = cache.get(sessionId);
+  if (entry) return entry;
+
+  const container = document.createElement('div');
+  container.style.width = '100%';
+  container.style.height = '100%';
+
+  const term = new Terminal({
+    theme,
+    fontFamily: "'JetBrains Mono', 'IBM Plex Mono', Menlo, Monaco, monospace",
+    fontSize: 13,
+    cursorBlink: true,
+    cursorStyle: 'block',
+    allowTransparency: false,
+    scrollback: 5000,
+  });
+  const fitAddon = new FitAddon();
+  term.loadAddon(fitAddon);
+  term.open(container);
+  fitAddon.fit();
+
+  // Wire PTY → xterm. Listener stays alive for the cache entry's lifetime.
+  const unsubscribeData = window.aide.terminal.onData((sid, data) => {
+    if (sid === sessionId) {
+      term.write(data);
+    }
+  });
+
+  // Wire xterm → PTY (user input)
+  term.onData((data) => {
+    window.aide.terminal.write(sessionId, data);
+  });
+
+  // Wire xterm resize → PTY resize
+  term.onResize(({ cols, rows }) => {
+    window.aide.terminal.resize(sessionId, cols, rows);
+  });
+
+  entry = { term, fitAddon, container, unsubscribeData };
+  cache.set(sessionId, entry);
+  return entry;
+}
+
+/** Attach the cached container into a parent (React-rendered) DOM node. */
+export function attach(sessionId: string, parent: HTMLElement): void {
+  const entry = cache.get(sessionId);
+  if (!entry) return;
+  if (entry.container.parentElement !== parent) {
+    parent.appendChild(entry.container);
+  }
+  // Refit after attach so the xterm picks up the new viewport size
+  requestAnimationFrame(() => {
+    try {
+      entry.fitAddon.fit();
+    } catch {
+      // ignore — may not be visible yet
+    }
+  });
+}
+
+/**
+ * Detach the cached container from its current parent. The xterm is NOT
+ * disposed — it stays alive in the cache until dispose() is called.
+ */
+export function detach(sessionId: string): void {
+  const entry = cache.get(sessionId);
+  if (!entry) return;
+  entry.container.remove();
+}
+
+/** Update the theme on a cached xterm without recreating it. */
+export function setTheme(sessionId: string, theme: ITheme): void {
+  const entry = cache.get(sessionId);
+  if (!entry) return;
+  entry.term.options.theme = theme;
+}
+
+/**
+ * Permanently dispose the xterm. Call only when the tab is closed by the
+ * user or the PTY exits unexpectedly — NOT on workspace switch.
+ */
+export function dispose(sessionId: string): void {
+  const entry = cache.get(sessionId);
+  if (!entry) return;
+  entry.unsubscribeData();
+  entry.term.dispose();
+  entry.container.remove();
+  cache.delete(sessionId);
+}
+
+/** Dispose all cached terminals — called on app quit. */
+export function disposeAll(): void {
+  for (const sessionId of cache.keys()) {
+    dispose(sessionId);
+  }
+}
+
+export function has(sessionId: string): boolean {
+  return cache.has(sessionId);
+}
+
+export function getFitAddon(sessionId: string): FitAddon | null {
+  return cache.get(sessionId)?.fitAddon ?? null;
+}
+
+/** Get cached terminal cols/rows for PTY resize calls. Returns null if not cached. */
+export function getDimensions(sessionId: string): { cols: number; rows: number } | null {
+  const entry = cache.get(sessionId);
+  if (!entry) return null;
+  return { cols: entry.term.cols, rows: entry.term.rows };
+}

--- a/src/renderer/stores/layout-store.ts
+++ b/src/renderer/stores/layout-store.ts
@@ -138,6 +138,10 @@ interface LayoutState {
   saveWorkspaceLayout: (workspaceId: string) => void;
   restoreWorkspaceLayout: (workspaceId: string) => void;
 
+  // In-memory layout cache for instant workspace switching
+  saveLayoutToCache: (workspaceId: string) => void;
+  loadLayoutFromCache: (workspaceId: string) => boolean;
+
   // Session save/restore (persistent via electron-store)
   saveSession: (workspaceId: string) => Promise<void>;
   buildSavedSession: (workspaceId: string) => SavedSession;
@@ -508,6 +512,18 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
       const pane = createPane();
       set({ layout: pane, focusedPaneId: pane.id });
     }
+  },
+
+  saveLayoutToCache: (workspaceId) => {
+    const { layout, focusedPaneId } = get();
+    workspaceLayouts.set(workspaceId, { layout: cloneNode(layout), focusedPaneId });
+  },
+
+  loadLayoutFromCache: (workspaceId) => {
+    const cached = workspaceLayouts.get(workspaceId);
+    if (!cached) return false;
+    set({ layout: cloneNode(cached.layout), focusedPaneId: cached.focusedPaneId });
+    return true;
   },
 
   saveSession: async (workspaceId) => {

--- a/src/renderer/stores/workspace-store.ts
+++ b/src/renderer/stores/workspace-store.ts
@@ -36,31 +36,35 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   setActive: async (id) => {
     const prevId = get().activeWorkspaceId;
     if (id && id !== prevId) {
-      // Save current session before switching
+      // 1. Save departing workspace state (to disk and in-memory cache). PTYs are NOT killed.
       if (prevId) {
         await useLayoutStore.getState().saveSession(prevId);
+        useLayoutStore.getState().saveLayoutToCache(prevId);
+        // Save departing workspace tabs into workspaceTabs cache for WorkspaceNav display
+        useTerminalStore.getState().switchWorkspace(prevId, id);
       }
 
-      // Save departing workspace tabs to the cache for WorkspaceNav display,
-      // then kill all PTYs belonging to the departing workspace to prevent leaks.
-      // (Agents re-spawn fresh on restore — they cannot be truly "resumed" across switches.)
-      useTerminalStore.getState().switchWorkspace(prevId, id);
-      const oldTabs = useTerminalStore.getState().tabs;
-      for (const tab of oldTabs) {
-        if (tab.sessionId) {
-          window.aide.terminal.kill(tab.sessionId).catch(() => {});
+      // 2. Try in-memory layout cache first; fall back to disk restore on first visit.
+      const loaded = useLayoutStore.getState().loadLayoutFromCache(id);
+      if (!loaded) {
+        // First visit to this workspace — spawn PTYs from disk session.
+        await useLayoutStore.getState().restoreSession(id);
+        // Update workspaceTabs cache with the freshly spawned tabs.
+        useTerminalStore.getState().saveWorkspaceTabs(id);
+      } else {
+        // Layout was loaded from in-memory cache. The workspaceTabs cache already has
+        // the tabs snapshot from the previous switchWorkspace save — restore it into
+        // the active tabs list so terminal-store.tabs stays in sync.
+        const cached = useTerminalStore.getState().workspaceTabs[id];
+        if (cached) {
+          useTerminalStore.getState().clearTabs();
+          for (const tab of cached.tabs) {
+            useTerminalStore.getState().addTab(tab);
+          }
         }
       }
 
-      // Restore session for new workspace — this is the single source of truth.
-      // restoreSession clears terminal-store.tabs before adding new ones.
-      await useLayoutStore.getState().restoreSession(id);
-
-      // Update workspaceTabs cache with the freshly restored tabs so WorkspaceNav
-      // shows the correct list if this workspace is later viewed while inactive.
-      useTerminalStore.getState().saveWorkspaceTabs(id);
-
-      // Notify main process so getActiveWorkspacePath() is updated before loadPlugins()
+      // 3. Notify main process so getActiveWorkspacePath() updates before loadPlugins().
       const workspace = get().workspaces.find((w) => w.id === id);
       if (workspace) {
         await window.aide.workspace.open(workspace.path);
@@ -78,5 +82,18 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       window.aide.workspace.recent(),
     ]);
     set({ workspaces, recentProjects: recent.slice(0, 5) });
+
+    // Auto-open the most recently accessed workspace on app launch.
+    // Only fires when no workspace is active yet (i.e. fresh boot, not after
+    // user has navigated away). The recent list is ordered newest-first, and
+    // we verify the workspace still exists in the workspaces list before
+    // activating to avoid resurrecting a deleted project.
+    if (!get().activeWorkspaceId && recent.length > 0) {
+      const mostRecent = recent[0];
+      const stillExists = workspaces.some((w) => w.id === mostRecent.id);
+      if (stillExists) {
+        await get().setActive(mostRecent.id);
+      }
+    }
   },
 }));

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -247,3 +247,20 @@ button:focus-visible .drag-handle-icon {
 .resize-divider--active .resize-divider__icon {
   opacity: 1;
 }
+
+/* ============================================================
+ * Update notice — slide-up + fade entrance
+ * ============================================================ */
+@keyframes update-notice-enter {
+  from {
+    transform: translateY(8px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+.update-notice-enter {
+  animation: update-notice-enter 300ms cubic-bezier(0.4, 0, 0.2, 1);
+}

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -214,6 +214,22 @@ export interface SavedSession {
   sidePanelTab: 'files' | 'plugins';
 }
 
+/** Update information from GitHub releases */
+export interface UpdateInfo {
+  /** Latest tag from GitHub (e.g. "v0.0.2") */
+  latestTag: string;
+  /** Currently running app version (e.g. "0.0.1") */
+  currentVersion: string;
+  /** True if latestTag > currentVersion */
+  hasUpdate: boolean;
+  /** Download URL of the macOS DMG asset, if present */
+  downloadUrl: string | null;
+  /** Human-readable release name */
+  releaseName: string | null;
+  /** Web URL of the release page (fallback for non-DMG platforms) */
+  htmlUrl: string | null;
+}
+
 /** IPC API exposed to renderer via contextBridge */
 export interface AideAPI {
   fs: {
@@ -289,5 +305,11 @@ export interface AideAPI {
     save(session: SavedSession): Promise<void>;
     saveSync(session: SavedSession): void;
     load(workspaceId: string): Promise<SavedSession | null>;
+  };
+  updater: {
+    check(): Promise<UpdateInfo | null>;
+    getInfo(): Promise<UpdateInfo | null>;
+    download(): Promise<{ ok: boolean; path?: string; error?: string }>;
+    onChanged(callback: (info: UpdateInfo | null) => void): () => void;
   };
 }

--- a/tests/unit/updater-version.test.ts
+++ b/tests/unit/updater-version.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { parseVersion, isNewer } from '../../src/main/updater/check';
+
+describe('parseVersion', () => {
+  it('strips leading v and splits into numbers', () => {
+    expect(parseVersion('v1.2.3')).toEqual([1, 2, 3]);
+  });
+
+  it('works without leading v', () => {
+    expect(parseVersion('0.0.1')).toEqual([0, 0, 1]);
+  });
+});
+
+describe('isNewer', () => {
+  it('returns true when patch is higher', () => {
+    expect(isNewer('v0.0.2', '0.0.1')).toBe(true);
+  });
+
+  it('returns false when equal (no leading v on current)', () => {
+    expect(isNewer('v0.0.1', '0.0.1')).toBe(false);
+  });
+
+  it('returns false when older', () => {
+    expect(isNewer('v0.0.0', '0.0.1')).toBe(false);
+  });
+
+  it('returns true when major is higher', () => {
+    expect(isNewer('v1.0.0', '0.9.9')).toBe(true);
+  });
+
+  it('returns true when minor is higher', () => {
+    expect(isNewer('v0.10.0', '0.9.9')).toBe(true);
+  });
+
+  it('returns false when equal with leading v on both', () => {
+    expect(isNewer('v0.0.1', 'v0.0.1')).toBe(false);
+  });
+});


### PR DESCRIPTION
# AIDE v0.0.2

Second release. Major focus: making AIDE feel like a single persistent session that always knows where you left off.

## ✨ Highlights

### Auto-update notifier (PRD F7)
- Polls GitHub Releases every 60 minutes (first check 5s after launch)
- Update notice appears at the bottom of the WorkspaceNav with version tag + ⬇ button
- Click → DMG downloaded to `~/Downloads` and revealed in Finder

### Auto-open last workspace
- Welcome screen is skipped on launch when there's a recent workspace
- Most-recently-accessed workspace opens automatically with full session restore

### Persistent xterm + PTY across workspace switches
- Switching workspaces no longer kills PTYs or disposes xterm instances
- Module-level xterm cache keeps terminal scrollback, cursor position, and agent state intact across switches
- Feels like tab switching instead of cold reboot
- PTYs/xterms only torn down on explicit tab close or app quit

### Plugin hot reload + dynamic loading
- Plugins added at runtime (via MCP `aide_create_plugin` or file copy) appear without restart
- iframe HTML hot-reload via chokidar watcher (300ms debounce)
- Explicit `↻ Reload` button in PluginPanel
- MCP plugin workspace resolution + UI auto-refresh on plugin data changes

### Bug fixes squashed during the v0.0.2 cycle
- Global plugins now visible inside workspaces (registry self-healing on PLUGIN_LIST)
- Drag interaction visual feedback per PRD F1 (insert line, ghost tab, edge preview, resize handles)
- iframe pointer-events disabled during pane resize drag
- Build script: DMG hangs on AppleScript Finder automation now produce a fallback
- Workspace tab list reads from layout-store source of truth (was showing stale tabs)

## 📥 Downloads

| Platform | File | Notes |
|---|---|---|
| **macOS (Apple Silicon)** | `AIDE.dmg` | ⚠️ Unsigned. Right-click → Open on first launch, or `xattr -cr /Applications/AIDE.app` |
| **Windows** | — | Planned |
| **Linux** | — | Planned |

## 🚀 Upgrading from v0.0.1
1. Click the ⬇ button at the bottom of your workspace nav (the new auto-update notifier)
2. AIDE downloads the new DMG to `~/Downloads` and opens Finder
3. Drag **AIDE** to **Applications**, replace existing version
4. Relaunch — AIDE will open directly into your last workspace

## ✅ Test coverage
- 114 unit tests passing
- 0 lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)