### PR TITLE
ci(release): verify native modules before publishing assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,33 @@ jobs:
       - name: Build DMG
         run: sh ./build.sh
 
+      - name: Verify native modules in build artifacts
+        run: |
+          set -e
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "arm64" ]; then
+            APP_DIR="out/AIDE-darwin-arm64/AIDE.app"
+          else
+            APP_DIR="out/AIDE-darwin-x64/AIDE.app"
+          fi
+          PTY_PATH="$APP_DIR/Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/pty.node"
+
+          echo "--- app.asar.unpacked contents ---"
+          ls -la "$APP_DIR/Contents/Resources/app.asar.unpacked/" || true
+
+          if [ ! -f "$PTY_PATH" ]; then
+            echo "::error::Missing native module at $PTY_PATH"
+            echo "This would ship a broken app that cannot spawn terminals."
+            exit 1
+          fi
+          echo "pty.node verified: $PTY_PATH ($(stat -f%z "$PTY_PATH") bytes)"
+
+          if ! unzip -l out/AIDE.app.zip | grep -q "node-pty/build/Release/pty.node"; then
+            echo "::error::pty.node missing from out/AIDE.app.zip"
+            exit 1
+          fi
+          echo "pty.node verified in AIDE.app.zip"
+
       - name: Upload assets to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

v0.0.7 CI-built assets shipped with an empty \`app.asar.unpacked/\` — no \`pty.node\` — breaking terminal spawn for every auto-updated user (\`posix_spawnp failed (UNKNOWN)\`). Local builds were intact, so we clobber-uploaded the working artifacts, but the broken CI behaviour will recur on the next release unless the workflow on \`main\` (the branch \`release: published\` uses as \`target_commitish\`) carries the guardrail.

## Change

Same as #60 (targeting develop) — adds a pre-upload verification step that fails the job if \`pty.node\` is missing from the built \`AIDE.app\` or from \`AIDE.app.zip\`. On failure the \`--clobber\` upload never runs, so any good artifacts on the release stay put.

Paired PR: #60 (→ develop).

## Test plan
- [x] yaml syntax check (plain shell block, no new action deps)
- [ ] Next release triggers the workflow — verify the step runs and upload still works on a healthy build

🤖 Generated with [Claude Code](https://claude.com/claude-code)