### PR TITLE
feat(ui): workspace path front-truncation + hover tooltip

### DIFF
--- a/src/renderer/components/ui/Tooltip.tsx
+++ b/src/renderer/components/ui/Tooltip.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState, useId } from 'react';
+
+interface TooltipProps {
+  content: React.ReactNode;
+  children: React.ReactNode;
+  placement?: 'top' | 'bottom' | 'right';
+  className?: string;
+}
+
+export function Tooltip({ content, children, placement = 'top', className }: TooltipProps) {
+  const [visible, setVisible] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const tooltipId = useId();
+
+  function show() {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setVisible(true), 200);
+  }
+
+  function hide() {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = null;
+    setVisible(false);
+  }
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const placementClasses: Record<NonNullable<TooltipProps['placement']>, string> = {
+    top: 'bottom-full left-1/2 -translate-x-1/2 mb-1',
+    bottom: 'top-full left-1/2 -translate-x-1/2 mt-1',
+    right: 'left-full top-1/2 -translate-y-1/2 ml-1',
+  };
+
+  return (
+    <div
+      data-tooltip-wrapper
+      className={`relative inline-flex${className ? ` ${className}` : ''}`}
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+      aria-describedby={visible ? tooltipId : undefined}
+    >
+      {children}
+      {visible && (
+        <div
+          id={tooltipId}
+          role="tooltip"
+          className={`absolute z-50 whitespace-pre-wrap rounded px-2 py-1 text-[10px] font-mono
+            bg-aide-surface-elevated border border-aide-border text-aide-text-primary shadow-md
+            pointer-events-none ${placementClasses[placement]}`}
+        >
+          {content}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/components/ui/Tooltip.tsx
+++ b/src/renderer/components/ui/Tooltip.tsx
@@ -1,4 +1,16 @@
+/**
+ * Tooltip — renders via ReactDOM.createPortal into document.body to escape
+ * overflow:hidden / overflow:auto ancestors (e.g. the scrollable workspace list).
+ *
+ * Positioning uses position:fixed with coordinates read from
+ * wrapperRef.getBoundingClientRect() at the moment of show.
+ *
+ * Known limitation: tooltip width is assumed to fit within max-w-xs (20rem).
+ * No dimension measurement is performed — centering is best-effort.
+ * Viewport edge clamping is not implemented.
+ */
 import { useEffect, useRef, useState, useId } from 'react';
+import { createPortal } from 'react-dom';
 
 interface TooltipProps {
   content: React.ReactNode;
@@ -7,14 +19,47 @@ interface TooltipProps {
   className?: string;
 }
 
+const GAP = 6; // px between wrapper and tooltip
+
 export function Tooltip({ content, children, placement = 'top', className }: TooltipProps) {
   const [visible, setVisible] = useState(false);
+  const [coords, setCoords] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const tooltipId = useId();
+
+  function computeCoords(): { top: number; left: number } {
+    if (!wrapperRef.current) return { top: 0, left: 0 };
+    const rect = wrapperRef.current.getBoundingClientRect();
+    // Assume max-w-xs = 320px, height ~28px for centering purposes
+    const assumedWidth = 320;
+    const assumedHeight = 28;
+    switch (placement) {
+      case 'bottom':
+        return {
+          top: rect.bottom + GAP,
+          left: rect.left + rect.width / 2 - assumedWidth / 2,
+        };
+      case 'right':
+        return {
+          top: rect.top + rect.height / 2 - assumedHeight / 2,
+          left: rect.right + GAP,
+        };
+      case 'top':
+      default:
+        return {
+          top: rect.top - assumedHeight - GAP,
+          left: rect.left + rect.width / 2 - assumedWidth / 2,
+        };
+    }
+  }
 
   function show() {
     if (timerRef.current) clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => setVisible(true), 200);
+    timerRef.current = setTimeout(() => {
+      setCoords(computeCoords());
+      setVisible(true);
+    }, 200);
   }
 
   function hide() {
@@ -29,34 +74,38 @@ export function Tooltip({ content, children, placement = 'top', className }: Too
     };
   }, []);
 
-  const placementClasses: Record<NonNullable<TooltipProps['placement']>, string> = {
-    top: 'bottom-full left-1/2 -translate-x-1/2 mb-1',
-    bottom: 'top-full left-1/2 -translate-x-1/2 mt-1',
-    right: 'left-full top-1/2 -translate-y-1/2 ml-1',
-  };
+  const tooltip = visible
+    ? createPortal(
+        <div
+          id={tooltipId}
+          role="tooltip"
+          style={{ top: coords.top, left: coords.left }}
+          className="fixed z-[9999] max-w-xs whitespace-pre-wrap rounded px-2 py-1 text-[10px] font-mono
+            bg-aide-surface-elevated border border-aide-border text-aide-text-primary shadow-md
+            pointer-events-none"
+        >
+          {content}
+        </div>,
+        document.body,
+      )
+    : null;
 
   return (
     <div
+      ref={wrapperRef}
       data-tooltip-wrapper
       className={`relative inline-flex${className ? ` ${className}` : ''}`}
       onMouseEnter={show}
       onMouseLeave={hide}
       onFocus={show}
       onBlur={hide}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') hide();
+      }}
       aria-describedby={visible ? tooltipId : undefined}
     >
       {children}
-      {visible && (
-        <div
-          id={tooltipId}
-          role="tooltip"
-          className={`absolute z-50 whitespace-pre-wrap rounded px-2 py-1 text-[10px] font-mono
-            bg-aide-surface-elevated border border-aide-border text-aide-text-primary shadow-md
-            pointer-events-none ${placementClasses[placement]}`}
-        >
-          {content}
-        </div>
-      )}
+      {tooltip}
     </div>
   );
 }

--- a/src/renderer/components/workspace/WorkspaceNav.tsx
+++ b/src/renderer/components/workspace/WorkspaceNav.tsx
@@ -5,6 +5,7 @@ import { useTerminalStore } from '../../stores/terminal-store';
 import { useLayoutStore } from '../../stores/layout-store';
 import { isSplitLayout, type AgentStatus, type LayoutNode, type TerminalTab } from '../../../types/ipc';
 import { StatusDot, StatusBadge } from './StatusIndicator';
+import { Tooltip } from '../ui/Tooltip';
 import { UpdateNotice } from '../updater/UpdateNotice';
 import { AgentDropdown } from '../terminal/AgentDropdown';
 
@@ -222,6 +223,7 @@ export function WorkspaceNav() {
                     >
                       {ws.name[0]?.toUpperCase() ?? '?'}
                     </span>
+                    <Tooltip content={`${ws.name}\n${ws.path}`} placement="right" className="flex-1 min-w-0">
                     <div className="flex flex-col flex-1 min-w-0">
                       {editingWorkspaceId === ws.id ? (
                         <input
@@ -239,8 +241,11 @@ export function WorkspaceNav() {
                       ) : (
                         <span className="text-xs font-mono text-aide-text-primary truncate">{ws.name}</span>
                       )}
-                      <span className="text-[10px] font-mono text-aide-text-tertiary truncate">{ws.path}</span>
+                      <span dir="rtl" className="text-[10px] font-mono text-aide-text-tertiary truncate inline-block w-full text-left">
+                        <span dir="ltr">{ws.path}</span>
+                      </span>
                     </div>
+                    </Tooltip>
                     {/* Tab count */}
                     <span className="text-[10px] font-mono text-aide-text-tertiary shrink-0">
                       ({wsTabs.length})

--- a/src/renderer/components/workspace/WorkspaceNav.tsx
+++ b/src/renderer/components/workspace/WorkspaceNav.tsx
@@ -241,6 +241,7 @@ export function WorkspaceNav() {
                       ) : (
                         <span className="text-xs font-mono text-aide-text-primary truncate">{ws.name}</span>
                       )}
+                      {/* dir="rtl" + inner dir="ltr" front-truncates long paths so the tail (last segment) stays visible */}
                       <span dir="rtl" className="text-[10px] font-mono text-aide-text-tertiary truncate inline-block w-full text-left">
                         <span dir="ltr">{ws.path}</span>
                       </span>

--- a/tests/unit/tooltip.test.tsx
+++ b/tests/unit/tooltip.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
+import { render, cleanup, act, fireEvent } from '@testing-library/react';
+import { Tooltip } from '../../src/renderer/components/ui/Tooltip';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('Tooltip', () => {
+  it('renders children always', () => {
+    const { getByText } = render(
+      <Tooltip content="tip text">
+        <button>child</button>
+      </Tooltip>
+    );
+    expect(getByText('child')).toBeTruthy();
+  });
+
+  it('tooltip is not in DOM initially', () => {
+    const { queryByRole } = render(
+      <Tooltip content="tip text">
+        <button>child</button>
+      </Tooltip>
+    );
+    expect(queryByRole('tooltip')).toBeNull();
+  });
+
+  it('shows tooltip with content after mouseenter + delay', async () => {
+    const { getByText, queryByRole } = render(
+      <Tooltip content="tip text">
+        <button>child</button>
+      </Tooltip>
+    );
+    const wrapper = getByText('child').closest('[data-tooltip-wrapper]') as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    // before delay: still hidden
+    expect(queryByRole('tooltip')).toBeNull();
+    // advance past 200ms delay
+    act(() => { vi.advanceTimersByTime(250); });
+    expect(queryByRole('tooltip')).toBeTruthy();
+    expect(queryByRole('tooltip')?.textContent).toBe('tip text');
+  });
+
+  it('hides tooltip after mouseleave', async () => {
+    const { getByText, queryByRole } = render(
+      <Tooltip content="tip text">
+        <button>child</button>
+      </Tooltip>
+    );
+    const wrapper = getByText('child').closest('[data-tooltip-wrapper]') as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    act(() => { vi.advanceTimersByTime(250); });
+    expect(queryByRole('tooltip')).toBeTruthy();
+
+    fireEvent.mouseLeave(wrapper);
+    expect(queryByRole('tooltip')).toBeNull();
+  });
+
+  it('shows tooltip on focus (keyboard a11y)', () => {
+    const { getByText, queryByRole } = render(
+      <Tooltip content="focus tip">
+        <button>child</button>
+      </Tooltip>
+    );
+    const wrapper = getByText('child').closest('[data-tooltip-wrapper]') as HTMLElement;
+    fireEvent.focus(wrapper);
+    act(() => { vi.advanceTimersByTime(250); });
+    expect(queryByRole('tooltip')).toBeTruthy();
+  });
+
+  it('hides tooltip on blur', () => {
+    const { getByText, queryByRole } = render(
+      <Tooltip content="focus tip">
+        <button>child</button>
+      </Tooltip>
+    );
+    const wrapper = getByText('child').closest('[data-tooltip-wrapper]') as HTMLElement;
+    fireEvent.focus(wrapper);
+    act(() => { vi.advanceTimersByTime(250); });
+    expect(queryByRole('tooltip')).toBeTruthy();
+
+    fireEvent.blur(wrapper);
+    expect(queryByRole('tooltip')).toBeNull();
+  });
+
+  it('sets aria-describedby on wrapper pointing to tooltip when open', () => {
+    const { getByText } = render(
+      <Tooltip content="aria tip">
+        <button>child</button>
+      </Tooltip>
+    );
+    const wrapper = getByText('child').closest('[data-tooltip-wrapper]') as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    act(() => { vi.advanceTimersByTime(250); });
+    const tooltipEl = wrapper.querySelector('[role="tooltip"]') as HTMLElement;
+    expect(tooltipEl).toBeTruthy();
+    expect(wrapper.getAttribute('aria-describedby')).toBe(tooltipEl.id);
+  });
+});

--- a/tests/unit/tooltip.test.tsx
+++ b/tests/unit/tooltip.test.tsx
@@ -89,7 +89,7 @@ describe('Tooltip', () => {
   });
 
   it('sets aria-describedby on wrapper pointing to tooltip when open', () => {
-    const { getByText } = render(
+    const { getByText, queryByRole } = render(
       <Tooltip content="aria tip">
         <button>child</button>
       </Tooltip>
@@ -97,8 +97,41 @@ describe('Tooltip', () => {
     const wrapper = getByText('child').closest('[data-tooltip-wrapper]') as HTMLElement;
     fireEvent.mouseEnter(wrapper);
     act(() => { vi.advanceTimersByTime(250); });
-    const tooltipEl = wrapper.querySelector('[role="tooltip"]') as HTMLElement;
+    // Tooltip is portal-rendered into document.body — use queryByRole which searches full document
+    const tooltipEl = queryByRole('tooltip') as HTMLElement;
     expect(tooltipEl).toBeTruthy();
     expect(wrapper.getAttribute('aria-describedby')).toBe(tooltipEl.id);
+  });
+
+  it('cancels pending show when mouse leaves before delay', () => {
+    const { getByText, queryByRole } = render(
+      <Tooltip content="hi"><button>x</button></Tooltip>
+    );
+    const trigger = getByText('x').closest('[data-tooltip-wrapper]') as HTMLElement;
+    fireEvent.mouseEnter(trigger);
+    fireEvent.mouseLeave(trigger);
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(queryByRole('tooltip')).toBeNull();
+  });
+
+  it('clears pending timer on unmount', () => {
+    const { getByText, unmount } = render(
+      <Tooltip content="hi"><button>x</button></Tooltip>
+    );
+    fireEvent.mouseEnter(getByText('x').closest('[data-tooltip-wrapper]') as HTMLElement);
+    unmount();
+    expect(() => { act(() => { vi.advanceTimersByTime(500); }); }).not.toThrow();
+  });
+
+  it('dismisses tooltip on ESC keydown', () => {
+    const { getByText, queryByRole } = render(
+      <Tooltip content="hi"><button>x</button></Tooltip>
+    );
+    const wrapper = getByText('x').closest('[data-tooltip-wrapper]') as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    act(() => { vi.advanceTimersByTime(250); });
+    expect(queryByRole('tooltip')).not.toBeNull();
+    fireEvent.keyDown(wrapper, { key: 'Escape' });
+    expect(queryByRole('tooltip')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- 워크스페이스 경로 truncation 방향을 끝→앞으로 전환 (`/Users/.../aide` → `…/repositories/aide`)
- hover 시 전체 name + path 를 보여주는 자체 `<Tooltip>` 컴포넌트 신규 추가 (Tailwind only, 외부 라이브러리 없음)
- 키보드 포커스에서도 tooltip 표시 + `role="tooltip"` 접근성 처리

## Test plan
- [x] `pnpm lint` (no new errors)
- [x] `pnpm test` (Tooltip 회귀 테스트 포함 전체 통과)
- [ ] reviewer: `pnpm start` 후 워크스페이스 행 hover 시 풀 경로 툴팁 + 경로 앞부분이 `…` 으로 잘리는지 확인

Closes kanban task task_pch4mwec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)