### PR TITLE
docs(ideation): add wnide rebranding analysis

### DIFF
--- a/docs/ideation/rebrand-wnide.md
+++ b/docs/ideation/rebrand-wnide.md
@@ -1,0 +1,200 @@
+---
+title: "AIDE → wnide 리브랜딩 아이데이션"
+category: ideation
+tags: [branding, naming, rebrand, wnide, trademark, namespace, provocative-branding]
+created: 2026-04-18
+updated: 2026-04-18
+related: [[rebrand-partide]], [[index]]
+---
+
+# AIDE → wnide 리브랜딩 아이데이션
+
+> 이 문서는 리브랜딩 아이데이션 기록이며, 실행 전 단계입니다.
+> `rebrand-partide.md` 와 동일한 포맷으로 작성되어, 두 후보를 1:1 비교할 수 있게 맞췄습니다.
+
+## 1. 요약 (Executive Summary)
+
+- 현재 브랜드 **"AIDE"** 가 Android IDE와 네이밍 충돌 → 리브랜딩 필요 (동일 배경).
+- 대체 후보: **wnide** — "**W**hy **N**eed **IDE**?" 의 이니셜리즘 / 수사적 질문 브랜드.
+- 서브 카피 후보:
+  - "Why need an IDE? Build your own."
+  - "The anti-IDE that assembles into one."
+- **권고 결론: 조건부 보류(Conditional Hold)** — 컨셉 임팩트는 강하나, 발음·부정 연상(whine) 리스크가 구조적. Partide 대비 우선순위 낮음.
+
+## 2. 리브랜딩 배경
+
+- Android IDE 와 네이밍 겹침 → SEO·사용자 혼동 (Partide 문서 §2 와 동일).
+- "Create n Play" 의 철학을 브랜드가 반영해야 함 — wnide 는 **"기성 IDE 가 왜 필요하냐"** 는 수사적 도발로 이 철학을 **정면에서 선언**.
+- Partide 가 "조립된 결과물"(명사적) 을 말한다면, wnide 는 **"카테고리 자체에 대한 질문"**(동사적/선언적) 이라는 점이 차별점.
+
+## 3. 후보 탐색 여정 (Decision Log)
+
+Partide 문서 §3 탐색 결과에 wnide 만 추가. 동일 후보군 재평가는 생략.
+
+| 후보 | 컨셉 | 결론 | 이유 |
+|------|------|------|------|
+| (Partide 문서 §3 전 항목) | — | — | `rebrand-partide.md` 참조 |
+| **wnide** | "Why Need IDE?" 이니셜리즘 | **조건부 보류** | 컨셉 강력, 그러나 발음·부정 연상·철자 마찰 (§6) |
+
+## 4. wnide 브랜드 상세
+
+### 4.1 네이밍 구조
+
+- Product name: **wnide** (all-lowercase 권장 — `ripgrep`, `nvim`, `curl` 계열 언더그라운드 톤).
+- 대문자 표기 시: **WNIDE** (공식 문서/상표 등록용).
+- Domain handle 후보: **wnide.dev** (primary), `wnide.sh`, `wnide.app`, `whyneedide.com`.
+- **발음 문제** — 세 가지 해석이 가능:
+  1. **/waɪn-aɪd/** ("wine-eyed") — `w` + `nide` 로 분리, 가장 자연스러우나 "**whine**" 과 동음 → §6.
+  2. **/dʌbəl.juː.naɪd/** ("double-you-nide") — 이니셜리즘 방식, 길고 마케팅 부적합.
+  3. **/waɪ.niːd/** ("why-need") — 의도된 원래 의미, 그러나 철자로부터 자동 도출 불가.
+- 공식 발음을 **고정** 하지 않으면 브랜드 음성 인지도가 분산됨.
+
+### 4.2 의미 층위
+
+1. **표면 (이니셜리즘)**: **W**hy **N**eed **IDE**? — 기성 IDE 범주에 대한 도발적 질문.
+2. **철학적**: "IDE 가 필요 없다" 가 아니라 "**당신에게 맞는 IDE 를 당신이 조립한다**" 는 제품 철학의 슬로건화.
+3. **언더그라운드 톤**: `wnide` 의 자음 클러스터 `wn-` 은 영어에 거의 없음 → 검색 청정도 ↑, 그러나 타이핑·발음 마찰 ↑.
+4. **문법 주의**: 영어 원어민 기준 "Why Need IDE?" 는 관사 누락 비문. **"Why Need an IDE?"** 가 정문이며, 여기서 `a` 를 떨어뜨린 형태라는 점을 브랜드 스토리로 명시 필요.
+
+### 4.3 서사 (narrative arc)
+
+- IDE 는 기성품으로 제공되는 "완성된 환경" 이라는 전제를 가짐.
+- wnide 는 이 전제에 질문을 던짐: **"왜 누군가 조립해 놓은 IDE 가 필요한가?"**
+- 제품은 질문의 **답** 으로 기능: CLI 에이전트 + 플러그인 조립 = 개인에게 최적화된 환경.
+- Partide 의 "입자→원자" 화학 메타포와 달리, wnide 는 **수사학적 도발** 에 의존 — 서사 자원이 얇음.
+
+### 4.4 태그라인 후보
+
+- A: "Why need an IDE? Build your own."
+- B: "The anti-IDE that assembles into one."
+- C: "wnide — because your IDE should be yours."
+- D: "Start from zero. Compose upward."
+- **권장**: **A** — 브랜드명의 의문문 형식을 직접 해소, 발음 혼란을 문장이 교정.
+
+## 5. 네임스페이스 Audit 결과 (추정)
+
+> ⚠️ **정식 조회 전 추정치**. Partide 문서 §5 와 달리 실시간 DB 확인 미완.
+
+### 5.1 낙관적 예측
+
+- **도메인**: `wnide.dev`, `.sh`, `.app` — 5글자 자음 클러스터 (`wn`) 의 희소성상 99% 미선점 예상.
+- **npm**: `wnide`, `@wnide/core` — 거의 확실히 미선점.
+- **GitHub**: `github.com/wnide` — 거의 확실히 미선점.
+- **USPTO TESS**: `WNIDE` — 조어이자 발음 난해 → 0건 예상.
+
+### 5.2 주의 항목
+
+- **"whine"** 과 글자 거리 1 (`wh` vs `w`) → 오타·검색 오인식 시 부정적 페이지로 귀착.
+- **"Wnide"** 를 자동완성·스펠체크가 "**wide**", "**whine**", "**winded**" 로 교정하는 빈도 모니터링 필요.
+
+## 6. ⚠️ 치명적 주의사항 — 발음·부정 연상 리스크
+
+wnide 의 구조적 약점 3종. Partide 의 Particle Industries 리스크가 **외부 상표 충돌** 이었다면, wnide 의 리스크는 **내재적 언어 리스크**.
+
+### 6.1 "Whine" 동음 문제
+
+- 발음 /waɪn/ 은 영어에서 "whine"(투덜대다·칭얼대다·불평하다) 과 동음이의어.
+- 개발자 도구 브랜드가 "불평 도구" 로 들리는 것은 **제품 포지셔닝 정반대**.
+- 마케팅 영상·팟캐스트·컨퍼런스 발음 시 매번 설명 각주가 붙음.
+- Partide 가 스페인어 "partido" 와 겹치는 수준(§5.2) 보다 **훨씬 심각** — partido 는 "정당/경기" 중립·긍정어, whine 은 부정어.
+
+### 6.2 철자-발음 불일치
+
+- 영어 원어민은 `wn-` 자음 클러스터를 자연 발음할 수 없음 (영어에 존재하지 않는 onset).
+- 결과:
+  - 구두 전달 실패 ("스펠 불러줘")
+  - 도메인 구술 공유 난항
+  - 한국어권 "우나이드" vs "워나이드" vs "더블유-나이드" 분열
+
+### 6.3 이니셜리즘 피로
+
+- "Why Need IDE?" 의 이니셜리즘은 **백크로님 느낌** — 이름을 먼저 정하고 의미를 후붙인 것으로 보일 수 있음.
+- 영문법상 "Why Need an IDE?" 가 정문 → `a` 탈락이 억지로 보임.
+- 기술 업계에서 이니셜리즘 백크로님은 신뢰도 ↓ (예: 과거 YACC = "Yet Another Compiler Compiler" 셀프디스형과 반대 방향).
+
+**결론**:
+
+- ❌ 공식 제품명으로 쓰려면 **공식 발음 가이드 + "not whine" 디스클레이머** 가 필수.
+- ❌ 음성 미디어(팟캐스트·유튜브·컨퍼런스) 비중이 큰 마케팅 전략과 상성 나쁨.
+- ✅ 개발자 내부 밈·서브브랜드·CLI 커맨드명(`wnide init`) 으로는 매력적.
+- ✅ 정식 제품명을 Partide 로 확정하고, wnide 는 **창립 철학 슬로건** 혹은 **CLI 도구명** 으로 분리 운영 가능.
+
+## 7. 실행 체크리스트 (Not Yet)
+
+Partide 체크리스트와 동일 구조. wnide 채택 시 변경되는 값만 표기.
+
+### Phase A: 네임스페이스 선점
+
+- [ ] `wnide.dev` 등록
+- [ ] `wnide.sh` 등록
+- [ ] `wnide.app` 등록
+- [ ] `whyneedide.com` 등록 (풀네임 보험)
+- [ ] npm `wnide` 예약
+- [ ] npm `@wnide` 스코프 점유
+- [ ] `github.com/wnide` org 생성
+
+### Phase B: 법률
+
+- [ ] 변리사 선임
+- [ ] USPTO TESS 전문 조회 — `WNIDE` Class 9 / 42
+- [ ] KIPO 상표 검색
+- [ ] "whine" 계열 기존 상표와의 음성 유사도 리스크 평가
+- [ ] 위험 평가 보고서 수령
+
+### Phase C: 브랜드 에셋
+
+- [ ] 로고 디자인 (의문부호 `?` 활용 시안 포함)
+- [ ] **발음 가이드 페이지 필수** — `/waɪ.niːd/` (공식) + 음성 샘플
+- [ ] 컬러 팔레트
+- [ ] 아이콘 — macOS `.icns`, Windows `.ico`
+- [ ] "Why Need an IDE?" 풀네임 워드마크 병행 디자인
+
+### Phase D: 코드 마이그레이션
+
+- [ ] `package.json`: `name: "wnide"`, `productName: "wnide"`
+- [ ] `forge.config.ts`
+- [ ] `Info.plist`
+- [ ] IPC 프로토콜: `aide://` → `wnide://` (소문자 관례와 일치)
+- [ ] 환경변수: `AIDE_*` → `WNIDE_*`
+- [ ] 에러·로그 프리픽스 `[AIDE]` → `[wnide]`
+
+### Phase E: 문서 교체
+
+- Partide 와 동일 (§E) — 페이지마다 "formerly AIDE" 병기.
+
+### Phase F: 배포 전환
+
+- Partide 와 동일 — v0.1.0 부터 wnide.
+
+## 8. Partide vs wnide 비교 (의사결정 보조)
+
+| 축 | Partide | wnide |
+|---|---|---|
+| 네이밍 유형 | 블렌드 조어 (particle+IDE) | 이니셜리즘 (Why Need IDE?) |
+| 발음 명확성 | 높음 (PAR-tide, "-ide" 패턴 자연) | **낮음** (wn- 클러스터) |
+| 부정 연상 | "partido"(중립) | **"whine"(부정)** |
+| 의미 전달 속도 | 중간 (블렌드 해석 필요) | **낮음** (백크로님 해석 필요) |
+| 철학 전달력 | 중간 (조립 메타포) | **높음** (카테고리 도발) |
+| 상표 리스크 | 낮음 (Particle 은 별개 회사로 회피 가능) | **낮음** (조어) |
+| 음성 마케팅 | 유리 | **불리** |
+| 개발자 커뮤니티 톤 | 중립 | **강한 언더그라운드 매력** |
+| 국제화 (한·영·일) | 안정 | 한국어 표기 분열 가능 (우나이드/와나이드) |
+| 전체 권고 | **1순위** | **슬로건·CLI명으로 분리 운영 검토** |
+
+## 9. 의사결정 권고
+
+1. **제품명 정면 후보로서 wnide 단독 채택은 비권장** — §6 리스크가 구조적.
+2. **이중 운영(Dual-use) 제안**:
+   - Product name: **Partide** (공식, 마케팅, 상표, 스토어 등록)
+   - Tagline / Manifesto: **"Why need an IDE?"** — 랜딩 hero copy 혹은 철학 문서 제목
+   - CLI 커맨드: 필요 시 `partide` (정식) + `wnide` (별칭) 동시 지원 검토.
+3. Partide 가 법률 검토에서 블록될 경우, wnide 는 **fallback 후보군에 편입** 하되 §6 리스크를 감수할지 재평가 필요.
+
+## 10. 타임라인 제안
+
+- wnide 단독 채택 시: Partide 타임라인에 **+2주** (발음 가이드·브랜드 보이스 튜닝).
+- 이중 운영 채택 시: Partide 타임라인 유지, wnide 는 마케팅 Phase 에서 슬로건으로만 사용.
+
+## 11. 결론
+
+wnide 는 **메시지는 강하지만 매개체(이름)가 약하다**. 제품 철학을 카피(copy) 레벨에서 드러내는 도구로는 탁월하나, 브랜드 그 자체로서는 발음·연상·백크로님 3중 마찰로 시장 진입 비용이 높다. 현시점 권고는 **Partide = 이름, "Why need an IDE?" = 철학** 의 역할 분담.


### PR DESCRIPTION
Analyzes "wnide" (Why Need IDE?) as an alternative rebrand candidate in the
same structure as rebrand-partide.md. Concludes conditional hold due to
pronunciation ambiguity and "whine" negative association; recommends using
the phrase as a philosophy tagline rather than the product name.