### PR TITLE
fix(tabs): swap native title for Tooltip component on hover

### DIFF
--- a/src/renderer/components/layout/PaneView.tsx
+++ b/src/renderer/components/layout/PaneView.tsx
@@ -10,6 +10,7 @@ import { useLayoutStore } from '../../stores/layout-store';
 import { useTerminalStore } from '../../stores/terminal-store';
 import * as xtermCache from '../../lib/xterm-cache';
 import type { Pane, TerminalTab } from '../../../types/ipc';
+import { Tooltip } from '../ui/Tooltip';
 
 const AGENT_COLORS: Record<string, string> = {
   claude: 'var(--agent-claude)',
@@ -103,7 +104,9 @@ function DraggableTab({ tab, paneId, isActive, onActivate, onClose, onContextMen
             className="bg-transparent outline-none border-b border-aide-accent text-[12px] font-mono min-w-0 w-24"
           />
         ) : (
-          <span className="truncate min-w-0 flex-1" title={tab.title}>{tab.title}</span>
+          <Tooltip content={tab.title} placement="bottom" className="min-w-0 flex-1">
+            <span className="truncate block w-full text-left">{tab.title}</span>
+          </Tooltip>
         )}
         {canClose && !isEditing && (
           <span

--- a/src/renderer/components/terminal/TabBar.tsx
+++ b/src/renderer/components/terminal/TabBar.tsx
@@ -1,5 +1,6 @@
 import { useTerminalStore } from '../../stores/terminal-store';
 import { AgentDropdown } from './AgentDropdown';
+import { Tooltip } from '../ui/Tooltip';
 
 const AGENT_COLORS: Record<string, string> = {
   claude: 'var(--agent-claude)',
@@ -45,7 +46,9 @@ export function TabBar() {
               className="w-1.5 h-1.5 rounded-full shrink-0"
               style={{ backgroundColor: dotColor }}
             />
-            <span className="truncate min-w-0 flex-1" title={tab.title}>{tab.title}</span>
+            <Tooltip content={tab.title} placement="bottom" className="min-w-0 flex-1">
+              <span className="truncate block w-full text-left">{tab.title}</span>
+            </Tooltip>
             {/* Close button on hover */}
             {tabs.length > 1 && (
               <span

--- a/src/renderer/components/ui/Tooltip.tsx
+++ b/src/renderer/components/ui/Tooltip.tsx
@@ -3,11 +3,12 @@
  * overflow:hidden / overflow:auto ancestors (e.g. the scrollable workspace list).
  *
  * Positioning uses position:fixed with coordinates read from
- * wrapperRef.getBoundingClientRect() at the moment of show.
+ * wrapperRef.getBoundingClientRect() at the moment of show. Centering is
+ * done via CSS transform translate(-50%, ...), so actual tooltip dimensions
+ * do not need to be measured.
  *
- * Known limitation: tooltip width is assumed to fit within max-w-xs (20rem).
- * No dimension measurement is performed — centering is best-effort.
- * Viewport edge clamping is not implemented.
+ * Known limitation: Viewport edge clamping is not implemented — tooltips
+ * near the viewport edge may overflow horizontally.
  */
 import { useEffect, useRef, useState, useId } from 'react';
 import { createPortal } from 'react-dom';
@@ -28,31 +29,26 @@ export function Tooltip({ content, children, placement = 'top', className }: Too
   const wrapperRef = useRef<HTMLDivElement>(null);
   const tooltipId = useId();
 
+  // Anchor point — actual centering is done via CSS transform in the tooltip div
   function computeCoords(): { top: number; left: number } {
     if (!wrapperRef.current) return { top: 0, left: 0 };
     const rect = wrapperRef.current.getBoundingClientRect();
-    // Assume max-w-xs = 320px, height ~28px for centering purposes
-    const assumedWidth = 320;
-    const assumedHeight = 28;
     switch (placement) {
       case 'bottom':
-        return {
-          top: rect.bottom + GAP,
-          left: rect.left + rect.width / 2 - assumedWidth / 2,
-        };
+        return { top: rect.bottom + GAP, left: rect.left + rect.width / 2 };
       case 'right':
-        return {
-          top: rect.top + rect.height / 2 - assumedHeight / 2,
-          left: rect.right + GAP,
-        };
+        return { top: rect.top + rect.height / 2, left: rect.right + GAP };
       case 'top':
       default:
-        return {
-          top: rect.top - assumedHeight - GAP,
-          left: rect.left + rect.width / 2 - assumedWidth / 2,
-        };
+        return { top: rect.top - GAP, left: rect.left + rect.width / 2 };
     }
   }
+
+  const transformByPlacement: Record<NonNullable<TooltipProps['placement']>, string> = {
+    top: 'translate(-50%, -100%)',
+    bottom: 'translate(-50%, 0)',
+    right: 'translate(0, -50%)',
+  };
 
   function show() {
     if (timerRef.current) clearTimeout(timerRef.current);
@@ -79,7 +75,7 @@ export function Tooltip({ content, children, placement = 'top', className }: Too
         <div
           id={tooltipId}
           role="tooltip"
-          style={{ top: coords.top, left: coords.left }}
+          style={{ top: coords.top, left: coords.left, transform: transformByPlacement[placement] }}
           className="fixed z-[9999] max-w-xs whitespace-pre-wrap rounded px-2 py-1 text-[10px] font-mono
             bg-aide-surface-elevated border border-aide-border text-aide-text-primary shadow-md
             pointer-events-none"


### PR DESCRIPTION
## Summary
- Electron에서 네이티브 `title` 속성이 표시 지연/미표시 이슈가 있어, 기존 `Tooltip` 컴포넌트(WorkspaceNav에서 사용 중)로 교체
- `PaneView.tsx` DraggableTab + `TabBar.tsx` 양쪽 탭 제목 span 을 `<Tooltip content={tab.title} placement="bottom">` 로 래핑
- `min-w-0 flex-1` 을 Tooltip wrapper 로 이동해 기존 truncate/layout 유지

## Background
PR #70 에서 네이티브 `title` 로 시도했으나 실제 환경에서 툴팁이 안 뜨는 케이스가 있어 교체합니다.

## Test plan
- [ ] `pnpm test` 176/176 통과 (로컬 확인 완료)
- [ ] 좁은 pane에 긴 제목 탭 생성 → hover 시 200ms 뒤 전체 제목 표시
- [ ] 탭 드래그, 더블클릭 rename, 닫기 버튼 regression 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)