### PR TITLE
fix: lazy-load file tree children to prevent IPC hang on large projects

### DIFF
--- a/src/main/ipc/fs-handlers.ts
+++ b/src/main/ipc/fs-handlers.ts
@@ -5,11 +5,12 @@ import chokidar from 'chokidar';
 import { IPC_CHANNELS } from './channels';
 import type { FileTreeNode } from '../../types/ipc';
 
-const MAX_DEPTH = 10;
+// Directories that are never useful to browse in a file tree
+const IGNORED_DIRS = new Set(['.git', 'node_modules', '.aide']);
 
-function readTree(dirPath: string, depth = 0): FileTreeNode[] {
-  if (depth >= MAX_DEPTH) return [];
-
+/** Returns immediate children only — no recursion. Directories have no children
+ *  populated; the renderer fetches them lazily on expand. */
+function readTree(dirPath: string): FileTreeNode[] {
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(dirPath, { withFileTypes: true });
@@ -19,20 +20,12 @@ function readTree(dirPath: string, depth = 0): FileTreeNode[] {
 
   const nodes: FileTreeNode[] = [];
   for (const entry of entries) {
+    if (entry.isDirectory() && IGNORED_DIRS.has(entry.name)) continue;
     const fullPath = path.join(dirPath, entry.name);
     if (entry.isDirectory()) {
-      nodes.push({
-        name: entry.name,
-        path: fullPath,
-        type: 'directory',
-        children: readTree(fullPath, depth + 1),
-      });
+      nodes.push({ name: entry.name, path: fullPath, type: 'directory' });
     } else {
-      nodes.push({
-        name: entry.name,
-        path: fullPath,
-        type: 'file',
-      });
+      nodes.push({ name: entry.name, path: fullPath, type: 'file' });
     }
   }
   return nodes;

--- a/src/renderer/components/file-explorer/FileExplorer.tsx
+++ b/src/renderer/components/file-explorer/FileExplorer.tsx
@@ -15,21 +15,34 @@ interface TreeNodeProps {
 
 function TreeNode({ node, depth, selectedPath, onSelect, revealPath, nodeRefs }: TreeNodeProps) {
   const [expanded, setExpanded] = useState(false);
+  const [children, setChildren] = useState<FileTreeNode[] | null>(null); // null = not yet loaded
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (ref.current) {
-      nodeRefs.current.set(node.path, ref.current);
-    }
+    if (ref.current) nodeRefs.current.set(node.path, ref.current);
     return () => { nodeRefs.current.delete(node.path); };
   }, [node.path, nodeRefs]);
 
-  // Auto-expand ancestor when a child is being revealed
+  // Auto-expand ancestor directories when a child path is being revealed
   useEffect(() => {
     if (revealPath && node.type === 'directory' && revealPath.startsWith(node.path + '/')) {
       setExpanded(true);
     }
   }, [revealPath, node.path, node.type]);
+
+  // Lazy-load children when a directory is expanded for the first time
+  useEffect(() => {
+    if (!expanded || node.type !== 'directory' || children !== null) return;
+    window.aide.fs.readTree(node.path)
+      .then((nodes) => {
+        const sorted = [...nodes].sort((a, b) => {
+          if (a.type !== b.type) return a.type === 'directory' ? -1 : 1;
+          return a.name.localeCompare(b.name);
+        });
+        setChildren(sorted);
+      })
+      .catch(() => setChildren([]));
+  }, [expanded, children, node.path, node.type]);
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -53,13 +66,6 @@ function TreeNode({ node, depth, selectedPath, onSelect, revealPath, nodeRefs }:
   const isSelected = selectedPath === node.path;
 
   if (node.type === 'directory') {
-    const sortedChildren = node.children
-      ? [...node.children].sort((a, b) => {
-          if (a.type !== b.type) return a.type === 'directory' ? -1 : 1;
-          return a.name.localeCompare(b.name);
-        })
-      : [];
-
     return (
       <div>
         <div
@@ -74,7 +80,7 @@ function TreeNode({ node, depth, selectedPath, onSelect, revealPath, nodeRefs }:
           </span>
           <span className="truncate">{node.name}</span>
         </div>
-        {expanded && sortedChildren.map((child) => (
+        {expanded && (children ?? []).map((child) => (
           <TreeNode
             key={child.path}
             node={child}
@@ -154,7 +160,6 @@ export function FileExplorer({ cwd }: FileExplorerProps) {
     const unsubReveal = window.aide.files.onReveal((filePath) => {
       setRevealPath(filePath);
       handleFileSelect(filePath);
-      // Scroll into view after tree re-renders with expanded state
       requestAnimationFrame(() => {
         nodeRefs.current.get(filePath)?.scrollIntoView({ block: 'nearest' });
       });


### PR DESCRIPTION
## Summary
- 파일 트리가 패키지 앱(DMG)에서 표시되지 않는 버그 수정
- 기존 10레벨 재귀 동기 탐색 → 즉각 자식만 로드 후 확장 시 lazy-load로 변경
- `node_modules`, `.git` 등 대형 디렉토리로 인한 IPC 블로킹 방지

## Root Cause
`fs-handlers.ts`의 `readTree()`가 MAX_DEPTH=10으로 동기 재귀 탐색을 수행, 대형 프로젝트에서 IPC 채널이 응답 없이 멈추는 현상 발생.

## Fix
- `readTree()`: 즉각 자식(depth 0)만 반환, 무시 디렉토리 필터(`.git`, `node_modules`, `.aide`) 적용
- `FileExplorer.tsx`: `TreeNode`에 lazy-load 추가 — 디렉토리 확장 시 IPC로 자식 노드 요청

## Test plan
- [ ] `pnpm start`로 대형 프로젝트 열기 → 파일 트리 즉시 표시 확인
- [ ] 디렉토리 클릭 → 자식 노드 lazy-load 확인
- [ ] `node_modules` 포함 프로젝트에서 IPC hang 없음 확인
- [ ] `pnpm test` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)