### PR TITLE
ci(release): verify native modules before publishing assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,33 @@ jobs:
       - name: Build DMG
         run: sh ./build.sh
 
+      - name: Verify native modules in build artifacts
+        run: |
+          set -e
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "arm64" ]; then
+            APP_DIR="out/AIDE-darwin-arm64/AIDE.app"
+          else
+            APP_DIR="out/AIDE-darwin-x64/AIDE.app"
+          fi
+          PTY_PATH="$APP_DIR/Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/pty.node"
+
+          echo "--- app.asar.unpacked contents ---"
+          ls -la "$APP_DIR/Contents/Resources/app.asar.unpacked/" || true
+
+          if [ ! -f "$PTY_PATH" ]; then
+            echo "::error::Missing native module at $PTY_PATH"
+            echo "This would ship a broken app that cannot spawn terminals."
+            exit 1
+          fi
+          echo "pty.node verified: $PTY_PATH ($(stat -f%z "$PTY_PATH") bytes)"
+
+          if ! unzip -l out/AIDE.app.zip | grep -q "node-pty/build/Release/pty.node"; then
+            echo "::error::pty.node missing from out/AIDE.app.zip"
+            exit 1
+          fi
+          echo "pty.node verified in AIDE.app.zip"
+
       - name: Upload assets to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

v0.0.7's CI-built assets shipped with an empty \`app.asar.unpacked/\` — no \`pty.node\` — which broke terminal spawn for every auto-updated user (\`posix_spawnp failed (UNKNOWN)\`). Local builds from the same repo state produce the native module correctly, so something in the CI environment caused the \`afterCopy\` hook or \`asar.unpack\` glob to not populate the app bundle.

Until the root cause is diagnosed, we need a guardrail that prevents the release workflow from silently publishing broken artifacts.

## Change

Add a \`Verify native modules in build artifacts\` step between \`Build DMG\` and \`Upload assets to release\`. The step:

1. Resolves the arch-specific app directory (\`out/AIDE-darwin-arm64\` or \`out/AIDE-darwin-x64\`)
2. Checks \`Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/pty.node\` exists
3. Checks \`out/AIDE.app.zip\` contains the same path
4. If either check fails: prints \`::error::\`, lists the unpacked directory, and exits non-zero

Upload is the next step (\`--clobber\`), so on failure nothing gets uploaded and any locally-uploaded good artifacts remain untouched.

## Test plan
- [x] yaml syntax — plain shell block, no new action deps
- [ ] Simulate a bad build locally by deleting pty.node from \`out/AIDE-darwin-arm64/AIDE.app/Contents/Resources/app.asar.unpacked\` → run the step inline and confirm it fails
- [ ] Next release triggers the workflow — verify step passes on a healthy CI build

## Follow-ups (not in this PR)
- Diagnose why CI build produces empty \`app.asar.unpacked\` (architecture mismatch? pnpm store symlink? AutoUnpackNativesPlugin behaviour?)
- Consider extending verification to other runtime-critical paths (\`chokidar\`, \`electron-store\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)