### PR TITLE
feat(plugin): persistent state, theme auto-inject, smart open

### DIFF
--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -6,3 +6,6 @@
 2026-04-15 [ingest] Created [[watcher-performance]] — chokidar watcher exclusion Stage 1 도입, Stage 2/3/Phase 2 로드맵
 2026-04-15 [ingest] Created [[main-process-cpu-home-watcher-bugfix]] — DMG idle CPU 127% 근본 원인(HOME watcher) 진단 및 workspace-scoped watcher로 해결
 2026-04-15 [update] Updated [[watcher-performance]] — HOME 감시 제거 섹션 추가, roadmap 표에 workspace-scoped watcher 완료 항목 반영
+2026-04-16 [ingest] Plugin theme auto-inject — protocol.ts AIDE_STYLE_SHIM 주입 + CREATE_PLUGIN_DESC Theme Support 섹션
+2026-04-16 [ingest] Plugin on/off state persistence — plugin-store 즉시 saveSession, restoreSession/loadPlugins await
+2026-04-16 [update] Partide 리브랜드 아이데이션 기록 [[rebrand-partide]] 작성 (PR #49)

--- a/src/main/mcp/server.js
+++ b/src/main/mcp/server.js
@@ -249,6 +249,13 @@ Available iframe APIs:
 window.aide shim:
 AIDE automatically injects the window.aide shim into all plugin iframes — both auto-generated and custom HTML. You do NOT need to include the shim manually in custom HTML.
 
+Theme sync API:
+  window.aide is automatically notified of theme changes via postMessage. Additionally you can listen:
+    window.addEventListener('message', (e) => {
+      if (e.data && e.data.theme) { /* e.data.theme === 'dark' | 'light' */ }
+    });
+  In most cases you don't need this — the CSS variables handle it.
+
 Events fire on every file click — eventBindings are NOT required for iframe postMessage:
   window.aide.on('file:clicked', function(data) { /* data.filePath — absolute path */ })
   window.aide.on('file:right-clicked', function(data) { /* data.filePath */ })
@@ -262,6 +269,24 @@ Invoking backend tools from iframe:
 
 eventBindings (.aide/settings.json): controls backend tool invocation on file events only — separate from iframe postMessage.
   Example: { "eventBindings": { "file:clicked": [{ "plugin": "my-plugin", "tool": "on-file-clicked", "args": {} }] } }
+
+Theme Support (REQUIRED):
+AIDE runs in both dark and light themes. Your plugin MUST work in both.
+
+CSS variables are AUTO-INJECTED into every plugin iframe by AIDE — you do NOT need to define :root, .light, or @media(prefers-color-scheme) blocks yourself. Just reference the variables:
+
+  background: var(--background);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  color: var(--accent);
+
+Runtime theme switching:
+AIDE sends postMessage({theme: 'dark'|'light'}) to the plugin iframe whenever the user toggles theme. The injected shim automatically updates document.documentElement.className, which triggers the .light class variables. Your CSS will re-render without any code on your side — provided you used var() references, not hardcoded colors.
+
+Detecting current theme from JS:
+  const isLight = document.documentElement.classList.contains('light');
+
+NEVER hardcode colors like #000, #fff, black, white, or any hex literal for UI surfaces. Always use the CSS variables below. Hardcoding will break one of the two themes.
 
 IMPORTANT — AIDE Design System Rules:
 If the plugin produces UI output (HTML/CSS), it MUST use these CSS custom properties (not hardcoded colors):
@@ -288,6 +313,7 @@ Style rules:
 - Spacing: 4px/8px/12px increments (Tailwind-compatible)
 - Never use hardcoded hex colors — always reference CSS variables
 - Element visibility: always set explicit display values (e.g. style.display = 'block', 'flex', 'grid') when showing hidden elements — never use style.display = '' because a CSS stylesheet display:none will persist
+- Dark/light parity: test both themes mentally before finalizing. If a color looks good on dark but unreadable on light (or vice versa), you've used the wrong variable. Example: buttons use var(--accent) for bg + #000 for text — this works because --accent differs per theme but black text stays readable on emerald in both.
 
 CDN Libraries (OFFLINE-CAPABLE):
 Plugins can load external libraries via the aide-cdn:// protocol, which caches files locally for offline use.

--- a/src/main/plugin/protocol.ts
+++ b/src/main/plugin/protocol.ts
@@ -72,6 +72,14 @@ export function registerCustomSchemes(): void {
 }
 
 /**
+ * Default theme CSS variables injected into every plugin iframe.
+ * Provides dark (default), .light class override, and prefers-color-scheme
+ * media query fallback. Plugins can override these with higher specificity
+ * if intentional custom theming is needed.
+ */
+const AIDE_STYLE_SHIM = `<style>:root{--background:#131519;--surface:#1A1C23;--surface-elevated:#24262E;--border:#2E3140;--text-primary:#E8E9ED;--text-secondary:#8B8D98;--text-tertiary:#5C5E6A;--accent:#10B981;--accent-warning:#F59E0B;--accent-info:#06B6D4;--scrollbar-thumb:rgba(255,255,255,0.08);--scrollbar-thumb-hover:rgba(255,255,255,0.16);--agent-claude:#D97706;--agent-gemini:#3B82F6;--agent-codex:#10B981}.light{--background:#F5F5F0;--surface:#FAFAF7;--surface-elevated:#EBEBE6;--border:#E0E3E8;--text-primary:#0D0D0D;--text-secondary:#6B7280;--text-tertiary:#9CA3AF;--accent:#059669;--scrollbar-thumb:rgba(0,0,0,0.12);--scrollbar-thumb-hover:rgba(0,0,0,0.22)}@media(prefers-color-scheme:light){:root:not(.dark){--background:#F5F5F0;--surface:#FAFAF7;--surface-elevated:#EBEBE6;--border:#E0E3E8;--text-primary:#0D0D0D;--text-secondary:#6B7280;--text-tertiary:#9CA3AF;--accent:#059669;--scrollbar-thumb:rgba(0,0,0,0.12);--scrollbar-thumb-hover:rgba(0,0,0,0.22)}}body{background:var(--background);color:var(--text-primary)}</style>`;
+
+/**
  * window.aide shim injected into every plugin iframe.
  * Provides on(), invoke(), emit(), and theme listener.
  * Injected by the protocol handler so ALL plugins get it automatically —
@@ -84,11 +92,13 @@ const AIDE_SHIM = `<script>window.aide=(function(){var _cid=0,_cbs={};window.add
  * If no </head> tag, prepend to the HTML.
  */
 function injectShim(html: string): string {
+  const injection = AIDE_STYLE_SHIM + AIDE_SHIM;
   const headClose = html.indexOf('</head>');
   if (headClose !== -1) {
-    return html.slice(0, headClose) + AIDE_SHIM + html.slice(headClose);
+    return html.slice(0, headClose) + injection + html.slice(headClose);
   }
-  return AIDE_SHIM + html;
+  // No </head> — prepend so style takes effect before body renders
+  return injection + html;
 }
 
 /**

--- a/src/renderer/components/plugin/PluginPanel.tsx
+++ b/src/renderer/components/plugin/PluginPanel.tsx
@@ -13,9 +13,6 @@ export function PluginPanel() {
     deletePlugin,
   } = usePluginStore();
 
-  const focusedPaneId = useLayoutStore((s) => s.focusedPaneId);
-  const addTabToPane = useLayoutStore((s) => s.addTabToPane);
-
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
 
   useEffect(() => {
@@ -24,15 +21,19 @@ export function PluginPanel() {
     return unsub;
   }, [loadPlugins]);
 
-  const handleOpenTab = (plugin: typeof plugins[number]) => {
-    const paneId = focusedPaneId ?? useLayoutStore.getState().focusedPaneId;
-    if (!paneId) return;
-    addTabToPane(paneId, {
-      id: `plugin-${plugin.id}-${Date.now()}`,
-      type: 'plugin',
-      pluginId: plugin.id,
-      title: plugin.name,
-    });
+  const handleOpenTab = async (plugin: typeof plugins[number]) => {
+    // Focus existing tab if already open
+    const allPanes = useLayoutStore.getState().getAllPanes();
+    const existing = allPanes
+      .flatMap((pane) => pane.tabs.map((tab) => ({ paneId: pane.id, tab })))
+      .find(({ tab }) => tab.type === 'plugin' && tab.pluginId === plugin.id);
+    if (existing) {
+      useLayoutStore.getState().setActiveTab(existing.paneId, existing.tab.id);
+      return;
+    }
+    // Smart Open: activate (also adds tab via plugin-store.activate) regardless of current state.
+    // activate() is idempotent on already-active plugins and skips tab creation if tab exists.
+    await activate(plugin.id);
   };
 
   const handleDeleteClick = (name: string) => {
@@ -91,7 +92,7 @@ export function PluginPanel() {
         <button
           onClick={() => handleOpenTab(plugin)}
           className="px-1.5 py-0.5 rounded text-[10px] font-mono text-aide-text-tertiary hover:text-aide-text-primary hover:bg-aide-surface-hover transition-colors"
-          title="Open as tab"
+          title="Open plugin (will activate if off)"
         >
           ↗
         </button>

--- a/src/renderer/stores/layout-store.ts
+++ b/src/renderer/stores/layout-store.ts
@@ -716,10 +716,10 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
     const restoredLayout = await rebuildNode(session.layout);
     set({ layout: restoredLayout, focusedPaneId: session.focusedPaneId });
 
-    // Restore active plugins
-    for (const pluginId of session.activePlugins) {
-      window.aide.plugin.activate(pluginId).catch(() => {});
-    }
+    // Restore active plugins — await so registry is settled before loadPlugins() runs
+    await Promise.allSettled(
+      session.activePlugins.map((pluginId) => window.aide.plugin.activate(pluginId))
+    );
 
     // Restore side panel tab
     useWorkspaceStore.getState().setSidePanelTab(session.sidePanelTab ?? 'files');

--- a/src/renderer/stores/plugin-store.ts
+++ b/src/renderer/stores/plugin-store.ts
@@ -58,6 +58,12 @@ export const usePluginStore = create<PluginState>((set, get) => ({
           }
         }
       }
+      // Persist plugin active state immediately — don't rely on beforeunload
+      const { useWorkspaceStore } = await import('./workspace-store');
+      const wsId = useWorkspaceStore.getState().activeWorkspaceId;
+      if (wsId) {
+        await useLayoutStore.getState().saveSession(wsId);
+      }
     } catch (e) {
       set({ error: e instanceof Error ? e.message : 'Failed to activate plugin' });
     }
@@ -77,6 +83,12 @@ export const usePluginStore = create<PluginState>((set, get) => ({
           layout.removeTabFromPane(pane.id, pluginTab.id);
           useTerminalStore.getState().removeTab(pluginTab.id);
         }
+      }
+      // Persist plugin active state immediately — don't rely on beforeunload
+      const { useWorkspaceStore } = await import('./workspace-store');
+      const wsId = useWorkspaceStore.getState().activeWorkspaceId;
+      if (wsId) {
+        await useLayoutStore.getState().saveSession(wsId);
       }
     } catch (e) {
       set({ error: e instanceof Error ? e.message : 'Failed to deactivate plugin' });

--- a/src/renderer/stores/workspace-store.ts
+++ b/src/renderer/stores/workspace-store.ts
@@ -79,7 +79,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       if (workspace) {
         await window.aide.workspace.open(workspace.path);
       }
-      usePluginStore.getState().loadPlugins();
+      await usePluginStore.getState().loadPlugins();
       invalidateSettingsCache();
     }
     set({ activeWorkspaceId: id });


### PR DESCRIPTION
## Summary

- Plugin on/off state now persists correctly across app restarts by saving session eagerly on activate/deactivate
- Plugin iframes automatically receive AIDE theme CSS variables via a style shim injected by the protocol handler
- The Open-as-tab button (↗) auto-activates inactive plugins and focuses existing tabs instead of duplicating them
- `restoreSession` now awaits all plugin activations before resolving, preventing IPC races on startup

## Changes

### Persistence
`plugin-store.ts`: `activate()` and `deactivate()` now call `saveSession()` immediately after state change instead of relying on `beforeunload`. `layout-store.ts`: `restoreSession` uses `await Promise.allSettled()` over all plugin activations. `workspace-store.ts`: `loadPlugins` is awaited before the store resolves.

### Theme Auto-Inject
`protocol.ts`: A new `AIDE_STYLE_SHIM` block is injected into every plugin iframe's `<head>` at serve time. It mirrors the host app's CSS variables (`--background`, `--text-primary`, etc.) and responds to both class-based and `prefers-color-scheme` theme switching — no plugin-side wiring required. `server.js`: `CREATE_PLUGIN_DESC` gained a Theme Support section so the model knows to use these variables.

### Smart Open
`PluginPanel.tsx`: `handleOpenTab` now checks all panes for an existing plugin tab and focuses it via `setActiveTab` if found. If no tab exists, it calls `activate(plugin.id)` which handles both enabling the plugin and adding the tab in one step. The broken-iframe state from opening an OFF plugin is eliminated. Button tooltip updated to reflect new behavior.

## Test plan

- [ ] Toggle a plugin OFF, click ↗ — plugin should activate and open as a tab
- [ ] Click ↗ on an already-open plugin tab — existing tab should receive focus, no duplicate tab created
- [ ] Restart the app with plugins in various on/off states — states should be restored correctly
- [ ] Open a plugin iframe and verify CSS variables resolve (background, text colors match host theme)
- [ ] Switch host theme (dark/light) and confirm plugin iframe updates accordingly
- [ ] `pnpm test` — 114 tests pass
- [ ] `pnpm lint` — no new errors

## Related

Follows on from PR #50 (pty crash fix on packaged build). Addresses the broken-iframe regression noted in that session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)