### PR TITLE
feat(plugin): remove global scope, eliminate .mcp.json from project root

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,5 @@
 import { app, BrowserWindow, ipcMain } from 'electron';
-import * as fs from 'fs';
+
 import { userInfo } from 'os';
 import path from 'path';
 import { fixPackagedEnv } from './fix-env';
@@ -77,16 +77,6 @@ const createWindow = (): void => {
 };
 
 app.on('ready', () => {
-  // Ensure global plugin directory exists on startup
-  try {
-    const home = (process.env.HOME && process.env.HOME !== '/') ? process.env.HOME : userInfo().homedir;
-    const globalPluginsDir = path.join(home, '.aide', 'plugins');
-    if (!fs.existsSync(globalPluginsDir)) {
-      fs.mkdirSync(globalPluginsDir, { recursive: true });
-    }
-  } catch (err) {
-    console.error('[AIDE] Plugin directory setup failed (non-fatal):', err);
-  }
   registerIpcHandlers();
   registerWorkspaceHandlers(ipcMain);
   const fallbackCwd = getHome();

--- a/src/main/ipc/plugin-handlers.ts
+++ b/src/main/ipc/plugin-handlers.ts
@@ -9,13 +9,8 @@ import type { PluginSpec } from '../plugin/spec-generator';
 import { generatePluginCode } from '../plugin/code-generator';
 import { PluginRegistry } from '../plugin/registry';
 import { getActiveWorkspacePath } from './workspace-handlers';
-import { getHome } from '../utils/home';
 
 const registry = new PluginRegistry();
-
-function getGlobalPluginsDir(): string {
-  return path.join(getHome(), '.aide', 'plugins');
-}
 
 function getLocalPluginsDir(cwd: string): string {
   return path.join(cwd, '.aide', 'plugins');
@@ -31,7 +26,7 @@ function readPluginSpec(pluginDir: string): PluginSpec | null {
   }
 }
 
-function loadDirIntoRegistry(dir: string, scope: 'local' | 'global'): void {
+function loadDirIntoRegistry(dir: string): void {
   if (!fs.existsSync(dir)) return;
   let entries: fs.Dirent[];
   try {
@@ -48,7 +43,7 @@ function loadDirIntoRegistry(dir: string, scope: 'local' | 'global'): void {
     const pluginDir = path.join(dir, entry.name);
     const spec = readPluginSpec(pluginDir);
     if (spec && !registry.get(spec.id)) {
-      registry.register(spec, pluginDir, scope);
+      registry.register(spec, pluginDir);
     }
   }
 }
@@ -56,21 +51,17 @@ function loadDirIntoRegistry(dir: string, scope: 'local' | 'global'): void {
 /**
  * Incremental rescan — called from chokidar events AND from PLUGIN_LIST.
  * Registers newly added plugins and unregisters plugins whose spec has
- * disappeared. Unlike refreshLocalPlugins, this runs even when the workspace
- * path hasn't changed, so plugins created at runtime (e.g. via MCP
- * aide_create_plugin) are picked up without restarting the app.
- *
- * Self-healing: PLUGIN_LIST calls this for BOTH scopes so global plugins
- * added after startup become visible inside a workspace without restart.
+ * disappeared. Runs even when the workspace path hasn't changed, so plugins
+ * created at runtime (e.g. via MCP aide_create_plugin) are picked up without
+ * restarting the app.
  */
-function rescanPluginsDir(dir: string, scope: 'local' | 'global'): void {
+function rescanPluginsDir(dir: string): void {
   // 1. Register any new plugins found on disk
-  loadDirIntoRegistry(dir, scope);
+  loadDirIntoRegistry(dir);
 
   // 2. Unregister plugins whose pluginDir no longer exists or whose spec
   //    has disappeared (plugin deleted by user or MCP)
-  const scoped = registry.list().filter((p) => p.scope === scope);
-  for (const plugin of scoped) {
+  for (const plugin of registry.list()) {
     if (!plugin.pluginDir.startsWith(dir)) continue;
     const specExists = fs.existsSync(path.join(plugin.pluginDir, 'plugin.spec.json'));
     if (!specExists) {
@@ -80,10 +71,6 @@ function rescanPluginsDir(dir: string, scope: 'local' | 'global'): void {
 }
 
 function ensurePluginsDirs(cwd: string): void {
-  try {
-    const globalDir = getGlobalPluginsDir();
-    if (!fs.existsSync(globalDir)) fs.mkdirSync(globalDir, { recursive: true });
-  } catch { /* non-fatal */ }
   try {
     const localDir = getLocalPluginsDir(cwd);
     if (!fs.existsSync(localDir)) fs.mkdirSync(localDir, { recursive: true });
@@ -97,8 +84,7 @@ function getEffectiveCwd(fallbackCwd: string): string {
 
 function loadRegistryFromDisk(cwd: string): void {
   ensurePluginsDirs(cwd);
-  loadDirIntoRegistry(getGlobalPluginsDir(), 'global');
-  loadDirIntoRegistry(getLocalPluginsDir(cwd), 'local');
+  loadDirIntoRegistry(getLocalPluginsDir(cwd));
 }
 
 function broadcastPluginsChanged(): void {
@@ -125,15 +111,15 @@ function broadcastDataChanged(): void {
   }
 }
 
-// Clears local plugins and reloads from the new workspace directory.
+// Clears all plugins and reloads from the new workspace directory.
 // No-op if the workspace hasn't changed.
-function refreshLocalPlugins(cwd: string): void {
+function refreshPlugins(cwd: string): void {
   const localDir = getLocalPluginsDir(cwd);
   if (lastLocalDir === localDir) return;
-  registry.clearLocalPlugins();
+  registry.clearPlugins();
   lastLocalDir = localDir;
   ensurePluginsDirs(cwd);
-  loadDirIntoRegistry(localDir, 'local');
+  loadDirIntoRegistry(localDir);
   // Re-watch local plugins dir for add/remove changes.
   // On any filesystem event, rescan the directory to register newly added
   // plugins (e.g. created by MCP aide_create_plugin at runtime) and drop
@@ -142,7 +128,7 @@ function refreshLocalPlugins(cwd: string): void {
   localPluginsWatcher = chokidar
     .watch(localDir, { ignoreInitial: true, depth: 2, ignored: WATCHER_EXCLUSIONS })
     .on('all', () => {
-      rescanPluginsDir(localDir, 'local');
+      rescanPluginsDir(localDir);
       broadcastPluginsChanged();
     });
   // Re-watch local plugins dir for index.html changes (debounced 300ms)
@@ -203,30 +189,6 @@ export function registerPluginHandlers(ipcMain: IpcMain, cwd: string): void {
   // Broadcast existing plugins immediately so the UI shows them on launch
   broadcastPluginsChanged();
 
-  // Watch global plugins dir for add/remove changes.
-  // Rescan on any event so runtime-added plugins become visible without restart.
-  const globalDir = getGlobalPluginsDir();
-  chokidar
-    .watch(globalDir, { ignoreInitial: true, depth: 2, ignored: WATCHER_EXCLUSIONS })
-    .on('all', () => {
-      rescanPluginsDir(globalDir, 'global');
-      broadcastPluginsChanged();
-    });
-
-  // Watch global plugins dir for index.html changes (debounced 300ms)
-  const htmlDebounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
-  chokidar
-    .watch(path.join(globalDir, '**/index.html'), { ignoreInitial: true, ignored: WATCHER_EXCLUSIONS })
-    .on('change', (filePath: string) => {
-      const pluginName = path.basename(path.dirname(filePath));
-      const existing = htmlDebounceTimers.get(pluginName);
-      if (existing) clearTimeout(existing);
-      htmlDebounceTimers.set(pluginName, setTimeout(() => {
-        htmlDebounceTimers.delete(pluginName);
-        broadcastHtmlChanged(pluginName);
-      }, 300));
-    });
-
   // Spec-only: generate and return spec without writing to disk
   ipcMain.handle(IPC_CHANNELS.PLUGIN_GENERATE_SPEC, async (_event, name: string, description: string) => {
     return generatePluginSpec(name, description);
@@ -241,7 +203,7 @@ export function registerPluginHandlers(ipcMain: IpcMain, cwd: string): void {
     const pluginDir = path.join(localDir, spec.name);
     try {
       generatePluginCode(spec, pluginDir);
-      registry.register(spec, pluginDir, 'local');
+      registry.register(spec, pluginDir);
     } catch (err) {
       // Cleanup orphaned files on pipeline failure
       if (fs.existsSync(pluginDir)) {
@@ -254,13 +216,10 @@ export function registerPluginHandlers(ipcMain: IpcMain, cwd: string): void {
 
   ipcMain.handle(IPC_CHANNELS.PLUGIN_LIST, async () => {
     const effectiveCwd = getEffectiveCwd(cwd);
-    // Clears stale local plugins when workspace changes, then reloads from current workspace
-    refreshLocalPlugins(effectiveCwd);
-    // Self-healing: rescan both scopes so plugins added at runtime (e.g. global
-    // plugins installed via MCP or a file manager after startup) become visible
-    // without restarting the app.
-    rescanPluginsDir(getGlobalPluginsDir(), 'global');
-    rescanPluginsDir(getLocalPluginsDir(effectiveCwd), 'local');
+    // Clears stale plugins when workspace changes, then reloads from current workspace
+    refreshPlugins(effectiveCwd);
+    // Self-healing: rescan so plugins added at runtime become visible without restart
+    rescanPluginsDir(getLocalPluginsDir(effectiveCwd));
     return registry.list();
   });
 
@@ -300,18 +259,17 @@ export function registerPluginHandlers(ipcMain: IpcMain, cwd: string): void {
     // Fallback: scan filesystem — plugin may be installed but not activated (OFF)
     if (!pluginDir) {
       const effectiveCwd = getEffectiveCwd(cwd);
-      for (const dir of [getLocalPluginsDir(effectiveCwd), getGlobalPluginsDir()]) {
-        if (!fs.existsSync(dir)) continue;
-        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const localDir = getLocalPluginsDir(effectiveCwd);
+      if (fs.existsSync(localDir)) {
+        for (const entry of fs.readdirSync(localDir, { withFileTypes: true })) {
           if (!entry.isDirectory()) continue;
-          const candidate = path.join(dir, entry.name);
+          const candidate = path.join(localDir, entry.name);
           const spec = readPluginSpec(candidate);
           if (spec && (spec.id === pluginId || spec.name === pluginId)) {
             pluginDir = candidate;
             break;
           }
         }
-        if (pluginDir) break;
       }
     }
 
@@ -330,7 +288,7 @@ export function registerPluginHandlers(ipcMain: IpcMain, cwd: string): void {
     const freshSpec = readPluginSpec(plugin.pluginDir);
     if (freshSpec) {
       registry.unregister(pluginId);
-      registry.register(freshSpec, plugin.pluginDir, plugin.scope);
+      registry.register(freshSpec, plugin.pluginDir);
       if (wasActive) {
         const effectiveCwd = getEffectiveCwd(cwd);
         registry.activate(freshSpec.id, effectiveCwd);
@@ -342,20 +300,12 @@ export function registerPluginHandlers(ipcMain: IpcMain, cwd: string): void {
 
   ipcMain.handle(IPC_CHANNELS.PLUGIN_DELETE, async (_event, pluginName: string) => {
     const effectiveCwd = getEffectiveCwd(cwd);
-    // Search local first, then global
     const localDir = getLocalPluginsDir(effectiveCwd);
-    const globalDir = getGlobalPluginsDir();
 
-    let pluginDir = path.join(localDir, pluginName);
-    let baseDir = localDir;
+    const pluginDir = path.join(localDir, pluginName);
 
-    if (!fs.existsSync(pluginDir)) {
-      pluginDir = path.join(globalDir, pluginName);
-      baseDir = globalDir;
-    }
-
-    // Prevent path traversal — pluginDir must be inside baseDir
-    if (!pluginDir.startsWith(baseDir + path.sep)) {
+    // Prevent path traversal — pluginDir must be inside localDir
+    if (!pluginDir.startsWith(localDir + path.sep)) {
       throw new Error('Invalid plugin name');
     }
 

--- a/src/main/ipc/terminal-handlers.ts
+++ b/src/main/ipc/terminal-handlers.ts
@@ -156,7 +156,7 @@ export function registerTerminalHandlers(ipcMain: IpcMain): void {
         'PATH', 'HOME', 'USER', 'LOGNAME', 'LANG', 'LC_ALL', 'LC_CTYPE',
         'SHELL', 'TERM', 'TMPDIR', 'XDG_RUNTIME_DIR',
         'NVM_DIR',  // needed for shell tabs to initialize nvm via .zshrc
-        'AIDE_PLUGINS_DIR', 'AIDE_WORKSPACE',
+        'AIDE_WORKSPACE',
       ];
       for (const key of allowedKeys) {
         if (process.env[key]) safeBaseEnv[key] = process.env[key] as string;

--- a/src/main/ipc/workspace-handlers.ts
+++ b/src/main/ipc/workspace-handlers.ts
@@ -46,6 +46,41 @@ function nextColor(counter: number): string {
   return WORKSPACE_COLORS[counter % WORKSPACE_COLORS.length];
 }
 
+/**
+ * Migration: remove AIDE-generated entries from {workspace}/.mcp.json.
+ * If only AIDE entries remain, delete the file entirely.
+ */
+function migrateProjectMcpJson(workspacePath: string): void {
+  const mcpPath = nodePath.join(workspacePath, '.mcp.json');
+  if (!fs.existsSync(mcpPath)) return;
+  try {
+    const raw = fs.readFileSync(mcpPath, 'utf-8');
+    const config = JSON.parse(raw);
+    if (!config.mcpServers || typeof config.mcpServers !== 'object') return;
+    if (!('aide' in config.mcpServers)) return;
+
+    delete config.mcpServers.aide;
+
+    if (Object.keys(config.mcpServers).length === 0) {
+      // No other servers — check if there are top-level keys besides mcpServers
+      const topKeys = Object.keys(config).filter((k) => k !== 'mcpServers');
+      if (topKeys.length === 0) {
+        fs.unlinkSync(mcpPath);
+        console.log('[AIDE] Removed legacy .mcp.json (AIDE-only)');
+      } else {
+        delete config.mcpServers;
+        fs.writeFileSync(mcpPath, JSON.stringify(config, null, 2));
+        console.log('[AIDE] Removed aide entry and empty mcpServers from .mcp.json');
+      }
+    } else {
+      fs.writeFileSync(mcpPath, JSON.stringify(config, null, 2));
+      console.log('[AIDE] Removed aide entry from .mcp.json (other servers preserved)');
+    }
+  } catch {
+    // Corrupt or unreadable — leave it alone
+  }
+}
+
 export function registerWorkspaceHandlers(ipcMain: IpcMain): void {
   ipcMain.handle(IPC_CHANNELS.WORKSPACE_LIST, () => {
     return getWorkspaces();
@@ -84,6 +119,8 @@ export function registerWorkspaceHandlers(ipcMain: IpcMain): void {
       workspace.lastOpened = Date.now();
       setWorkspaces(workspaces);
     }
+    // Migrate legacy .mcp.json (remove AIDE entries from project root)
+    migrateProjectMcpJson(path);
     // .aide/plugins creation is delegated (see WORKSPACE_CREATE comment).
     try { writeMcpConfig(path); } catch (err) {
       console.warn('[AIDE] Failed to write workspace MCP config:', (err as Error).message);

--- a/src/main/ipc/workspace-handlers.ts
+++ b/src/main/ipc/workspace-handlers.ts
@@ -50,7 +50,7 @@ function nextColor(counter: number): string {
  * Migration: remove AIDE-generated entries from {workspace}/.mcp.json.
  * If only AIDE entries remain, delete the file entirely.
  */
-function migrateProjectMcpJson(workspacePath: string): void {
+export function migrateProjectMcpJson(workspacePath: string): void {
   const mcpPath = nodePath.join(workspacePath, '.mcp.json');
   if (!fs.existsSync(mcpPath)) return;
   try {

--- a/src/main/mcp/config-writer.ts
+++ b/src/main/mcp/config-writer.ts
@@ -60,7 +60,7 @@ export function getMcpServerPath(): string {
  * Shared helper: merges the AIDE MCP server entry into a JSON config file.
  * Safe to call multiple times — merges rather than overwrites.
  */
-function registerJsonMcpConfig(configPath: string, nodePath: string, serverPath: string, globalPluginsDir: string): void {
+function registerJsonMcpConfig(configPath: string, nodePath: string, serverPath: string): void {
   fs.mkdirSync(path.dirname(configPath), { recursive: true });
   let config: Record<string, unknown> = {};
   if (fs.existsSync(configPath)) {
@@ -76,9 +76,6 @@ function registerJsonMcpConfig(configPath: string, nodePath: string, serverPath:
   (config.mcpServers as Record<string, unknown>)['aide'] = {
     command: nodePath,
     args: [serverPath],
-    // Global registration only sets AIDE_GLOBAL_PLUGINS_DIR.
-    // AIDE_PLUGINS_DIR and AIDE_WORKSPACE are workspace-specific and set via --mcp-config.
-    env: { AIDE_GLOBAL_PLUGINS_DIR: globalPluginsDir },
   };
   fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
 }
@@ -105,33 +102,21 @@ function removeTomlSection(content: string, sectionHeader: string): string {
 
 export function writeMcpConfig(workspacePath: string): string {
   const home = getHome();
-  const globalPluginsDir = path.join(home, '.aide', 'plugins');
-  const localPluginsDir = path.join(workspacePath, '.aide', 'plugins');
   const nodePath = resolveNodePath();
   const serverPath = getMcpServerPath();
 
-  // Global dir is under HOME — always writable. Local dir lives inside the
-  // workspace and may be permission-restricted (macOS TCC). Isolate failures
-  // so a restricted workspace doesn't skip global MCP registration.
-  try { fs.mkdirSync(globalPluginsDir, { recursive: true }); } catch (err) {
-    console.warn('[AIDE] Could not create global plugins dir:', (err as Error).message);
-  }
-  try { fs.mkdirSync(localPluginsDir, { recursive: true }); } catch (err) {
-    console.warn('[AIDE] Could not create local plugins dir:', (err as Error).message);
-  }
-
   writeMcpServerScript();
 
-  // Register in ~/.claude.json (Claude uses --mcp-config per-workspace; global is a fallback)
+  // Register in ~/.claude.json (Claude uses --mcp-config per-workspace; this is a fallback)
   try {
-    registerJsonMcpConfig(path.join(home, '.claude.json'), nodePath, serverPath, globalPluginsDir);
+    registerJsonMcpConfig(path.join(home, '.claude.json'), nodePath, serverPath);
   } catch (err) {
     console.warn('[AIDE] Failed to register Claude MCP config:', (err as Error).message);
   }
 
   // Register in ~/.gemini/settings.json (Gemini has no --mcp-config flag)
   try {
-    registerJsonMcpConfig(path.join(home, '.gemini', 'settings.json'), nodePath, serverPath, globalPluginsDir);
+    registerJsonMcpConfig(path.join(home, '.gemini', 'settings.json'), nodePath, serverPath);
   } catch (err) {
     console.warn('[AIDE] Failed to register Gemini MCP config:', (err as Error).message);
   }
@@ -143,7 +128,7 @@ export function writeMcpConfig(workspacePath: string): string {
     let content = fs.existsSync(codexConfigPath) ? fs.readFileSync(codexConfigPath, 'utf-8') : '';
     content = removeTomlSection(content, '[mcp_servers.aide]');
     const prefix = content.trimEnd();
-    const block = `[mcp_servers.aide]\ncommand = ${JSON.stringify(nodePath)}\nargs = [${JSON.stringify(serverPath)}]\nenv = { AIDE_GLOBAL_PLUGINS_DIR = ${JSON.stringify(globalPluginsDir)} }\n`;
+    const block = `[mcp_servers.aide]\ncommand = ${JSON.stringify(nodePath)}\nargs = [${JSON.stringify(serverPath)}]\n`;
     fs.writeFileSync(codexConfigPath, prefix.length > 0 ? `${prefix}\n\n${block}` : block);
   } catch (err) {
     console.warn('[AIDE] Failed to register Codex MCP config:', (err as Error).message);
@@ -155,8 +140,6 @@ export function writeMcpConfig(workspacePath: string): string {
         command: 'node',
         args: [getMcpServerPath()],
         env: {
-          AIDE_GLOBAL_PLUGINS_DIR: globalPluginsDir,
-          AIDE_PLUGINS_DIR: localPluginsDir,
           AIDE_WORKSPACE: workspacePath,
         },
       },
@@ -165,28 +148,6 @@ export function writeMcpConfig(workspacePath: string): string {
 
   const mcpConfigPath = getMcpConfigPath();
   fs.writeFileSync(mcpConfigPath, JSON.stringify(config, null, 2));
-
-  // Write project-level .mcp.json at workspace root so Claude Code CLI auto-detects
-  // workspace-specific env vars (AIDE_WORKSPACE, AIDE_PLUGINS_DIR) when running in the project.
-  try {
-    const projectMcpPath = path.join(workspacePath, '.mcp.json');
-    const projectConfig = {
-      mcpServers: {
-        aide: {
-          command: nodePath,
-          args: [serverPath],
-          env: {
-            AIDE_GLOBAL_PLUGINS_DIR: globalPluginsDir,
-            AIDE_PLUGINS_DIR: localPluginsDir,
-            AIDE_WORKSPACE: workspacePath,
-          },
-        },
-      },
-    };
-    fs.writeFileSync(projectMcpPath, JSON.stringify(projectConfig, null, 2));
-  } catch (err) {
-    console.warn('[AIDE] Failed to write project .mcp.json:', (err as Error).message);
-  }
 
   return mcpConfigPath;
 }

--- a/src/main/mcp/server.js
+++ b/src/main/mcp/server.js
@@ -5,7 +5,6 @@ const path = require("path");
 const vm = require("vm");
 const crypto = require("crypto");
 
-const GLOBAL_PLUGINS_DIR = process.env.AIDE_GLOBAL_PLUGINS_DIR || "";
 function safeCwd() {
   // process.cwd() throws EPERM in packaged Electron apps when launched from Finder
   // (HOME=/ or unmounted cwd). Fall back to HOME / getpwuid / /tmp.
@@ -14,7 +13,7 @@ function safeCwd() {
   try { return require("os").userInfo().homedir; } catch { /* ignore */ }
   return "/tmp";
 }
-const PLUGINS_DIR = process.env.AIDE_PLUGINS_DIR || path.join(safeCwd(), ".aide", "plugins");
+const PLUGINS_DIR = path.join(safeCwd(), ".aide", "plugins");
 const WORKSPACE = process.env.AIDE_WORKSPACE || safeCwd();
 
 function send(msg) {
@@ -36,13 +35,7 @@ function scanPluginsDir(dir) {
 }
 
 function listPluginSpecs() {
-  const globalSpecs = scanPluginsDir(GLOBAL_PLUGINS_DIR);
-  const localSpecs = scanPluginsDir(PLUGINS_DIR);
-  // Merge: local overrides global if same name
-  const byName = new Map();
-  for (const s of globalSpecs) byName.set(s.name, s);
-  for (const s of localSpecs) byName.set(s.name, s);
-  return Array.from(byName.values());
+  return scanPluginsDir(PLUGINS_DIR);
 }
 
 // Fix #1: Read spec.entryPoint instead of hardcoding "src/index.js"
@@ -57,21 +50,6 @@ function resolvePluginDir(pluginName) {
           const entryPoint = spec.entryPoint || "src/index.js";
           if (fs.existsSync(path.join(localDir, entryPoint))) {
             return { dir: localDir, base: PLUGINS_DIR, entryPoint };
-          }
-        } catch {}
-      }
-    }
-  }
-  if (GLOBAL_PLUGINS_DIR) {
-    const globalDir = path.join(GLOBAL_PLUGINS_DIR, pluginName);
-    if (path.resolve(globalDir).startsWith(path.resolve(GLOBAL_PLUGINS_DIR) + path.sep)) {
-      const specPath = path.join(globalDir, "plugin.spec.json");
-      if (fs.existsSync(specPath)) {
-        try {
-          const spec = JSON.parse(fs.readFileSync(specPath, "utf-8"));
-          const entryPoint = spec.entryPoint || "src/index.js";
-          if (fs.existsSync(path.join(globalDir, entryPoint))) {
-            return { dir: globalDir, base: GLOBAL_PLUGINS_DIR, entryPoint };
           }
         } catch {}
       }
@@ -133,10 +111,7 @@ function invokePluginTool(pluginName, toolName, args) {
 }
 
 function createPlugin(params) {
-  const scope = params.scope;
-  if (!scope) throw new Error("scope is required. Ask the user whether they want the plugin installed globally (~/.aide/plugins, shared across all workspaces) or locally ({workspace}/.aide/plugins, only in the current project) before calling this tool.");
-  const baseDir = scope === "global" ? GLOBAL_PLUGINS_DIR : PLUGINS_DIR;
-  if (!baseDir) throw new Error(scope === "global" ? "AIDE_GLOBAL_PLUGINS_DIR not set" : "AIDE_PLUGINS_DIR not set");
+  const baseDir = PLUGINS_DIR;
   const safeName = params.name.toLowerCase().replace(/[^a-z0-9-]/g, "-");
   const pluginDir = path.join(baseDir, safeName);
   if (!path.resolve(pluginDir).startsWith(path.resolve(baseDir))) throw new Error("Invalid plugin name");
@@ -213,13 +188,7 @@ function editPlugin(params) {
   return spec;
 }
 
-// Fix #4: corrected description (removed copy-paste error at end of CDN section)
-// Fix #5: updated shim docs (auto-injected, no manual inclusion needed)
-// Fix #3: added fileAssociations to inputSchemas
-// Fix #6: scope required in aide_delete_plugin
-const CREATE_PLUGIN_DESC = `IMPORTANT: Before calling this tool, you MUST ask the user whether they want the plugin installed globally (~/.aide/plugins, shared across all workspaces) or locally ({workspace}/.aide/plugins, only in the current project). Do not assume a default — always wait for the user's explicit answer.
-
-Create a new AIDE plugin from code. The code must be a CommonJS module exporting { name, version, tools, invoke(toolName, args) }.
+const CREATE_PLUGIN_DESC = `Create a new AIDE plugin from code. Plugins are installed in the workspace ({workspace}/.aide/plugins). The code must be a CommonJS module exporting { name, version, tools, invoke(toolName, args) }.
 
 Sandbox Environment:
 - require('path') → always available
@@ -344,10 +313,9 @@ function getBuiltinTools() {
           permissions: { type: "array", items: { type: "string" }, description: "Required permissions: fs:read, fs:write, network, process" },
           tools: { type: "array", description: "Tool definitions the plugin exposes", items: { type: "object", properties: { name: { type: "string" }, description: { type: "string" }, parameters: { type: "object" } } } },
           html: { type: "string", description: "Optional custom index.html for the plugin iframe UI. If omitted, a default UI is auto-generated. The window.aide shim (on, invoke, emit, theme) is automatically injected by AIDE into all iframes — you do not need to include it manually." },
-          scope: { type: "string", enum: ["global", "local"], description: "Where to install: global (~/.aide/plugins, shared across all workspaces) or local ({workspace}/.aide/plugins, only in the current project). Must be explicitly chosen by the user." },
           fileAssociations: { type: "array", items: { type: "string" }, description: "File extensions or glob patterns this plugin handles (e.g. [\".html\", \".css\", \"*.json\"]). Used to associate the plugin with file types in the file tree." }
         },
-        required: ["name", "description", "code", "scope"]
+        required: ["name", "description", "code"]
       }
     },
     {
@@ -378,16 +346,14 @@ function getBuiltinTools() {
       }
     },
     {
-      // Fix #6: scope is now required (consistent with aide_create_plugin)
       name: "aide_delete_plugin",
       description: "Delete an installed AIDE plugin.",
       inputSchema: {
         type: "object",
         properties: {
-          plugin_name: { type: "string" },
-          scope: { type: "string", enum: ["global", "local"], description: "Which scope to delete from: global (~/.aide/plugins) or local ({workspace}/.aide/plugins)." }
+          plugin_name: { type: "string" }
         },
-        required: ["plugin_name", "scope"]
+        required: ["plugin_name"]
       }
     }
   ];
@@ -427,13 +393,8 @@ function handleRequest(method, id, params) {
       } else if (tn === "aide_edit_plugin") {
         sendResult(id, { content: [{ type: "text", text: JSON.stringify(editPlugin(ta), null, 2) }] });
       } else if (tn === "aide_delete_plugin") {
-        // Fix #6: scope is required — no default fallback
-        const scope = ta.scope;
-        if (!scope) throw new Error("scope is required: 'global' or 'local'");
-        const baseDir = scope === "global" ? GLOBAL_PLUGINS_DIR : PLUGINS_DIR;
-        if (!baseDir) throw new Error("Plugins directory not configured for scope: " + scope);
-        const dir = path.join(baseDir, ta.plugin_name);
-        if (!path.resolve(dir).startsWith(path.resolve(baseDir) + path.sep)) throw new Error("Invalid plugin name");
+        const dir = path.join(PLUGINS_DIR, ta.plugin_name);
+        if (!path.resolve(dir).startsWith(path.resolve(PLUGINS_DIR) + path.sep)) throw new Error("Invalid plugin name");
         if (fs.existsSync(dir)) fs.rmSync(dir, { recursive: true });
         sendResult(id, { content: [{ type: "text", text: "Deleted plugin: " + ta.plugin_name }] });
       } else if (tn.startsWith("plugin_")) {

--- a/src/main/plugin/protocol.ts
+++ b/src/main/plugin/protocol.ts
@@ -15,17 +15,15 @@ import { protocol } from 'electron';
 import * as fs from 'fs';
 import * as path from 'path';
 import { getActiveWorkspacePath } from '../ipc/workspace-handlers';
-import { getHome } from '../utils/home';
 
 /**
- * Scan local + global plugin directories for a plugin matching `pluginId`
+ * Scan local plugin directory for a plugin matching `pluginId`
  * (by spec.id or spec.name) and return its index.html content.
  */
 function findPluginHtml(pluginId: string, fallbackCwd: string): string | null {
   const effectiveCwd = getActiveWorkspacePath() ?? fallbackCwd;
   const dirs = [
     path.join(effectiveCwd, '.aide', 'plugins'),
-    path.join(getHome(), '.aide', 'plugins'),
   ];
 
   for (const dir of dirs) {

--- a/src/main/plugin/registry.ts
+++ b/src/main/plugin/registry.ts
@@ -9,7 +9,6 @@ interface RegisteredPlugin {
   sandbox: PluginSandbox | null;
   active: boolean;
   pluginDir: string;
-  scope: 'local' | 'global';
 }
 
 interface RegisteredTool {
@@ -26,13 +25,12 @@ export class PluginRegistry {
     this.emitterFactory = factory;
   }
 
-  register(spec: PluginSpec, pluginDir: string, scope: 'local' | 'global' = 'local'): void {
+  register(spec: PluginSpec, pluginDir: string): void {
     this.plugins.set(spec.id, {
       spec,
       sandbox: new PluginSandbox(pluginDir, spec),
       active: false,
       pluginDir,
-      scope,
     });
   }
 
@@ -89,11 +87,10 @@ export class PluginRegistry {
     return true;
   }
 
-  list(): Array<PluginSpec & { active: boolean; scope: 'local' | 'global'; pluginDir: string }> {
+  list(): Array<PluginSpec & { active: boolean; pluginDir: string }> {
     return Array.from(this.plugins.values()).map((p) => ({
       ...p.spec,
       active: p.active,
-      scope: p.scope,
       pluginDir: p.pluginDir,
     }));
   }
@@ -102,9 +99,8 @@ export class PluginRegistry {
     return this.plugins.get(id);
   }
 
-  clearLocalPlugins(): void {
+  clearPlugins(): void {
     for (const [id, plugin] of this.plugins) {
-      if (plugin.scope !== 'local') continue;
       if (plugin.active && plugin.sandbox) {
         plugin.sandbox.stop();
       }

--- a/src/renderer/components/layout/PaneView.tsx
+++ b/src/renderer/components/layout/PaneView.tsx
@@ -126,7 +126,6 @@ function DraggableTab({ tab, paneId, isActive, onActivate, onClose, onContextMen
 
 interface PaneViewProps {
   pane: Pane;
-  showHeader?: boolean;
 }
 
 interface ContextMenu {
@@ -135,14 +134,13 @@ interface ContextMenu {
   tabId: string;
 }
 
-export function PaneView({ pane, showHeader = false }: PaneViewProps) {
+export function PaneView({ pane }: PaneViewProps) {
   const focusedPaneId = useLayoutStore((s) => s.focusedPaneId);
   const setFocusedPane = useLayoutStore((s) => s.setFocusedPane);
   const setActiveTab = useLayoutStore((s) => s.setActiveTab);
   const removeTabFromPane = useLayoutStore((s) => s.removeTabFromPane);
   const renameTabInPane = useLayoutStore((s) => s.renameTabInPane);
   const splitPane = useLayoutStore((s) => s.splitPane);
-  const closePaneAndMergeTabs = useLayoutStore((s) => s.closePaneAndMergeTabs);
 
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [contextMenu, setContextMenu] = useState<ContextMenu | null>(null);
@@ -197,7 +195,6 @@ export function PaneView({ pane, showHeader = false }: PaneViewProps) {
   const isCrossPaneDrag = draggingSourcePaneId !== null && draggingSourcePaneId !== pane.id;
 
   const isFocused = focusedPaneId === pane.id;
-  const activeTab = pane.tabs.find((t) => t.id === pane.activeTabId) ?? pane.tabs[0];
 
   const handleRenameTab = useCallback((tabId: string, title: string) => {
     renameTabInPane(pane.id, tabId, title);
@@ -265,28 +262,6 @@ export function PaneView({ pane, showHeader = false }: PaneViewProps) {
 
         {dropdownOpen && <AgentDropdown paneId={pane.id} onClose={() => setDropdownOpen(false)} />}
       </div>
-
-      {/* Pane Header (multi-pane mode) */}
-      {showHeader && activeTab && (
-        <div className="flex items-center gap-2 shrink-0 bg-aide-surface px-3 border-b border-aide-border" style={{ height: '28px' }}>
-          {activeTab.type === 'plugin' ? (
-            <span className="text-[12px]" style={{ color: 'var(--accent)' }}>◈</span>
-          ) : (
-            <span
-              className="w-2 h-2 rounded-full"
-              style={{ backgroundColor: AGENT_COLORS[activeTab.agentId ?? 'shell'] ?? AGENT_COLORS.shell }}
-            />
-          )}
-          <span className="text-[11px] font-mono text-aide-text-secondary truncate flex-1">{activeTab.title}</span>
-          <button
-            onClick={(e) => { e.stopPropagation(); closePaneAndMergeTabs(pane.id); }}
-            className="text-[12px] text-aide-text-tertiary hover:text-aide-text-primary transition-colors leading-none"
-            title="Close pane (merge tabs to sibling)"
-          >
-            ✕
-          </button>
-        </div>
-      )}
 
       {/* Content area — also a drop zone */}
       <div ref={setDropRefs} data-pane-drop={pane.id} className="flex-1 overflow-hidden relative">

--- a/src/renderer/components/layout/SplitContainer.tsx
+++ b/src/renderer/components/layout/SplitContainer.tsx
@@ -4,24 +4,13 @@ import { useLayoutStore } from '../../stores/layout-store';
 import type { LayoutNode } from '../../../types/ipc';
 import { isSplitLayout } from '../../../types/ipc';
 
-function countPanes(node: LayoutNode): number {
-  if (isSplitLayout(node)) {
-    return node.children.reduce((sum, child) => sum + countPanes(child), 0);
-  }
-  return 1;
-}
-
 interface SplitContainerProps {
   node: LayoutNode;
 }
 
 export function SplitContainer({ node }: SplitContainerProps) {
-  // Derive pane count from the layout tree (stable primitive selector)
-  const layout = useLayoutStore((s) => s.layout);
-  const paneCount = countPanes(layout);
-
   if (!isSplitLayout(node)) {
-    return <PaneView pane={node} showHeader={paneCount > 1} />;
+    return <PaneView pane={node} />;
   }
 
   const isHorizontal = node.direction === 'horizontal';

--- a/src/renderer/components/plugin/PluginPanel.tsx
+++ b/src/renderer/components/plugin/PluginPanel.tsx
@@ -47,8 +47,6 @@ export function PluginPanel() {
   };
 
   const activeCount = plugins.filter((p) => p.active).length;
-  const localPlugins = plugins.filter((p) => p.scope === 'local');
-  const globalPlugins = plugins.filter((p) => p.scope === 'global');
 
   const renderPlugin = (plugin: typeof plugins[number]) => (
     <div
@@ -146,23 +144,8 @@ export function PluginPanel() {
         )}
 
         {!loading && plugins.length > 0 && (
-          <div className="flex flex-col gap-3 px-2 py-2">
-            {localPlugins.length > 0 && (
-              <div className="flex flex-col gap-1">
-                <span className="text-[9px] uppercase tracking-widest text-aide-text-tertiary font-mono px-1 pb-0.5">
-                  Local
-                </span>
-                {localPlugins.map(renderPlugin)}
-              </div>
-            )}
-            {globalPlugins.length > 0 && (
-              <div className="flex flex-col gap-1">
-                <span className="text-[9px] uppercase tracking-widest text-aide-text-tertiary font-mono px-1 pb-0.5">
-                  Global
-                </span>
-                {globalPlugins.map(renderPlugin)}
-              </div>
-            )}
+          <div className="flex flex-col gap-1 px-2 py-2">
+            {plugins.map(renderPlugin)}
           </div>
         )}
       </div>

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -30,7 +30,6 @@ export interface PluginInfo {
   version: string;
   description: string;
   active: boolean;
-  scope: 'local' | 'global';
   tools: PluginTool[];
   /** File extensions this plugin handles, e.g. ['.json', '.yaml'] */
   fileAssociations?: string[];

--- a/tests/unit/migrate-mcp-json.test.ts
+++ b/tests/unit/migrate-mcp-json.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { migrateProjectMcpJson } from '../../src/main/ipc/workspace-handlers';
+
+describe('migrateProjectMcpJson', () => {
+  let tmpDir: string;
+  let mcpPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aide-migrate-test-'));
+    mcpPath = path.join(tmpDir, '.mcp.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('does nothing when .mcp.json does not exist', () => {
+    migrateProjectMcpJson(tmpDir);
+    expect(fs.existsSync(mcpPath)).toBe(false);
+  });
+
+  it('deletes .mcp.json when it only contains mcpServers.aide', () => {
+    const config = {
+      mcpServers: {
+        aide: { command: 'node', args: ['server.js'], env: { AIDE_WORKSPACE: tmpDir } },
+      },
+    };
+    fs.writeFileSync(mcpPath, JSON.stringify(config, null, 2));
+
+    migrateProjectMcpJson(tmpDir);
+
+    expect(fs.existsSync(mcpPath)).toBe(false);
+  });
+
+  it('removes aide key but preserves other servers', () => {
+    const config = {
+      mcpServers: {
+        aide: { command: 'node', args: ['server.js'] },
+        other: { command: 'python', args: ['other.py'] },
+      },
+    };
+    fs.writeFileSync(mcpPath, JSON.stringify(config, null, 2));
+
+    migrateProjectMcpJson(tmpDir);
+
+    expect(fs.existsSync(mcpPath)).toBe(true);
+    const result = JSON.parse(fs.readFileSync(mcpPath, 'utf-8'));
+    expect(result.mcpServers.aide).toBeUndefined();
+    expect(result.mcpServers.other).toEqual({ command: 'python', args: ['other.py'] });
+  });
+
+  it('does nothing when .mcp.json has no mcpServers key', () => {
+    const config = { someOtherKey: 'value' };
+    fs.writeFileSync(mcpPath, JSON.stringify(config));
+
+    migrateProjectMcpJson(tmpDir);
+
+    const result = JSON.parse(fs.readFileSync(mcpPath, 'utf-8'));
+    expect(result).toEqual(config);
+  });
+
+  it('does nothing when mcpServers has no aide key', () => {
+    const config = {
+      mcpServers: { other: { command: 'python', args: ['other.py'] } },
+    };
+    fs.writeFileSync(mcpPath, JSON.stringify(config));
+
+    migrateProjectMcpJson(tmpDir);
+
+    const result = JSON.parse(fs.readFileSync(mcpPath, 'utf-8'));
+    expect(result).toEqual(config);
+  });
+
+  it('removes mcpServers but preserves other top-level keys when aide is the only server', () => {
+    const config = {
+      mcpServers: {
+        aide: { command: 'node', args: ['server.js'] },
+      },
+      customSetting: true,
+    };
+    fs.writeFileSync(mcpPath, JSON.stringify(config, null, 2));
+
+    migrateProjectMcpJson(tmpDir);
+
+    expect(fs.existsSync(mcpPath)).toBe(true);
+    const result = JSON.parse(fs.readFileSync(mcpPath, 'utf-8'));
+    expect(result.mcpServers).toBeUndefined();
+    expect(result.customSetting).toBe(true);
+  });
+
+  it('does not crash on corrupt .mcp.json', () => {
+    fs.writeFileSync(mcpPath, '{invalid json!!!');
+
+    expect(() => migrateProjectMcpJson(tmpDir)).not.toThrow();
+    // File left as-is
+    expect(fs.readFileSync(mcpPath, 'utf-8')).toBe('{invalid json!!!');
+  });
+});

--- a/tests/unit/plugin-registry.test.ts
+++ b/tests/unit/plugin-registry.test.ts
@@ -22,64 +22,42 @@ describe('PluginRegistry', () => {
   });
 
   describe('register / list', () => {
-    it('lists registered plugins with scope', () => {
-      registry.register(makeSpec('id-1', 'local-plugin'), '/tmp/local-plugin', 'local');
-      registry.register(makeSpec('id-2', 'global-plugin'), '/tmp/global-plugin', 'global');
+    it('lists registered plugins', () => {
+      registry.register(makeSpec('id-1', 'plugin-a'), '/tmp/plugin-a');
+      registry.register(makeSpec('id-2', 'plugin-b'), '/tmp/plugin-b');
       const list = registry.list();
       expect(list).toHaveLength(2);
-      expect(list.find((p) => p.id === 'id-1')?.scope).toBe('local');
-      expect(list.find((p) => p.id === 'id-2')?.scope).toBe('global');
+      expect(list.find((p) => p.id === 'id-1')).toBeDefined();
+      expect(list.find((p) => p.id === 'id-2')).toBeDefined();
     });
   });
 
-  describe('clearLocalPlugins', () => {
-    it('removes all local plugins and keeps global plugins', () => {
-      registry.register(makeSpec('local-1', 'local-a'), '/tmp/local-a', 'local');
-      registry.register(makeSpec('local-2', 'local-b'), '/tmp/local-b', 'local');
-      registry.register(makeSpec('global-1', 'global-a'), '/tmp/global-a', 'global');
+  describe('clearPlugins', () => {
+    it('removes all plugins', () => {
+      registry.register(makeSpec('id-1', 'plugin-a'), '/tmp/plugin-a');
+      registry.register(makeSpec('id-2', 'plugin-b'), '/tmp/plugin-b');
 
-      registry.clearLocalPlugins();
+      registry.clearPlugins();
 
-      const list = registry.list();
-      expect(list).toHaveLength(1);
-      expect(list[0].id).toBe('global-1');
-      expect(list[0].scope).toBe('global');
-    });
-
-    it('is a no-op when there are no local plugins', () => {
-      registry.register(makeSpec('global-1', 'global-a'), '/tmp/global-a', 'global');
-      expect(() => registry.clearLocalPlugins()).not.toThrow();
-      expect(registry.list()).toHaveLength(1);
-    });
-
-    it('is a no-op on an empty registry', () => {
-      expect(() => registry.clearLocalPlugins()).not.toThrow();
       expect(registry.list()).toHaveLength(0);
     });
 
-    it('allows re-registering local plugins after clearing', () => {
-      registry.register(makeSpec('local-1', 'local-a'), '/tmp/local-a', 'local');
-      registry.clearLocalPlugins();
-      registry.register(makeSpec('local-1', 'local-a'), '/tmp/local-a', 'local');
-      expect(registry.list()).toHaveLength(1);
-      expect(registry.list()[0].scope).toBe('local');
+    it('is a no-op on an empty registry', () => {
+      expect(() => registry.clearPlugins()).not.toThrow();
+      expect(registry.list()).toHaveLength(0);
     });
 
-    it('does not affect active status of global plugins', () => {
-      registry.register(makeSpec('local-1', 'local-a'), '/tmp/local-a', 'local');
-      registry.register(makeSpec('global-1', 'global-a'), '/tmp/global-a', 'global');
-
-      registry.clearLocalPlugins();
-
-      const global = registry.list().find((p) => p.id === 'global-1');
-      expect(global).toBeDefined();
-      expect(global?.active).toBe(false);
+    it('allows re-registering plugins after clearing', () => {
+      registry.register(makeSpec('id-1', 'plugin-a'), '/tmp/plugin-a');
+      registry.clearPlugins();
+      registry.register(makeSpec('id-1', 'plugin-a'), '/tmp/plugin-a');
+      expect(registry.list()).toHaveLength(1);
     });
   });
 
   describe('unregister', () => {
     it('removes a plugin by id', () => {
-      registry.register(makeSpec('id-1', 'plugin-a'), '/tmp/plugin-a', 'local');
+      registry.register(makeSpec('id-1', 'plugin-a'), '/tmp/plugin-a');
       registry.unregister('id-1');
       expect(registry.list()).toHaveLength(0);
     });


### PR DESCRIPTION
## Summary
- Remove global plugin scope entirely — plugins are now workspace-local only (`.aide/plugins`)
- Eliminate `.mcp.json` generation at project root so AIDE never creates files outside `.aide/`
- Add migration logic to auto-clean AIDE entries from existing `.mcp.json` on workspace open
- Remove duplicate pane header below tab bar for vertical space savings

## Changes (13 files, +206 -340)

### Global scope removal
- `server.js`: Remove `GLOBAL_PLUGINS_DIR`, `scope` param, `AIDE_PLUGINS_DIR` env read
- `config-writer.ts`: Remove `.mcp.json` write and `AIDE_GLOBAL_PLUGINS_DIR` env from all agent configs
- `plugin-handlers.ts`: Remove `getGlobalPluginsDir()`, global watchers, scope params
- `registry.ts`: Remove `scope` field, rename `clearLocalPlugins` → `clearPlugins`
- `protocol.ts`: Remove global dir from `findPluginHtml()` lookup
- `index.ts`: Remove global plugins dir creation on startup
- `ipc.ts`: Remove `PluginInfo.scope` field
- `PluginPanel.tsx`: Replace Local/Global sections with single flat list

### Migration
- `workspace-handlers.ts`: On `WORKSPACE_OPEN`, detect and clean AIDE entries from `.mcp.json`
  - AIDE-only file → delete entirely
  - AIDE + other servers → remove aide key, preserve rest
  - Corrupt/unreadable → leave as-is

### UI cleanup
- `PaneView.tsx`: Remove redundant 28px pane header
- `SplitContainer.tsx`: Remove `showHeader` prop and `countPanes` helper

## Test plan
- [x] `pnpm lint` — no new errors
- [x] `pnpm test` — 119/119 pass (10 files)
- [x] Migration unit tests: 7 cases covering all edge cases
- [ ] `pnpm start` → verify flat plugin list, no `.mcp.json` at root
- [ ] Existing `.mcp.json` with aide entry → auto-cleaned on workspace open

🤖 Generated with [Claude Code](https://claude.com/claude-code)