### PR TITLE
feat: workspace context menu — rename, path display, show in finder

### DIFF
--- a/design.pen
+++ b/design.pen
@@ -16971,6 +16971,30 @@
                   "children": [
                     {
                       "type": "frame",
+                      "id": "KnaQq",
+                      "name": "cm1",
+                      "width": "fill_container",
+                      "height": 32,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "aJx1z",
+                          "name": "newcm1txt",
+                          "fill": "$--text-primary",
+                          "content": "Rename",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
                       "id": "pGd6P",
                       "name": "cm2",
                       "width": "fill_container",

--- a/src/main/ipc/channels.ts
+++ b/src/main/ipc/channels.ts
@@ -83,4 +83,6 @@ export const IPC_CHANNELS = {
   WORKSPACE_RECENT: 'workspace:recent',
   WORKSPACE_OPEN_DIALOG: 'workspace:open-dialog',
   WORKSPACE_CREATE_PROJECT: 'workspace:create-project',
+  WORKSPACE_RENAME: 'workspace:rename',
+  WORKSPACE_SHOW_IN_FINDER: 'workspace:show-in-finder',
 } as const;

--- a/src/main/ipc/workspace-handlers.ts
+++ b/src/main/ipc/workspace-handlers.ts
@@ -1,4 +1,4 @@
-import { dialog, BrowserWindow, type IpcMain } from 'electron';
+import { dialog, shell, BrowserWindow, type IpcMain } from 'electron';
 import fs from 'fs';
 import nodePath from 'path';
 import Store from 'electron-store';
@@ -112,6 +112,19 @@ export function registerWorkspaceHandlers(ipcMain: IpcMain): void {
     const result = await dialog.showOpenDialog(win!, { properties: ['openDirectory'] });
     if (result.canceled || result.filePaths.length === 0) return null;
     return result.filePaths[0];
+  });
+
+  ipcMain.handle(IPC_CHANNELS.WORKSPACE_RENAME, (_event, id: string, name: string) => {
+    const workspaces = getWorkspaces();
+    const ws = workspaces.find((w) => w.id === id);
+    if (!ws) return null;
+    ws.name = name;
+    setWorkspaces(workspaces);
+    return ws;
+  });
+
+  ipcMain.handle(IPC_CHANNELS.WORKSPACE_SHOW_IN_FINDER, (_event, path: string) => {
+    shell.showItemInFolder(path);
   });
 
   ipcMain.handle(IPC_CHANNELS.WORKSPACE_CREATE_PROJECT, async (_event, projectName: string) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -85,6 +85,8 @@ const aideAPI: AideAPI = {
     recent: () => ipcRenderer.invoke(IPC_CHANNELS.WORKSPACE_RECENT),
     openDialog: () => ipcRenderer.invoke(IPC_CHANNELS.WORKSPACE_OPEN_DIALOG),
     createProject: (name: string) => ipcRenderer.invoke(IPC_CHANNELS.WORKSPACE_CREATE_PROJECT, name),
+    rename: (id: string, name: string) => ipcRenderer.invoke(IPC_CHANNELS.WORKSPACE_RENAME, id, name),
+    showInFinder: (path: string) => ipcRenderer.invoke(IPC_CHANNELS.WORKSPACE_SHOW_IN_FINDER, path),
   },
 
   agent: {

--- a/src/renderer/components/workspace/WorkspaceNav.tsx
+++ b/src/renderer/components/workspace/WorkspaceNav.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useWorkspaceStore } from '../../stores/workspace-store';
 import { useAgentStore } from '../../stores/agent-store';
 import { useTerminalStore } from '../../stores/terminal-store';
@@ -17,7 +17,7 @@ function collectPaneTabs(node: LayoutNode): TerminalTab[] {
 }
 
 export function WorkspaceNav() {
-  const { workspaces, activeWorkspaceId, navExpanded, setActive, toggleNav, addWorkspace, removeWorkspace } = useWorkspaceStore();
+  const { workspaces, activeWorkspaceId, navExpanded, setActive, toggleNav, addWorkspace, removeWorkspace, renameWorkspace } = useWorkspaceStore();
   const { sessionStatuses } = useAgentStore();
   const { workspaceTabs, activeTabId, setActiveTab } = useTerminalStore();
   // Subscribe to layout so this component re-renders when active workspace tabs change
@@ -25,6 +25,11 @@ export function WorkspaceNav() {
   const [expandedProjects, setExpandedProjects] = useState<Set<string>>(new Set());
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
   const [dropdownWorkspaceId, setDropdownWorkspaceId] = useState<string | null>(null);
+  const [contextMenuId, setContextMenuId] = useState<string | null>(null);
+  const [contextMenuPos, setContextMenuPos] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+  const [editingWorkspaceId, setEditingWorkspaceId] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState('');
+  const contextMenuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!window.aide?.agent?.onStatus) return;
@@ -33,6 +38,48 @@ export function WorkspaceNav() {
     });
     return unsubscribe;
   }, []);
+
+  useEffect(() => {
+    if (!contextMenuId) return;
+    const handler = (e: MouseEvent) => {
+      if (contextMenuRef.current && !contextMenuRef.current.contains(e.target as Node)) {
+        setContextMenuId(null);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [contextMenuId]);
+
+  const handleContextMenu = (e: React.MouseEvent, wsId: string) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setContextMenuId(wsId);
+    setContextMenuPos({ x: e.clientX, y: e.clientY });
+  };
+
+  const handleStartRename = (ws: { id: string; name: string }) => {
+    setContextMenuId(null);
+    setEditingWorkspaceId(ws.id);
+    setEditingName(ws.name);
+  };
+
+  const handleCommitRename = async (id: string) => {
+    const name = editingName.trim();
+    if (name) {
+      renameWorkspace(id, name);
+      await window.aide.workspace.rename(id, name);
+    }
+    setEditingWorkspaceId(null);
+  };
+
+  const handleCancelRename = () => {
+    setEditingWorkspaceId(null);
+  };
+
+  const handleShowInFinder = (path: string) => {
+    setContextMenuId(null);
+    window.aide.workspace.showInFinder(path);
+  };
 
   // Get tabs for a given workspace (active: from layout tree; inactive: from saved snapshot).
   // Excludes plugin tabs and sorts alphabetically by title.
@@ -152,6 +199,7 @@ export function WorkspaceNav() {
                   className={`relative group flex items-center gap-1 px-1 py-1.5 rounded transition-colors ${
                     isActive ? 'bg-aide-surface-elevated' : 'hover:bg-aide-surface-elevated'
                   }`}
+                  onContextMenu={(e) => handleContextMenu(e, ws.id)}
                 >
                   {/* Chevron toggle */}
                   <button
@@ -173,7 +221,25 @@ export function WorkspaceNav() {
                     >
                       {ws.name[0]?.toUpperCase() ?? '?'}
                     </span>
-                    <span className="text-xs font-mono text-aide-text-primary truncate flex-1">{ws.name}</span>
+                    <div className="flex flex-col flex-1 min-w-0">
+                      {editingWorkspaceId === ws.id ? (
+                        <input
+                          autoFocus
+                          value={editingName}
+                          onChange={(e) => setEditingName(e.target.value)}
+                          onBlur={() => handleCommitRename(ws.id)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') handleCommitRename(ws.id);
+                            if (e.key === 'Escape') handleCancelRename();
+                          }}
+                          onClick={(e) => e.stopPropagation()}
+                          className="text-xs font-mono text-aide-text-primary bg-aide-surface-elevated border border-aide-border rounded px-1 outline-none"
+                        />
+                      ) : (
+                        <span className="text-xs font-mono text-aide-text-primary truncate">{ws.name}</span>
+                      )}
+                      <span className="text-[10px] font-mono text-aide-text-tertiary truncate">{ws.path}</span>
+                    </div>
                     {/* Tab count */}
                     <span className="text-[10px] font-mono text-aide-text-tertiary shrink-0">
                       ({wsTabs.length})
@@ -200,17 +266,15 @@ export function WorkspaceNav() {
                     <AgentDropdown onClose={() => setDropdownWorkspaceId(null)} />
                   )}
 
-                  {/* Delete workspace button — only shown when multiple workspaces exist */}
-                  {workspaces.length > 1 && (
-                    <button
-                      onClick={(e) => { e.stopPropagation(); setDeleteConfirmId(ws.id); }}
-                      title="Delete workspace"
-                      className="opacity-0 group-hover:opacity-100 text-aide-text-tertiary hover:text-red-400 shrink-0 flex items-center justify-center transition-opacity"
-                      style={{ fontSize: '12px', width: '14px', height: '14px' }}
-                    >
-                      ×
-                    </button>
-                  )}
+                  {/* Context menu button */}
+                  <button
+                    onClick={(e) => { e.stopPropagation(); handleContextMenu(e, ws.id); }}
+                    title="More options"
+                    className="opacity-0 group-hover:opacity-100 text-aide-text-tertiary hover:text-aide-text-primary shrink-0 flex items-center justify-center transition-opacity"
+                    style={{ fontSize: '12px', width: '14px', height: '14px' }}
+                  >
+                    ···
+                  </button>
                 </div>
 
                 {/* Agent entries */}
@@ -255,6 +319,36 @@ export function WorkspaceNav() {
             <span>New Workspace</span>
           </button>
         </div>
+
+        {/* Context menu */}
+        {contextMenuId && (
+          <div
+            ref={contextMenuRef}
+            className="fixed z-50 bg-aide-surface-elevated border border-aide-border rounded shadow-lg py-1 min-w-[160px]"
+            style={{ left: contextMenuPos.x, top: contextMenuPos.y }}
+          >
+            <button
+              onClick={() => { const ws = workspaces.find((w) => w.id === contextMenuId); if (ws) handleStartRename(ws); }}
+              className="flex items-center w-full px-3 py-2 text-xs font-mono text-aide-text-primary hover:bg-aide-surface-sidebar transition-colors"
+            >
+              Rename
+            </button>
+            <button
+              onClick={() => { const ws = workspaces.find((w) => w.id === contextMenuId); if (ws) handleShowInFinder(ws.path); }}
+              className="flex items-center w-full px-3 py-2 text-xs font-mono text-aide-text-primary hover:bg-aide-surface-sidebar transition-colors"
+            >
+              Show in Finder
+            </button>
+            <hr className="border-aide-border my-1" />
+            <button
+              onClick={() => { const id = contextMenuId; setContextMenuId(null); if (workspaces.length > 1) setDeleteConfirmId(id); }}
+              disabled={workspaces.length <= 1}
+              className="flex items-center w-full px-3 py-2 text-xs font-mono text-red-400 hover:bg-aide-surface-sidebar transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              Remove from Workspace
+            </button>
+          </div>
+        )}
 
         {/* Delete workspace confirmation dialog */}
         {deleteConfirmId && (

--- a/src/renderer/stores/workspace-store.ts
+++ b/src/renderer/stores/workspace-store.ts
@@ -17,6 +17,7 @@ interface WorkspaceState {
   selectedFilePath: string | null;
   addWorkspace: (workspace: WorkspaceInfo) => void;
   removeWorkspace: (id: string) => void;
+  renameWorkspace: (id: string, name: string) => void;
   setActive: (id: string | null) => void;
   toggleNav: () => void;
   setSidePanelTab: (tab: SidePanelTab) => void;
@@ -38,6 +39,10 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     set((state) => ({ workspaces: [...state.workspaces, workspace] })),
   removeWorkspace: (id) =>
     set((state) => ({ workspaces: state.workspaces.filter((w) => w.id !== id) })),
+  renameWorkspace: (id, name) =>
+    set((state) => ({
+      workspaces: state.workspaces.map((w) => (w.id === id ? { ...w, name } : w)),
+    })),
   setActive: async (id) => {
     const prevId = get().activeWorkspaceId;
     if (id && id !== prevId) {

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -266,6 +266,8 @@ export interface AideAPI {
     recent(): Promise<WorkspaceInfo[]>;
     openDialog(): Promise<string | null>;
     createProject(name: string): Promise<WorkspaceInfo | null>;
+    rename(id: string, name: string): Promise<WorkspaceInfo | null>;
+    showInFinder(path: string): Promise<void>;
   };
   agent: {
     detect(): Promise<AgentConfig[]>;


### PR DESCRIPTION
## Summary

- Right-click or `···` button on workspace row opens context menu (Rename → Show in Finder → Remove from Workspace)
- **Inline rename**: clicking Rename switches the name to an `<input>`, saved on Enter/blur, cancelled on Esc
- **Path display**: workspace path always shown below the name in the sidebar
- **Show in Finder**: opens the workspace directory via `shell.showItemInFolder()`
- IPC: added `WORKSPACE_RENAME` and `WORKSPACE_SHOW_IN_FINDER` channels with main-process handlers
- `design.pen`: added Rename (`cm1`) item to ContextMenu frame (AhO8e) at top position

Closes #35

## Test plan

- [ ] Right-click on a workspace row → context menu appears at cursor
- [ ] `···` button (hover) → same context menu
- [ ] Rename → name becomes input; Enter saves, Esc cancels, blur saves
- [ ] Rename persists after switching workspaces and reloading
- [ ] Path text visible below workspace name at all times
- [ ] Show in Finder → Finder opens to workspace directory
- [ ] Remove from Workspace → existing delete confirmation dialog
- [ ] `pnpm test` passes (114/114)

🤖 Generated with [Claude Code](https://claude.com/claude-code)