### PR TITLE
chore: bump version to 0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aide",
   "productName": "AIDE",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "AI-Driven IDE - Create n Play plugins with natural language",
   "main": ".vite/build/index.js",
   "private": true,


### PR DESCRIPTION
## Summary

Syncs the v0.0.6 version bump from `release/0.0.6` back into `develop` per GitFlow. Pairs with the release PR targeting `main`.

## Changes
- `package.json`: 0.0.5 → 0.0.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)