### PR TITLE
feat: in-place auto-update + UpdateNotice to sidebar bottom

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,9 @@ jobs:
       - name: Build DMG
         run: sh ./build.sh
 
-      - name: Upload DMG to release
+      - name: Upload assets to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${{ github.event.release.tag_name }}" out/AIDE.dmg --clobber
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" out/AIDE.dmg --clobber
+          gh release upload "${{ github.event.release.tag_name }}" out/AIDE.app.zip --clobber

--- a/build.sh
+++ b/build.sh
@@ -104,6 +104,13 @@ echo "  Converting to compressed DMG..."
 hdiutil convert "$DMG_TMP_PATH" -format UDZO -o "$DMG_PATH"
 rm -f "$DMG_TMP_PATH"
 
+# Create .app.zip for in-place auto-update
+echo "[+] Creating app.zip for auto-update..."
+ZIP_PATH="out/AIDE.app.zip"
+rm -f "$ZIP_PATH"
+ditto -c -k --keepParent "$APP_PATH" "$ZIP_PATH"
+
 echo ""
 echo "Build complete!"
 echo "Output: $DMG_PATH"
+echo "        $ZIP_PATH"

--- a/src/main/ipc/channels.ts
+++ b/src/main/ipc/channels.ts
@@ -61,6 +61,7 @@ export const IPC_CHANNELS = {
   // Updater
   UPDATER_CHECK: 'updater:check',
   UPDATER_DOWNLOAD: 'updater:download',
+  UPDATER_INSTALL: 'updater:install',
   UPDATER_INFO_CHANGED: 'updater:info-changed',
   UPDATER_GET_INFO: 'updater:get-info',
 

--- a/src/main/ipc/updater-handlers.ts
+++ b/src/main/ipc/updater-handlers.ts
@@ -1,5 +1,5 @@
 import type { IpcMain } from 'electron';
-import { checkForUpdate, getCachedUpdateInfo, downloadUpdate } from '../updater/check';
+import { checkForUpdate, getCachedUpdateInfo, downloadUpdate, installUpdate } from '../updater/check';
 import { IPC_CHANNELS } from './channels';
 
 export function registerUpdaterHandlers(ipcMain: IpcMain): void {
@@ -8,4 +8,6 @@ export function registerUpdaterHandlers(ipcMain: IpcMain): void {
   ipcMain.handle(IPC_CHANNELS.UPDATER_GET_INFO, () => getCachedUpdateInfo());
 
   ipcMain.handle(IPC_CHANNELS.UPDATER_DOWNLOAD, () => downloadUpdate());
+
+  ipcMain.handle(IPC_CHANNELS.UPDATER_INSTALL, () => installUpdate());
 }

--- a/src/main/updater/check.ts
+++ b/src/main/updater/check.ts
@@ -8,7 +8,9 @@
  */
 import { app, BrowserWindow, net, shell } from 'electron';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
+import { execFile, spawn } from 'child_process';
 import { IPC_CHANNELS } from '../ipc/channels';
 import { getHome } from '../utils/home';
 
@@ -26,6 +28,8 @@ export interface UpdateInfo {
   hasUpdate: boolean;
   /** Download URL of the macOS DMG asset, if present */
   downloadUrl: string | null;
+  /** Download URL of the .app.zip asset for in-place auto-install, if present */
+  zipDownloadUrl: string | null;
   /** Human-readable release name */
   releaseName: string | null;
   /** Web URL of the release page (fallback for non-DMG platforms) */
@@ -99,12 +103,14 @@ export async function checkForUpdate(): Promise<UpdateInfo | null> {
     const latestTag = release.tag_name;
     const currentVersion = app.getVersion();
     const dmgAsset = release.assets.find((a) => a.name.endsWith('.dmg'));
+    const zipAsset = release.assets.find((a) => a.name.endsWith('.app.zip'));
 
     cachedInfo = {
       latestTag,
       currentVersion,
       hasUpdate: isNewer(latestTag, currentVersion),
       downloadUrl: dmgAsset?.browser_download_url ?? null,
+      zipDownloadUrl: zipAsset?.browser_download_url ?? null,
       releaseName: release.name,
       htmlUrl: release.html_url,
     };
@@ -161,6 +167,82 @@ export async function downloadUpdate(): Promise<{ ok: boolean; path?: string; er
     return { ok: false, error: (err as Error).message };
   } finally {
     downloading = false;
+  }
+}
+
+/**
+ * Download .app.zip, extract it, spawn a detached shell script that waits for
+ * the app to quit then replaces the .app bundle and relaunches.
+ * Falls back to downloadUpdate() if no zip asset is present.
+ */
+export async function installUpdate(): Promise<{ ok: boolean; error?: string }> {
+  if (!app.isPackaged) {
+    return { ok: false, error: 'Auto-install only available in packaged app' };
+  }
+  if (!cachedInfo?.zipDownloadUrl) {
+    // No zip asset — fall back to the DMG download path
+    return downloadUpdate();
+  }
+  if (downloading) return { ok: false, error: 'Already downloading' };
+  downloading = true;
+
+  try {
+    // 1. Download .app.zip to a temp directory
+    const tmpDir = path.join(os.tmpdir(), `aide-update-${Date.now()}`);
+    fs.mkdirSync(tmpDir, { recursive: true });
+    const zipPath = path.join(tmpDir, 'AIDE.app.zip');
+
+    const response = await net.fetch(cachedInfo.zipDownloadUrl);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const buffer = Buffer.from(await response.arrayBuffer());
+    fs.writeFileSync(zipPath, buffer);
+
+    // 2. Extract using ditto (preserves .app structure, symlinks, resource forks)
+    await new Promise<void>((resolve, reject) => {
+      execFile('ditto', ['-x', '-k', zipPath, tmpDir], (err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+
+    const newAppPath = path.join(tmpDir, 'AIDE.app');
+    if (!fs.existsSync(newAppPath)) {
+      throw new Error('AIDE.app not found in zip');
+    }
+
+    // 3. Determine current .app bundle path from the executable path
+    const exePath = app.getPath('exe');
+    const appPath = exePath.replace(/\.app\/Contents\/.*$/, '.app');
+
+    // 4. Write the update shell script
+    const scriptPath = path.join(tmpDir, 'update.sh');
+    const script = [
+      '#!/bin/bash',
+      'sleep 3',
+      // Remove quarantine so macOS Gatekeeper doesn't block the replaced app
+      `xattr -rd com.apple.quarantine "${newAppPath}" 2>/dev/null || true`,
+      // Try direct replacement first; escalate to admin dialog if needed
+      `if rm -rf "${appPath}" 2>/dev/null && cp -R "${newAppPath}" "${appPath}" 2>/dev/null; then`,
+      '  echo "Replaced directly"',
+      'else',
+      `  osascript -e "do shell script \\"rm -rf '${appPath}' && cp -R '${newAppPath}' '${appPath}'\\" with administrator privileges" 2>/dev/null`,
+      'fi',
+      // Clean up temp directory and relaunch
+      `rm -rf "${tmpDir}"`,
+      `open "${appPath}"`,
+    ].join('\n');
+
+    fs.writeFileSync(scriptPath, script, { mode: 0o755 });
+
+    // 5. Spawn the script detached so it outlives the app process
+    spawn('bash', [scriptPath], { detached: true, stdio: 'ignore' }).unref();
+
+    // 6. Quit — the script will relaunch the updated app after 3 s
+    app.quit();
+    return { ok: true };
+  } catch (err) {
+    downloading = false;
+    return { ok: false, error: (err as Error).message };
   }
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -194,6 +194,8 @@ const aideAPI: AideAPI = {
       ipcRenderer.invoke(IPC_CHANNELS.UPDATER_GET_INFO),
     download: (): Promise<{ ok: boolean; path?: string; error?: string }> =>
       ipcRenderer.invoke(IPC_CHANNELS.UPDATER_DOWNLOAD),
+    install: (): Promise<{ ok: boolean; error?: string }> =>
+      ipcRenderer.invoke(IPC_CHANNELS.UPDATER_INSTALL),
     onChanged: (callback: (info: UpdateInfo | null) => void) => {
       const listener = (_event: Electron.IpcRendererEvent, info: UpdateInfo | null) =>
         callback(info);

--- a/src/renderer/components/updater/UpdateNotice.tsx
+++ b/src/renderer/components/updater/UpdateNotice.tsx
@@ -24,7 +24,6 @@ export function UpdateNotice({ collapsed = false }: Props) {
     try {
       if (canAutoInstall) {
         await window.aide.updater.install();
-        // App will quit and relaunch — no need to reset state
       } else {
         await window.aide.updater.download();
         setDownloading(false);
@@ -34,43 +33,53 @@ export function UpdateNotice({ collapsed = false }: Props) {
     }
   };
 
-  const label = downloading
-    ? canAutoInstall ? 'Installing...' : 'Downloading...'
-    : canAutoInstall ? 'Install & Restart' : 'Download';
-
   if (collapsed) {
     return (
-      <div className="update-notice-enter flex items-center justify-center w-12 h-12 border-t border-aide-border">
+      <div className="shrink-0 flex items-center justify-center w-full border-t border-aide-border pt-2">
         <button
           onClick={handleAction}
           disabled={downloading}
           title={`${canAutoInstall ? 'Install update' : 'Download update'} — ${info.latestTag}`}
-          className="w-7 h-7 rounded flex items-center justify-center bg-aide-accent text-aide-terminal-bg hover:opacity-85 transition-opacity disabled:opacity-50"
+          className="w-7 h-7 rounded-[6px] flex items-center justify-center bg-aide-accent text-aide-terminal-bg hover:opacity-85 transition-opacity disabled:opacity-50 text-[11px]"
         >
-          ⬇
+          ↑
         </button>
       </div>
     );
   }
 
+  const currentLabel = `v${info.currentVersion}`;
+  const nextLabel = info.latestTag.startsWith('v') ? info.latestTag : `v${info.latestTag}`;
+  const actionLabel = downloading
+    ? canAutoInstall ? 'Installing…' : 'Downloading…'
+    : canAutoInstall ? 'Install & Restart' : 'Download';
+
   return (
-    <div className="update-notice-enter flex items-center gap-2.5 px-3 py-3 border-t border-aide-border bg-aide-surface-sidebar">
-      <div className="flex flex-col flex-1 min-w-0 gap-0.5">
-        <span className="text-[9px] font-mono font-semibold uppercase tracking-wider text-aide-accent">
-          ⬆ Update available
-        </span>
-        <span className="text-[13px] font-mono font-bold text-aide-text-primary truncate">
-          {info.latestTag}
-        </span>
+    <div className="shrink-0 border-t border-aide-border bg-aide-surface-sidebar">
+      <div className="px-3 pt-2.5 pb-3 flex flex-col gap-2">
+        {/* Header row */}
+        <div className="flex items-center gap-1.5">
+          <span className="text-[9px] font-mono font-semibold uppercase tracking-wider text-aide-accent leading-none">
+            ↑ Update available
+          </span>
+        </div>
+
+        {/* Version transition */}
+        <div className="flex items-center gap-1.5">
+          <span className="text-[11px] font-mono text-aide-text-tertiary">{currentLabel}</span>
+          <span className="text-[10px] text-aide-text-tertiary">→</span>
+          <span className="text-[11px] font-mono font-bold text-aide-text-primary">{nextLabel}</span>
+        </div>
+
+        {/* Action button */}
+        <button
+          onClick={handleAction}
+          disabled={downloading}
+          className="w-full h-7 rounded flex items-center justify-center bg-aide-accent text-aide-terminal-bg text-[11px] font-bold font-mono hover:opacity-85 transition-opacity disabled:opacity-60 whitespace-nowrap"
+        >
+          {actionLabel}
+        </button>
       </div>
-      <button
-        onClick={handleAction}
-        disabled={downloading}
-        title={`${label} — ${info.latestTag}`}
-        className="shrink-0 px-2 h-7 rounded flex items-center justify-center bg-aide-accent text-aide-terminal-bg text-[10px] font-bold font-mono hover:opacity-85 transition-opacity disabled:opacity-50 whitespace-nowrap"
-      >
-        {downloading ? '...' : '⬇'}
-      </button>
     </div>
   );
 }

--- a/src/renderer/components/updater/UpdateNotice.tsx
+++ b/src/renderer/components/updater/UpdateNotice.tsx
@@ -16,23 +16,35 @@ export function UpdateNotice({ collapsed = false }: Props) {
 
   if (!info?.hasUpdate) return null;
 
-  const handleDownload = async () => {
+  const canAutoInstall = !!info.zipDownloadUrl;
+
+  const handleAction = async () => {
     if (downloading) return;
     setDownloading(true);
     try {
-      await window.aide.updater.download();
-    } finally {
+      if (canAutoInstall) {
+        await window.aide.updater.install();
+        // App will quit and relaunch — no need to reset state
+      } else {
+        await window.aide.updater.download();
+        setDownloading(false);
+      }
+    } catch {
       setDownloading(false);
     }
   };
+
+  const label = downloading
+    ? canAutoInstall ? 'Installing...' : 'Downloading...'
+    : canAutoInstall ? 'Install & Restart' : 'Download';
 
   if (collapsed) {
     return (
       <div className="update-notice-enter flex items-center justify-center w-12 h-12 border-t border-aide-border">
         <button
-          onClick={handleDownload}
+          onClick={handleAction}
           disabled={downloading}
-          title={`Update available — ${info.latestTag}`}
+          title={`${canAutoInstall ? 'Install update' : 'Download update'} — ${info.latestTag}`}
           className="w-7 h-7 rounded flex items-center justify-center bg-aide-accent text-aide-terminal-bg hover:opacity-85 transition-opacity disabled:opacity-50"
         >
           ⬇
@@ -45,19 +57,19 @@ export function UpdateNotice({ collapsed = false }: Props) {
     <div className="update-notice-enter flex items-center gap-2.5 px-3 py-3 border-t border-aide-border bg-aide-surface-sidebar">
       <div className="flex flex-col flex-1 min-w-0 gap-0.5">
         <span className="text-[9px] font-mono font-semibold uppercase tracking-wider text-aide-accent">
-          ⬆ {downloading ? 'Downloading...' : 'Update available'}
+          ⬆ Update available
         </span>
         <span className="text-[13px] font-mono font-bold text-aide-text-primary truncate">
           {info.latestTag}
         </span>
       </div>
       <button
-        onClick={handleDownload}
+        onClick={handleAction}
         disabled={downloading}
-        title={`Download ${info.latestTag}`}
-        className="shrink-0 w-7 h-7 rounded flex items-center justify-center bg-aide-accent text-aide-terminal-bg text-[13px] font-bold hover:opacity-85 transition-opacity disabled:opacity-50"
+        title={`${label} — ${info.latestTag}`}
+        className="shrink-0 px-2 h-7 rounded flex items-center justify-center bg-aide-accent text-aide-terminal-bg text-[10px] font-bold font-mono hover:opacity-85 transition-opacity disabled:opacity-50 whitespace-nowrap"
       >
-        ⬇
+        {downloading ? '...' : '⬇'}
       </button>
     </div>
   );

--- a/src/renderer/components/workspace/WorkspaceNav.tsx
+++ b/src/renderer/components/workspace/WorkspaceNav.tsx
@@ -183,8 +183,9 @@ export function WorkspaceNav() {
           </button>
         </div>
 
-        {/* Workspace list */}
-        <div className="flex-1 overflow-y-auto min-h-0 flex flex-col gap-0.5 px-1">
+        {/* Scrollable middle — workspace list + add button */}
+        <div className="flex-1 overflow-y-auto min-h-0">
+        <div className="flex flex-col gap-0.5 px-1">
           {workspaces.map((ws) => {
             const isActive = ws.id === activeWorkspaceId;
             const status = getWorkspaceStatus(ws.id);
@@ -307,8 +308,8 @@ export function WorkspaceNav() {
           })}
         </div>
 
-        {/* Add button */}
-        <div className="px-2 py-2 shrink-0">
+        {/* Add button — inside scroll area, right below workspace list */}
+        <div className="px-2 py-2">
           <button
             onClick={handleAddWorkspace}
             className="flex items-center gap-2 w-full px-2 py-1.5 rounded text-xs font-mono text-aide-text-secondary hover:bg-aide-surface-elevated transition-colors"
@@ -317,7 +318,9 @@ export function WorkspaceNav() {
             <span>New Workspace</span>
           </button>
         </div>
+        </div>{/* end scrollable middle */}
 
+        {/* Update section — fixed at sidebar bottom */}
         <UpdateNotice />
 
         {/* Context menu */}

--- a/src/renderer/components/workspace/WorkspaceNav.tsx
+++ b/src/renderer/components/workspace/WorkspaceNav.tsx
@@ -168,8 +168,8 @@ export function WorkspaceNav() {
   if (navExpanded) {
     return (
       <div
-        className="flex flex-col bg-aide-surface-sidebar border-r border-aide-border shrink-0 overflow-y-auto"
-        style={{ width: '220px' }}
+        className="flex flex-col bg-aide-surface-sidebar border-r border-aide-border shrink-0 min-h-0"
+        style={{ width: '220px', height: '100%' }}
       >
         {/* Header */}
         <div className="flex items-center justify-between px-3 py-2 shrink-0">
@@ -184,7 +184,7 @@ export function WorkspaceNav() {
         </div>
 
         {/* Workspace list */}
-        <div className="flex flex-col gap-0.5 px-1">
+        <div className="flex-1 overflow-y-auto min-h-0 flex flex-col gap-0.5 px-1">
           {workspaces.map((ws) => {
             const isActive = ws.id === activeWorkspaceId;
             const status = getWorkspaceStatus(ws.id);
@@ -307,10 +307,8 @@ export function WorkspaceNav() {
           })}
         </div>
 
-        <UpdateNotice />
-
         {/* Add button */}
-        <div className="px-2 mt-2">
+        <div className="px-2 py-2 shrink-0">
           <button
             onClick={handleAddWorkspace}
             className="flex items-center gap-2 w-full px-2 py-1.5 rounded text-xs font-mono text-aide-text-secondary hover:bg-aide-surface-elevated transition-colors"
@@ -319,6 +317,8 @@ export function WorkspaceNav() {
             <span>New Workspace</span>
           </button>
         </div>
+
+        <UpdateNotice />
 
         {/* Context menu */}
         {contextMenuId && (
@@ -381,7 +381,7 @@ export function WorkspaceNav() {
   return (
     <div
       className="flex flex-col items-center py-2 gap-2 bg-aide-surface-sidebar border-r border-aide-border shrink-0"
-      style={{ width: '48px' }}
+      style={{ width: '48px', height: '100%' }}
     >
       {/* Expand toggle */}
       <button
@@ -419,7 +419,7 @@ export function WorkspaceNav() {
 
       <div className="w-6 border-t border-aide-border my-1" />
 
-      <UpdateNotice collapsed />
+      <div className="flex-1" />
 
       <button
         onClick={handleAddWorkspace}
@@ -428,6 +428,8 @@ export function WorkspaceNav() {
       >
         +
       </button>
+
+      <UpdateNotice collapsed />
     </div>
   );
 }

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -226,6 +226,8 @@ export interface UpdateInfo {
   hasUpdate: boolean;
   /** Download URL of the macOS DMG asset, if present */
   downloadUrl: string | null;
+  /** Download URL of the .app.zip asset for in-place auto-install, if present */
+  zipDownloadUrl: string | null;
   /** Human-readable release name */
   releaseName: string | null;
   /** Web URL of the release page (fallback for non-DMG platforms) */
@@ -314,6 +316,7 @@ export interface AideAPI {
     check(): Promise<UpdateInfo | null>;
     getInfo(): Promise<UpdateInfo | null>;
     download(): Promise<{ ok: boolean; path?: string; error?: string }>;
+    install(): Promise<{ ok: boolean; error?: string }>;
     onChanged(callback: (info: UpdateInfo | null) => void): () => void;
   };
 }


### PR DESCRIPTION
## Summary

- **인플레이스 자동 업데이트** — 코드 서명 없이 `.app.zip` 기반 교체 방식 (Method 2)
- **UpdateNotice 위치** — 워크스페이스 리스트 아래가 아닌 사이드바 하단으로 이동

## 자동 업데이트 동작 방식

```
릴리즈 publish
  → build.sh가 AIDE.dmg + AIDE.app.zip 생성 (ditto)
  → 앱 시작 시 GitHub Releases API 폴링
  → zipDownloadUrl 감지 → UpdateNotice에 "Install & Restart" 표시
  → 클릭 → zip 다운로드 → ditto 압축 해제
  → update.sh 스크립트 (detached spawn)
      sleep 3 → quarantine 제거 → .app 교체 → open 재실행
  → app.quit() → 3초 후 새 버전으로 재시작
```

**어드민 권한** — `/Applications` 쓰기 실패 시 `osascript`로 자동 권한 다이얼로그 표시

**폴백** — `.app.zip` 없으면 기존 DMG 다운로드 → Finder에서 수동 설치

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `build.sh` | DMG 빌드 후 `ditto`로 `.app.zip` 생성 |
| `.github/workflows/release.yml` | `AIDE.app.zip` 릴리즈 업로드 추가 |
| `src/main/updater/check.ts` | `zipDownloadUrl` 감지 + `installUpdate()` 구현 |
| `src/main/ipc/channels.ts` | `UPDATER_INSTALL` 채널 추가 |
| `src/main/ipc/updater-handlers.ts` | install 핸들러 등록 |
| `src/preload/index.ts` | `install()` API 노출 |
| `src/types/ipc.ts` | `zipDownloadUrl`, `install()` 타입 추가 |
| `UpdateNotice.tsx` | zip 있으면 "Install & Restart", 없으면 "Download" |
| `WorkspaceNav.tsx` | UpdateNotice 하단 고정, 워크스페이스 목록 독립 스크롤 |

## Test plan

- [ ] `pnpm test` 114/114 통과
- [ ] 사이드바 하단에 UpdateNotice 위치 확인 (업데이트 있을 때)
- [ ] 다음 릴리즈 publish 시 `AIDE.app.zip` 자동 첨부 확인
- [ ] `zipDownloadUrl` 있을 때 "Install & Restart" 버튼 표시 확인
- [ ] 설치 후 3초 뒤 새 버전으로 앱 재시작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)