### PR TITLE
chore: bump version to 0.0.4

### DIFF
--- a/docs/wiki/file-tree-lazy-load-hotfix.md
+++ b/docs/wiki/file-tree-lazy-load-hotfix.md
@@ -1,0 +1,35 @@
+---
+title: File Tree Lazy-Load Hotfix (v0.0.4)
+category: session-log
+tags: [hotfix, file-tree, ipc, performance, v0.0.4]
+created: 2026-04-15
+---
+
+# File Tree Lazy-Load Hotfix (v0.0.4)
+
+## Problem
+
+패키지 앱(DMG)에서 파일 트리가 표시되지 않는 현상.
+`pnpm start` 개발 모드에서는 정상 동작하나 배포 버전에서는 파일 탐색기가 빈 상태.
+
+## Root Cause
+
+`src/main/ipc/fs-handlers.ts`의 `readTree()` 함수가 MAX_DEPTH=10으로 동기 재귀 탐색을 수행.
+`node_modules`, `.git` 등 수천 개의 파일이 있는 디렉토리에서 IPC 채널이 응답 없이 블로킹됨.
+개발 모드에서는 타임아웃 허용치가 높아 증상이 숨겨졌으나 패키징 후 명확히 드러남.
+
+## Fix
+
+### `src/main/ipc/fs-handlers.ts`
+- `readTree()`를 비재귀로 변경 — 즉각 자식(depth 0)만 반환
+- `IGNORED_DIRS` 필터 추가: `.git`, `node_modules`, `.aide`
+
+### `src/renderer/components/file-explorer/FileExplorer.tsx`
+- `TreeNode`에 lazy-load 추가
+- `children` 상태를 `null`(미로드)로 초기화
+- 디렉토리 확장 시 `window.aide.fs.readTree(node.path)` IPC 호출로 자식 로드
+
+## PRs
+
+- **#44**: hotfix/file-tree-lazy-load → main
+- **#45**: hotfix/file-tree-lazy-load → develop

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aide",
   "productName": "AIDE",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "AI-Driven IDE - Create n Play plugins with natural language",
   "main": ".vite/build/index.js",
   "private": true,

--- a/src/main/ipc/fs-handlers.ts
+++ b/src/main/ipc/fs-handlers.ts
@@ -5,11 +5,12 @@ import chokidar from 'chokidar';
 import { IPC_CHANNELS } from './channels';
 import type { FileTreeNode } from '../../types/ipc';
 
-const MAX_DEPTH = 10;
+// Directories that are never useful to browse in a file tree
+const IGNORED_DIRS = new Set(['.git', 'node_modules', '.aide']);
 
-function readTree(dirPath: string, depth = 0): FileTreeNode[] {
-  if (depth >= MAX_DEPTH) return [];
-
+/** Returns immediate children only — no recursion. Directories have no children
+ *  populated; the renderer fetches them lazily on expand. */
+function readTree(dirPath: string): FileTreeNode[] {
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(dirPath, { withFileTypes: true });
@@ -19,20 +20,12 @@ function readTree(dirPath: string, depth = 0): FileTreeNode[] {
 
   const nodes: FileTreeNode[] = [];
   for (const entry of entries) {
+    if (entry.isDirectory() && IGNORED_DIRS.has(entry.name)) continue;
     const fullPath = path.join(dirPath, entry.name);
     if (entry.isDirectory()) {
-      nodes.push({
-        name: entry.name,
-        path: fullPath,
-        type: 'directory',
-        children: readTree(fullPath, depth + 1),
-      });
+      nodes.push({ name: entry.name, path: fullPath, type: 'directory' });
     } else {
-      nodes.push({
-        name: entry.name,
-        path: fullPath,
-        type: 'file',
-      });
+      nodes.push({ name: entry.name, path: fullPath, type: 'file' });
     }
   }
   return nodes;

--- a/src/renderer/components/file-explorer/FileExplorer.tsx
+++ b/src/renderer/components/file-explorer/FileExplorer.tsx
@@ -15,21 +15,34 @@ interface TreeNodeProps {
 
 function TreeNode({ node, depth, selectedPath, onSelect, revealPath, nodeRefs }: TreeNodeProps) {
   const [expanded, setExpanded] = useState(false);
+  const [children, setChildren] = useState<FileTreeNode[] | null>(null); // null = not yet loaded
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (ref.current) {
-      nodeRefs.current.set(node.path, ref.current);
-    }
+    if (ref.current) nodeRefs.current.set(node.path, ref.current);
     return () => { nodeRefs.current.delete(node.path); };
   }, [node.path, nodeRefs]);
 
-  // Auto-expand ancestor when a child is being revealed
+  // Auto-expand ancestor directories when a child path is being revealed
   useEffect(() => {
     if (revealPath && node.type === 'directory' && revealPath.startsWith(node.path + '/')) {
       setExpanded(true);
     }
   }, [revealPath, node.path, node.type]);
+
+  // Lazy-load children when a directory is expanded for the first time
+  useEffect(() => {
+    if (!expanded || node.type !== 'directory' || children !== null) return;
+    window.aide.fs.readTree(node.path)
+      .then((nodes) => {
+        const sorted = [...nodes].sort((a, b) => {
+          if (a.type !== b.type) return a.type === 'directory' ? -1 : 1;
+          return a.name.localeCompare(b.name);
+        });
+        setChildren(sorted);
+      })
+      .catch(() => setChildren([]));
+  }, [expanded, children, node.path, node.type]);
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -53,13 +66,6 @@ function TreeNode({ node, depth, selectedPath, onSelect, revealPath, nodeRefs }:
   const isSelected = selectedPath === node.path;
 
   if (node.type === 'directory') {
-    const sortedChildren = node.children
-      ? [...node.children].sort((a, b) => {
-          if (a.type !== b.type) return a.type === 'directory' ? -1 : 1;
-          return a.name.localeCompare(b.name);
-        })
-      : [];
-
     return (
       <div>
         <div
@@ -74,7 +80,7 @@ function TreeNode({ node, depth, selectedPath, onSelect, revealPath, nodeRefs }:
           </span>
           <span className="truncate">{node.name}</span>
         </div>
-        {expanded && sortedChildren.map((child) => (
+        {expanded && (children ?? []).map((child) => (
           <TreeNode
             key={child.path}
             node={child}
@@ -154,7 +160,6 @@ export function FileExplorer({ cwd }: FileExplorerProps) {
     const unsubReveal = window.aide.files.onReveal((filePath) => {
       setRevealPath(filePath);
       handleFileSelect(filePath);
-      // Scroll into view after tree re-renders with expanded state
       requestAnimationFrame(() => {
         nodeRefs.current.get(filePath)?.scrollIntoView({ block: 'nearest' });
       });


### PR DESCRIPTION
## Summary
- v0.0.4 버전 bump
- 파일 트리 lazy-load 핫픽스(#44, #45) 포함 릴리즈 준비

## Changes
- `package.json`: version 0.0.3 → 0.0.4
- `docs/wiki/file-tree-lazy-load-hotfix.md`: 핫픽스 내용 문서화

## Related PRs
- Hotfix #44 (→ main), #45 (→ develop): 파일 트리 IPC 블로킹 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)