### PR TITLE
hotfix: v0.0.8 — clear all xattrs on auto-installed app

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aide",
   "productName": "AIDE",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "AI-Driven IDE - Create n Play plugins with natural language",
   "main": ".vite/build/index.js",
   "private": true,

--- a/src/main/updater/check.ts
+++ b/src/main/updater/check.ts
@@ -171,6 +171,35 @@ export async function downloadUpdate(): Promise<{ ok: boolean; path?: string; er
 }
 
 /**
+ * Build the bash update script as a string. Exported for unit testing.
+ */
+export function buildUpdateScript(params: {
+  appPath: string;
+  newAppPath: string;
+  tmpDir: string;
+}): string {
+  const { appPath, newAppPath, tmpDir } = params;
+  return [
+    '#!/bin/bash',
+    'sleep 3',
+    // Remove quarantine on extracted app (legacy defense)
+    `xattr -rd com.apple.quarantine "${newAppPath}" 2>/dev/null || true`,
+    // Try direct replacement first; escalate to admin dialog if needed
+    `if rm -rf "${appPath}" 2>/dev/null && cp -R "${newAppPath}" "${appPath}" 2>/dev/null; then`,
+    '  echo "Replaced directly"',
+    'else',
+    `  osascript -e "do shell script \\"rm -rf '${appPath}' && cp -R '${newAppPath}' '${appPath}'\\" with administrator privileges" 2>/dev/null`,
+    'fi',
+    // Clear ALL extended attributes on the installed app — defends against
+    // quarantine/provenance/other xattrs interfering with hardened runtime.
+    `xattr -cr "${appPath}" 2>/dev/null || true`,
+    // Clean up temp directory and relaunch
+    `rm -rf "${tmpDir}"`,
+    `open "${appPath}"`,
+  ].join('\n');
+}
+
+/**
  * Download .app.zip, extract it, spawn a detached shell script that waits for
  * the app to quit then replaces the .app bundle and relaunches.
  * Falls back to downloadUpdate() if no zip asset is present.
@@ -216,21 +245,7 @@ export async function installUpdate(): Promise<{ ok: boolean; error?: string }> 
 
     // 4. Write the update shell script
     const scriptPath = path.join(tmpDir, 'update.sh');
-    const script = [
-      '#!/bin/bash',
-      'sleep 3',
-      // Remove quarantine so macOS Gatekeeper doesn't block the replaced app
-      `xattr -rd com.apple.quarantine "${newAppPath}" 2>/dev/null || true`,
-      // Try direct replacement first; escalate to admin dialog if needed
-      `if rm -rf "${appPath}" 2>/dev/null && cp -R "${newAppPath}" "${appPath}" 2>/dev/null; then`,
-      '  echo "Replaced directly"',
-      'else',
-      `  osascript -e "do shell script \\"rm -rf '${appPath}' && cp -R '${newAppPath}' '${appPath}'\\" with administrator privileges" 2>/dev/null`,
-      'fi',
-      // Clean up temp directory and relaunch
-      `rm -rf "${tmpDir}"`,
-      `open "${appPath}"`,
-    ].join('\n');
+    const script = buildUpdateScript({ appPath, newAppPath, tmpDir });
 
     fs.writeFileSync(scriptPath, script, { mode: 0o755 });
 

--- a/tests/unit/update-script.test.ts
+++ b/tests/unit/update-script.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { buildUpdateScript } from '../../src/main/updater/check';
+
+const BASE_PARAMS = {
+  appPath: '/Applications/AIDE.app',
+  newAppPath: '/tmp/aide-update-123/AIDE.app',
+  tmpDir: '/tmp/aide-update-123',
+};
+
+describe('buildUpdateScript', () => {
+  it('starts with #!/bin/bash', () => {
+    const script = buildUpdateScript(BASE_PARAMS);
+    expect(script.startsWith('#!/bin/bash')).toBe(true);
+  });
+
+  it('contains sleep 3', () => {
+    const script = buildUpdateScript(BASE_PARAMS);
+    expect(script).toContain('sleep 3');
+  });
+
+  it('removes quarantine on newAppPath before cp -R', () => {
+    const script = buildUpdateScript(BASE_PARAMS);
+    const quarantineIdx = script.indexOf(
+      `xattr -rd com.apple.quarantine "${BASE_PARAMS.newAppPath}"`,
+    );
+    const cpIdx = script.indexOf(`cp -R "${BASE_PARAMS.newAppPath}" "${BASE_PARAMS.appPath}"`);
+    expect(quarantineIdx).toBeGreaterThan(-1);
+    expect(cpIdx).toBeGreaterThan(-1);
+    expect(quarantineIdx).toBeLessThan(cpIdx);
+  });
+
+  it('clears all xattrs on appPath after cp -R and before rm -rf tmpDir', () => {
+    const script = buildUpdateScript(BASE_PARAMS);
+    const cpIdx = script.indexOf(`cp -R "${BASE_PARAMS.newAppPath}" "${BASE_PARAMS.appPath}"`);
+    const xattrCrIdx = script.indexOf(`xattr -cr "${BASE_PARAMS.appPath}"`);
+    const rmIdx = script.indexOf(`rm -rf "${BASE_PARAMS.tmpDir}"`);
+    expect(xattrCrIdx).toBeGreaterThan(-1);
+    expect(xattrCrIdx).toBeGreaterThan(cpIdx);
+    expect(xattrCrIdx).toBeLessThan(rmIdx);
+  });
+
+  it('contains rm -rf tmpDir with the correct path', () => {
+    const script = buildUpdateScript(BASE_PARAMS);
+    expect(script).toContain(`rm -rf "${BASE_PARAMS.tmpDir}"`);
+  });
+
+  it('contains cp -R with correct paths', () => {
+    const script = buildUpdateScript(BASE_PARAMS);
+    expect(script).toContain(
+      `cp -R "${BASE_PARAMS.newAppPath}" "${BASE_PARAMS.appPath}"`,
+    );
+  });
+
+  it('ends with open appPath as the last meaningful line', () => {
+    const script = buildUpdateScript(BASE_PARAMS);
+    const lines = script.split('\n').filter((l) => l.trim() !== '');
+    expect(lines[lines.length - 1]).toBe(`open "${BASE_PARAMS.appPath}"`);
+  });
+
+  it('handles paths with spaces', () => {
+    const params = {
+      appPath: '/Applications/My App.app',
+      newAppPath: '/tmp/aide-update-456/My App.app',
+      tmpDir: '/tmp/aide-update-456',
+    };
+    const script = buildUpdateScript(params);
+    expect(script).toContain(`"${params.appPath}"`);
+    expect(script).toContain(`"${params.newAppPath}"`);
+    expect(script).toContain(`xattr -cr "${params.appPath}"`);
+    expect(script).toContain(`open "${params.appPath}"`);
+  });
+});


### PR DESCRIPTION
## Why

Auto-update previously stripped only \`com.apple.quarantine\` from the extracted bundle before \`cp -R\`. Any other extended attribute that came down with the download (\`com.apple.provenance\`, etc.) remained on the installed \`/Applications/AIDE.app\`. If a future macOS policy change makes one of those attributes interact with Gatekeeper or hardened runtime to block child-process spawning, users would see silent terminal failures with no way to self-diagnose.

This matches the manual-install convention where users typically run \`xattr -c /Applications/AIDE.app\` once after drag-installing a DMG.

## Change

In \`installUpdate()\`, after the \`cp -R\`/osascript replacement block and before cleanup, run:

\`\`\`
xattr -cr "\${appPath}" 2>/dev/null || true
\`\`\`

Also extracted the bash script generation into a pure \`buildUpdateScript()\` export so the layout is unit-testable. 8 new tests (\`tests/unit/update-script.test.ts\`) pin the ordering: shebang → sleep → quarantine strip on the extracted app → replace (direct + admin fallback) → **xattr -cr on the installed app** → temp cleanup → \`open\`.

Not a regression fix for v0.0.7's pty.node-missing bug — that was the CI packaging issue (fixed by #60/#61). This is pure defense-in-depth for the attribute side of the auto-update path.

## Changes (3 files, +103 -16)
- \`src/main/updater/check.ts\` — \`buildUpdateScript()\` export + \`xattr -cr\` line
- \`tests/unit/update-script.test.ts\` (new, 8 tests)
- \`package.json\` — 0.0.7 → 0.0.8

## Test plan
- [x] \`pnpm test\` — 161/161 pass
- [x] \`pnpm lint\` — no new errors
- [ ] Install v0.0.8 via auto-update → \`xattr /Applications/AIDE.app\` should show no attributes (or only \`com.apple.provenance\` which macOS re-applies on launch)

## Related
- v0.0.7 hotfix: #58
- CI guardrail: #60, #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)