### PR TITLE
release: v0.0.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,33 @@ jobs:
       - name: Build DMG
         run: sh ./build.sh
 
+      - name: Verify native modules in build artifacts
+        run: |
+          set -e
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "arm64" ]; then
+            APP_DIR="out/AIDE-darwin-arm64/AIDE.app"
+          else
+            APP_DIR="out/AIDE-darwin-x64/AIDE.app"
+          fi
+          PTY_PATH="$APP_DIR/Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/pty.node"
+
+          echo "--- app.asar.unpacked contents ---"
+          ls -la "$APP_DIR/Contents/Resources/app.asar.unpacked/" || true
+
+          if [ ! -f "$PTY_PATH" ]; then
+            echo "::error::Missing native module at $PTY_PATH"
+            echo "This would ship a broken app that cannot spawn terminals."
+            exit 1
+          fi
+          echo "pty.node verified: $PTY_PATH ($(stat -f%z "$PTY_PATH") bytes)"
+
+          if ! unzip -l out/AIDE.app.zip | grep -q "node-pty/build/Release/pty.node"; then
+            echo "::error::pty.node missing from out/AIDE.app.zip"
+            exit 1
+          fi
+          echo "pty.node verified in AIDE.app.zip"
+
       - name: Upload assets to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/ideation/rebrand-wnide.md
+++ b/docs/ideation/rebrand-wnide.md
@@ -1,0 +1,200 @@
+---
+title: "AIDE → wnide 리브랜딩 아이데이션"
+category: ideation
+tags: [branding, naming, rebrand, wnide, trademark, namespace, provocative-branding]
+created: 2026-04-18
+updated: 2026-04-18
+related: [[rebrand-partide]], [[index]]
+---
+
+# AIDE → wnide 리브랜딩 아이데이션
+
+> 이 문서는 리브랜딩 아이데이션 기록이며, 실행 전 단계입니다.
+> `rebrand-partide.md` 와 동일한 포맷으로 작성되어, 두 후보를 1:1 비교할 수 있게 맞췄습니다.
+
+## 1. 요약 (Executive Summary)
+
+- 현재 브랜드 **"AIDE"** 가 Android IDE와 네이밍 충돌 → 리브랜딩 필요 (동일 배경).
+- 대체 후보: **wnide** — "**W**hy **N**eed **IDE**?" 의 이니셜리즘 / 수사적 질문 브랜드.
+- 서브 카피 후보:
+  - "Why need an IDE? Build your own."
+  - "The anti-IDE that assembles into one."
+- **권고 결론: 조건부 보류(Conditional Hold)** — 컨셉 임팩트는 강하나, 발음·부정 연상(whine) 리스크가 구조적. Partide 대비 우선순위 낮음.
+
+## 2. 리브랜딩 배경
+
+- Android IDE 와 네이밍 겹침 → SEO·사용자 혼동 (Partide 문서 §2 와 동일).
+- "Create n Play" 의 철학을 브랜드가 반영해야 함 — wnide 는 **"기성 IDE 가 왜 필요하냐"** 는 수사적 도발로 이 철학을 **정면에서 선언**.
+- Partide 가 "조립된 결과물"(명사적) 을 말한다면, wnide 는 **"카테고리 자체에 대한 질문"**(동사적/선언적) 이라는 점이 차별점.
+
+## 3. 후보 탐색 여정 (Decision Log)
+
+Partide 문서 §3 탐색 결과에 wnide 만 추가. 동일 후보군 재평가는 생략.
+
+| 후보 | 컨셉 | 결론 | 이유 |
+|------|------|------|------|
+| (Partide 문서 §3 전 항목) | — | — | `rebrand-partide.md` 참조 |
+| **wnide** | "Why Need IDE?" 이니셜리즘 | **조건부 보류** | 컨셉 강력, 그러나 발음·부정 연상·철자 마찰 (§6) |
+
+## 4. wnide 브랜드 상세
+
+### 4.1 네이밍 구조
+
+- Product name: **wnide** (all-lowercase 권장 — `ripgrep`, `nvim`, `curl` 계열 언더그라운드 톤).
+- 대문자 표기 시: **WNIDE** (공식 문서/상표 등록용).
+- Domain handle 후보: **wnide.dev** (primary), `wnide.sh`, `wnide.app`, `whyneedide.com`.
+- **발음 문제** — 세 가지 해석이 가능:
+  1. **/waɪn-aɪd/** ("wine-eyed") — `w` + `nide` 로 분리, 가장 자연스러우나 "**whine**" 과 동음 → §6.
+  2. **/dʌbəl.juː.naɪd/** ("double-you-nide") — 이니셜리즘 방식, 길고 마케팅 부적합.
+  3. **/waɪ.niːd/** ("why-need") — 의도된 원래 의미, 그러나 철자로부터 자동 도출 불가.
+- 공식 발음을 **고정** 하지 않으면 브랜드 음성 인지도가 분산됨.
+
+### 4.2 의미 층위
+
+1. **표면 (이니셜리즘)**: **W**hy **N**eed **IDE**? — 기성 IDE 범주에 대한 도발적 질문.
+2. **철학적**: "IDE 가 필요 없다" 가 아니라 "**당신에게 맞는 IDE 를 당신이 조립한다**" 는 제품 철학의 슬로건화.
+3. **언더그라운드 톤**: `wnide` 의 자음 클러스터 `wn-` 은 영어에 거의 없음 → 검색 청정도 ↑, 그러나 타이핑·발음 마찰 ↑.
+4. **문법 주의**: 영어 원어민 기준 "Why Need IDE?" 는 관사 누락 비문. **"Why Need an IDE?"** 가 정문이며, 여기서 `a` 를 떨어뜨린 형태라는 점을 브랜드 스토리로 명시 필요.
+
+### 4.3 서사 (narrative arc)
+
+- IDE 는 기성품으로 제공되는 "완성된 환경" 이라는 전제를 가짐.
+- wnide 는 이 전제에 질문을 던짐: **"왜 누군가 조립해 놓은 IDE 가 필요한가?"**
+- 제품은 질문의 **답** 으로 기능: CLI 에이전트 + 플러그인 조립 = 개인에게 최적화된 환경.
+- Partide 의 "입자→원자" 화학 메타포와 달리, wnide 는 **수사학적 도발** 에 의존 — 서사 자원이 얇음.
+
+### 4.4 태그라인 후보
+
+- A: "Why need an IDE? Build your own."
+- B: "The anti-IDE that assembles into one."
+- C: "wnide — because your IDE should be yours."
+- D: "Start from zero. Compose upward."
+- **권장**: **A** — 브랜드명의 의문문 형식을 직접 해소, 발음 혼란을 문장이 교정.
+
+## 5. 네임스페이스 Audit 결과 (추정)
+
+> ⚠️ **정식 조회 전 추정치**. Partide 문서 §5 와 달리 실시간 DB 확인 미완.
+
+### 5.1 낙관적 예측
+
+- **도메인**: `wnide.dev`, `.sh`, `.app` — 5글자 자음 클러스터 (`wn`) 의 희소성상 99% 미선점 예상.
+- **npm**: `wnide`, `@wnide/core` — 거의 확실히 미선점.
+- **GitHub**: `github.com/wnide` — 거의 확실히 미선점.
+- **USPTO TESS**: `WNIDE` — 조어이자 발음 난해 → 0건 예상.
+
+### 5.2 주의 항목
+
+- **"whine"** 과 글자 거리 1 (`wh` vs `w`) → 오타·검색 오인식 시 부정적 페이지로 귀착.
+- **"Wnide"** 를 자동완성·스펠체크가 "**wide**", "**whine**", "**winded**" 로 교정하는 빈도 모니터링 필요.
+
+## 6. ⚠️ 치명적 주의사항 — 발음·부정 연상 리스크
+
+wnide 의 구조적 약점 3종. Partide 의 Particle Industries 리스크가 **외부 상표 충돌** 이었다면, wnide 의 리스크는 **내재적 언어 리스크**.
+
+### 6.1 "Whine" 동음 문제
+
+- 발음 /waɪn/ 은 영어에서 "whine"(투덜대다·칭얼대다·불평하다) 과 동음이의어.
+- 개발자 도구 브랜드가 "불평 도구" 로 들리는 것은 **제품 포지셔닝 정반대**.
+- 마케팅 영상·팟캐스트·컨퍼런스 발음 시 매번 설명 각주가 붙음.
+- Partide 가 스페인어 "partido" 와 겹치는 수준(§5.2) 보다 **훨씬 심각** — partido 는 "정당/경기" 중립·긍정어, whine 은 부정어.
+
+### 6.2 철자-발음 불일치
+
+- 영어 원어민은 `wn-` 자음 클러스터를 자연 발음할 수 없음 (영어에 존재하지 않는 onset).
+- 결과:
+  - 구두 전달 실패 ("스펠 불러줘")
+  - 도메인 구술 공유 난항
+  - 한국어권 "우나이드" vs "워나이드" vs "더블유-나이드" 분열
+
+### 6.3 이니셜리즘 피로
+
+- "Why Need IDE?" 의 이니셜리즘은 **백크로님 느낌** — 이름을 먼저 정하고 의미를 후붙인 것으로 보일 수 있음.
+- 영문법상 "Why Need an IDE?" 가 정문 → `a` 탈락이 억지로 보임.
+- 기술 업계에서 이니셜리즘 백크로님은 신뢰도 ↓ (예: 과거 YACC = "Yet Another Compiler Compiler" 셀프디스형과 반대 방향).
+
+**결론**:
+
+- ❌ 공식 제품명으로 쓰려면 **공식 발음 가이드 + "not whine" 디스클레이머** 가 필수.
+- ❌ 음성 미디어(팟캐스트·유튜브·컨퍼런스) 비중이 큰 마케팅 전략과 상성 나쁨.
+- ✅ 개발자 내부 밈·서브브랜드·CLI 커맨드명(`wnide init`) 으로는 매력적.
+- ✅ 정식 제품명을 Partide 로 확정하고, wnide 는 **창립 철학 슬로건** 혹은 **CLI 도구명** 으로 분리 운영 가능.
+
+## 7. 실행 체크리스트 (Not Yet)
+
+Partide 체크리스트와 동일 구조. wnide 채택 시 변경되는 값만 표기.
+
+### Phase A: 네임스페이스 선점
+
+- [ ] `wnide.dev` 등록
+- [ ] `wnide.sh` 등록
+- [ ] `wnide.app` 등록
+- [ ] `whyneedide.com` 등록 (풀네임 보험)
+- [ ] npm `wnide` 예약
+- [ ] npm `@wnide` 스코프 점유
+- [ ] `github.com/wnide` org 생성
+
+### Phase B: 법률
+
+- [ ] 변리사 선임
+- [ ] USPTO TESS 전문 조회 — `WNIDE` Class 9 / 42
+- [ ] KIPO 상표 검색
+- [ ] "whine" 계열 기존 상표와의 음성 유사도 리스크 평가
+- [ ] 위험 평가 보고서 수령
+
+### Phase C: 브랜드 에셋
+
+- [ ] 로고 디자인 (의문부호 `?` 활용 시안 포함)
+- [ ] **발음 가이드 페이지 필수** — `/waɪ.niːd/` (공식) + 음성 샘플
+- [ ] 컬러 팔레트
+- [ ] 아이콘 — macOS `.icns`, Windows `.ico`
+- [ ] "Why Need an IDE?" 풀네임 워드마크 병행 디자인
+
+### Phase D: 코드 마이그레이션
+
+- [ ] `package.json`: `name: "wnide"`, `productName: "wnide"`
+- [ ] `forge.config.ts`
+- [ ] `Info.plist`
+- [ ] IPC 프로토콜: `aide://` → `wnide://` (소문자 관례와 일치)
+- [ ] 환경변수: `AIDE_*` → `WNIDE_*`
+- [ ] 에러·로그 프리픽스 `[AIDE]` → `[wnide]`
+
+### Phase E: 문서 교체
+
+- Partide 와 동일 (§E) — 페이지마다 "formerly AIDE" 병기.
+
+### Phase F: 배포 전환
+
+- Partide 와 동일 — v0.1.0 부터 wnide.
+
+## 8. Partide vs wnide 비교 (의사결정 보조)
+
+| 축 | Partide | wnide |
+|---|---|---|
+| 네이밍 유형 | 블렌드 조어 (particle+IDE) | 이니셜리즘 (Why Need IDE?) |
+| 발음 명확성 | 높음 (PAR-tide, "-ide" 패턴 자연) | **낮음** (wn- 클러스터) |
+| 부정 연상 | "partido"(중립) | **"whine"(부정)** |
+| 의미 전달 속도 | 중간 (블렌드 해석 필요) | **낮음** (백크로님 해석 필요) |
+| 철학 전달력 | 중간 (조립 메타포) | **높음** (카테고리 도발) |
+| 상표 리스크 | 낮음 (Particle 은 별개 회사로 회피 가능) | **낮음** (조어) |
+| 음성 마케팅 | 유리 | **불리** |
+| 개발자 커뮤니티 톤 | 중립 | **강한 언더그라운드 매력** |
+| 국제화 (한·영·일) | 안정 | 한국어 표기 분열 가능 (우나이드/와나이드) |
+| 전체 권고 | **1순위** | **슬로건·CLI명으로 분리 운영 검토** |
+
+## 9. 의사결정 권고
+
+1. **제품명 정면 후보로서 wnide 단독 채택은 비권장** — §6 리스크가 구조적.
+2. **이중 운영(Dual-use) 제안**:
+   - Product name: **Partide** (공식, 마케팅, 상표, 스토어 등록)
+   - Tagline / Manifesto: **"Why need an IDE?"** — 랜딩 hero copy 혹은 철학 문서 제목
+   - CLI 커맨드: 필요 시 `partide` (정식) + `wnide` (별칭) 동시 지원 검토.
+3. Partide 가 법률 검토에서 블록될 경우, wnide 는 **fallback 후보군에 편입** 하되 §6 리스크를 감수할지 재평가 필요.
+
+## 10. 타임라인 제안
+
+- wnide 단독 채택 시: Partide 타임라인에 **+2주** (발음 가이드·브랜드 보이스 튜닝).
+- 이중 운영 채택 시: Partide 타임라인 유지, wnide 는 마케팅 Phase 에서 슬로건으로만 사용.
+
+## 11. 결론
+
+wnide 는 **메시지는 강하지만 매개체(이름)가 약하다**. 제품 철학을 카피(copy) 레벨에서 드러내는 도구로는 탁월하나, 브랜드 그 자체로서는 발음·연상·백크로님 3중 마찰로 시장 진입 비용이 높다. 현시점 권고는 **Partide = 이름, "Why need an IDE?" = 철학** 의 역할 분담.

--- a/docs/wiki/ui-tab-and-workspace-truncation.md
+++ b/docs/wiki/ui-tab-and-workspace-truncation.md
@@ -1,0 +1,114 @@
+# UI: Tab Title Overflow & Workspace Path Tooltip
+
+좁은 윈도우에서의 텍스트 처리 패턴 두 가지를 정리한다. 두 변경은 별도 PR로 머지되었다 (#67 탭 overflow, #66 워크스페이스 툴팁).
+
+## 문제
+
+### 1. 탭 제목 wrapping
+
+`PaneView`, `TabBar`, `WorkspaceNav` 의 탭 제목 `<span>` 에는 truncation CSS가 없거나 (`PaneView`/`TabBar`) 부모 flex 컨테이너의 폭 제약이 없어 (`WorkspaceNav`), 윈도우가 좁아지면 탭 제목이 두 줄·세 줄로 wrap 되어 탭 행 높이가 늘어났다.
+
+### 2. 워크스페이스 경로 잘림 방향
+
+`WorkspaceNav` 의 워크스페이스 행은 이름과 절대 경로를 표시한다. 절대 경로는 끝부분 (`/aide` 같은 마지막 세그먼트) 이 식별에 가장 중요한데, 기본 `text-overflow: ellipsis` 는 뒤에서 자른다 → `/Users/chinshuu/Doc…` 처럼 정작 중요한 끝이 사라졌다. hover 시 풀 경로를 볼 수단도 없었다.
+
+## 해결
+
+### 탭 제목 (PR #67)
+
+세 컴포넌트의 탭 컨테이너에 동일한 패턴 적용:
+
+```tsx
+// 부모 버튼/컨테이너
+className="flex items-center min-w-0 min-w-[80px] max-w-[200px]"
+
+// 제목 span
+className="truncate"
+
+// close 버튼 (있을 경우)
+className="flex-shrink-0"
+```
+
+핵심 포인트:
+- **`min-w-0`** — Flex 자식은 기본값이 `min-width: auto` 라 콘텐츠보다 작게 줄지 않는다. `min-w-0` 으로 풀어줘야 `truncate` 가 동작한다 (자주 빠뜨리는 부분).
+- **`max-w-[200px]`** — wrap 대신 ellipsis 트리거를 위한 상한. 200px 는 모노스페이스 12px 폰트로 약 25자.
+- **`min-w-[80px]`** — 너무 좁아져 탭이 사라지는 것 방지.
+- **`flex-shrink-0` on close button** — title 만 줄이고 close 는 항상 표시.
+
+대상 파일:
+- `src/renderer/components/layout/PaneView.tsx`
+- `src/renderer/components/terminal/TabBar.tsx`
+- `src/renderer/components/workspace/WorkspaceNav.tsx` (line ~300, 탭 제목 영역만)
+
+### 워크스페이스 경로 (PR #66)
+
+#### Front-truncation (좌측 ellipsis)
+
+CSS `direction` 트릭으로 라이브러리 없이 처리:
+
+```tsx
+<span dir="rtl" className="truncate inline-block w-full text-left">
+  <span dir="ltr">{ws.path}</span>
+</span>
+```
+
+`dir="rtl"` 은 ellipsis 위치를 좌측으로 옮긴다. 안쪽 `dir="ltr"` 은 경로 자체의 글자 방향은 정상으로 유지. 결과: `…/repositories/aide`.
+
+#### Tooltip 컴포넌트 (신규)
+
+`src/renderer/components/ui/Tooltip.tsx` — Tailwind only, 외부 의존성 없음.
+
+```tsx
+import { Tooltip } from '../ui/Tooltip';
+
+<Tooltip content={`${ws.name}\n${ws.path}`} placement="right">
+  <button>…workspace row…</button>
+</Tooltip>
+```
+
+Public API:
+
+| Prop | 타입 | 기본값 | 설명 |
+|------|------|--------|------|
+| `content` | `React.ReactNode` | (필수) | 툴팁 내용. `\n` 으로 멀티라인. ReactNode 도 가능. |
+| `children` | `React.ReactNode` | (필수) | 툴팁이 붙을 대상 |
+| `placement` | `'top' \| 'bottom' \| 'right'` | `'top'` | 표시 위치 |
+| `className` | `string` | — | wrapper 추가 클래스 |
+
+동작:
+- hover (`mouseenter`) / focus (`focusin`) 시 200ms 지연 후 표시 (플리커 방지)
+- `mouseleave` / `focusout` 즉시 hide
+- 표시 중 wrapper 에 `aria-describedby` 자동 부여
+- 툴팁 노드는 `role="tooltip"`
+- 포지셔닝은 wrapper 기준 absolute (포털 사용 안함 — 본 스코프에서 충분)
+
+## 재사용 가이드라인
+
+### Tooltip 적용 시 주의
+
+1. **Wrapper 가 `relative` 컨텍스트를 가질 것** — 컴포넌트 내부에서 `relative` 를 추가하지만, 부모가 `overflow: hidden` 이면 잘릴 수 있다. side panel 같은 좁은 영역에서는 `placement="right"` 권장.
+2. **인터랙션 가능한 children** (button, link 등) 에만 사용 — 일반 텍스트에 hover 만 거는 건 a11y 안티패턴이라 `aria-describedby` 가 의미 없어짐.
+3. **포털이 필요한 케이스 (드롭다운 안쪽 등)** — 본 컴포넌트는 portal 없이 wrapper-relative 로 동작하므로 `overflow:hidden` 부모가 있는 컨테이너에서는 잘릴 수 있다. 그런 경우 향후 `Tooltip` 에 `portal?: boolean` 옵션을 추가하거나 `@radix-ui/react-tooltip` 도입을 고려.
+
+### 탭 truncation 패턴 적용 시
+
+다른 좁은 영역 (예: 새 탭 그룹, 사이드바 항목) 에 같은 패턴을 적용할 때:
+
+- **`min-w-0` 누락 디버깅** — `truncate` 적용했는데 안 잘리면 99% 부모 flex 의 `min-width: auto` 문제. 부모/자식 양쪽에 `min-w-0` 추가해 보기.
+- **`max-w-*` 값** — 12px 모노스페이스 기준 200px ≈ 25자. 다른 폰트 크기에서는 비례 조정.
+- **`flex-shrink-0` 누락 디버깅** — close/icon 버튼이 사라진다면 부모 flex 가 그것까지 줄이고 있는 것. 액션 요소에는 항상 `flex-shrink-0`.
+
+## 검증
+
+- 단위 테스트: `tests/unit/tab-title-overflow.test.tsx` (탭), `tests/unit/tooltip.test.tsx` (Tooltip) — 총 14 신규 케이스
+- 시각 검증 시나리오:
+  1. `pnpm start` → 윈도우 폭을 600px 이하로 줄여 탭 제목이 wrap 되지 않고 `…` 으로 잘리는지
+  2. 워크스페이스 행에 마우스 hover → 200ms 후 풀 name + path 툴팁 표시
+  3. 키보드 Tab 으로 워크스페이스 행에 focus → 동일하게 툴팁 표시 (a11y)
+  4. 경로 표시가 `…/repositories/aide` 형태인지 (앞이 잘리고 끝이 보이는지)
+
+## 관련 PR
+
+- #66 — `feat(ui): show full workspace path in hover tooltip with front-truncated label`
+- #67 — `feat(ui): truncate long tab titles with ellipsis`
+- 칸반: `task_hk6huk7o`, `task_pch4mwec`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aide",
   "productName": "AIDE",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "AI-Driven IDE - Create n Play plugins with natural language",
   "main": ".vite/build/index.js",
   "private": true,

--- a/src/main/mcp/server.js
+++ b/src/main/mcp/server.js
@@ -364,11 +364,7 @@ function getBuiltinTools() {
       return {
         name: "plugin_" + p.name + "_" + t.name,
         description: "[Plugin: " + p.name + "] " + t.description,
-        inputSchema: {
-          type: "object",
-          properties: Object.fromEntries(Object.entries(t.parameters).map(function(e) { return [e[0], { type: e[1].type }]; })),
-          required: Object.entries(t.parameters).filter(function(e) { return e[1].required; }).map(function(e) { return e[0]; })
-        }
+        inputSchema: t.parameters
       };
     });
   });

--- a/src/main/mcp/server.js
+++ b/src/main/mcp/server.js
@@ -428,4 +428,10 @@ function processBuffer() {
 }
 process.stdin.setEncoding("utf-8");
 process.stdin.on("data", function(chunk) { buffer += chunk; processBuffer(); });
-process.stdin.on("end", function() { process.exit(0); });
+process.stdin.on("end", function() {
+  // process.exit(0) truncates piped stdout when the kernel pipe buffer is still
+  // draining (observed at ~8KB on CI). End stdout explicitly and let Node exit
+  // naturally once the write stream has flushed.
+  if (process.stdout.writableEnded) return;
+  process.stdout.end();
+});

--- a/src/renderer/components/layout/PaneView.tsx
+++ b/src/renderer/components/layout/PaneView.tsx
@@ -22,16 +22,17 @@ const AGENT_COLORS: Record<string, string> = {
 
 interface DraggableTabProps {
   tab: TerminalTab;
-  paneId?: string;
+  paneId: string;
   isActive: boolean;
   onActivate: () => void;
   onClose: (e: React.MouseEvent) => void;
   onContextMenu: (e: React.MouseEvent) => void;
-  onRename?: (title: string) => void;
+  onRename: (title: string) => void;
   canClose: boolean;
 }
 
-export function DraggableTab({ tab, paneId = '', isActive, onActivate, onClose, onContextMenu, onRename = () => {}, canClose }: DraggableTabProps) {
+// 80px min / 200px max chosen to fit ~25 chars at 12px monospace; keep in sync with TabBar.tsx
+function DraggableTab({ tab, paneId, isActive, onActivate, onClose, onContextMenu, onRename, canClose }: DraggableTabProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: tab.id,
     data: { tab, paneId },
@@ -72,7 +73,7 @@ export function DraggableTab({ tab, paneId = '', isActive, onActivate, onClose, 
         onClick={isEditing ? undefined : onActivate}
         onDoubleClick={(e) => { if (isPlugin) return; e.stopPropagation(); setIsEditing(true); }}
         onContextMenu={onContextMenu}
-        className={`group relative flex items-center gap-1.5 px-3 h-full text-[12px] font-mono transition-colors min-w-[80px] max-w-[200px] min-w-0 ${
+        className={`group relative flex items-center gap-1.5 px-3 h-full text-[12px] font-mono transition-colors min-w-[80px] max-w-[200px] ${
           isActive
             ? 'bg-aide-tab-active-bg text-aide-text-primary'
             : 'bg-aide-tab-inactive-bg text-aide-text-secondary hover:text-aide-text-primary'
@@ -102,7 +103,7 @@ export function DraggableTab({ tab, paneId = '', isActive, onActivate, onClose, 
             className="bg-transparent outline-none border-b border-aide-accent text-[12px] font-mono min-w-0 w-24"
           />
         ) : (
-          <span className="truncate">{tab.title}</span>
+          <span className="truncate min-w-0 flex-1">{tab.title}</span>
         )}
         {canClose && !isEditing && (
           <span

--- a/src/renderer/components/layout/PaneView.tsx
+++ b/src/renderer/components/layout/PaneView.tsx
@@ -10,6 +10,7 @@ import { useLayoutStore } from '../../stores/layout-store';
 import { useTerminalStore } from '../../stores/terminal-store';
 import * as xtermCache from '../../lib/xterm-cache';
 import type { Pane, TerminalTab } from '../../../types/ipc';
+import { Tooltip } from '../ui/Tooltip';
 
 const AGENT_COLORS: Record<string, string> = {
   claude: 'var(--agent-claude)',
@@ -103,7 +104,9 @@ function DraggableTab({ tab, paneId, isActive, onActivate, onClose, onContextMen
             className="bg-transparent outline-none border-b border-aide-accent text-[12px] font-mono min-w-0 w-24"
           />
         ) : (
-          <span className="truncate min-w-0 flex-1" title={tab.title}>{tab.title}</span>
+          <Tooltip content={tab.title} placement="bottom" className="min-w-0 flex-1">
+            <span className="truncate block w-full text-left">{tab.title}</span>
+          </Tooltip>
         )}
         {canClose && !isEditing && (
           <span

--- a/src/renderer/components/layout/PaneView.tsx
+++ b/src/renderer/components/layout/PaneView.tsx
@@ -103,7 +103,7 @@ function DraggableTab({ tab, paneId, isActive, onActivate, onClose, onContextMen
             className="bg-transparent outline-none border-b border-aide-accent text-[12px] font-mono min-w-0 w-24"
           />
         ) : (
-          <span className="truncate min-w-0 flex-1">{tab.title}</span>
+          <span className="truncate min-w-0 flex-1" title={tab.title}>{tab.title}</span>
         )}
         {canClose && !isEditing && (
           <span

--- a/src/renderer/components/layout/PaneView.tsx
+++ b/src/renderer/components/layout/PaneView.tsx
@@ -22,16 +22,16 @@ const AGENT_COLORS: Record<string, string> = {
 
 interface DraggableTabProps {
   tab: TerminalTab;
-  paneId: string;
+  paneId?: string;
   isActive: boolean;
   onActivate: () => void;
   onClose: (e: React.MouseEvent) => void;
   onContextMenu: (e: React.MouseEvent) => void;
-  onRename: (title: string) => void;
+  onRename?: (title: string) => void;
   canClose: boolean;
 }
 
-function DraggableTab({ tab, paneId, isActive, onActivate, onClose, onContextMenu, onRename, canClose }: DraggableTabProps) {
+export function DraggableTab({ tab, paneId = '', isActive, onActivate, onClose, onContextMenu, onRename = () => {}, canClose }: DraggableTabProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: tab.id,
     data: { tab, paneId },
@@ -72,7 +72,7 @@ function DraggableTab({ tab, paneId, isActive, onActivate, onClose, onContextMen
         onClick={isEditing ? undefined : onActivate}
         onDoubleClick={(e) => { if (isPlugin) return; e.stopPropagation(); setIsEditing(true); }}
         onContextMenu={onContextMenu}
-        className={`group relative flex items-center gap-1.5 px-3 h-full text-[12px] font-mono transition-colors ${
+        className={`group relative flex items-center gap-1.5 px-3 h-full text-[12px] font-mono transition-colors min-w-[80px] max-w-[200px] min-w-0 ${
           isActive
             ? 'bg-aide-tab-active-bg text-aide-text-primary'
             : 'bg-aide-tab-inactive-bg text-aide-text-secondary hover:text-aide-text-primary'
@@ -102,7 +102,7 @@ function DraggableTab({ tab, paneId, isActive, onActivate, onClose, onContextMen
             className="bg-transparent outline-none border-b border-aide-accent text-[12px] font-mono min-w-0 w-24"
           />
         ) : (
-          <span>{tab.title}</span>
+          <span className="truncate">{tab.title}</span>
         )}
         {canClose && !isEditing && (
           <span
@@ -112,7 +112,7 @@ function DraggableTab({ tab, paneId, isActive, onActivate, onClose, onContextMen
             onKeyDown={(e) => {
               if (e.key === 'Enter' || e.key === ' ') onClose(e as unknown as React.MouseEvent);
             }}
-            className="ml-1 opacity-0 group-hover:opacity-100 text-[10px] text-aide-text-tertiary hover:text-aide-text-primary transition-opacity leading-none"
+            className="ml-1 shrink-0 opacity-0 group-hover:opacity-100 text-[10px] text-aide-text-tertiary hover:text-aide-text-primary transition-opacity leading-none"
           >
             ×
           </span>

--- a/src/renderer/components/terminal/TabBar.tsx
+++ b/src/renderer/components/terminal/TabBar.tsx
@@ -26,7 +26,8 @@ export function TabBar() {
           <button
             key={tab.id}
             onClick={() => setActiveTab(tab.id)}
-            className={`group relative flex items-center gap-1.5 px-3 h-full text-[12px] font-mono transition-colors min-w-[80px] max-w-[200px] min-w-0 ${
+            // 80px min / 200px max: keep in sync with PaneView.tsx DraggableTab (fits ~25 chars at 12px monospace)
+            className={`group relative flex items-center gap-1.5 px-3 h-full text-[12px] font-mono transition-colors min-w-[80px] max-w-[200px] ${
               isActive
                 ? 'bg-aide-tab-active-bg text-aide-text-primary'
                 : 'bg-aide-tab-inactive-bg text-aide-text-secondary hover:text-aide-text-primary'
@@ -44,7 +45,7 @@ export function TabBar() {
               className="w-1.5 h-1.5 rounded-full shrink-0"
               style={{ backgroundColor: dotColor }}
             />
-            <span className="truncate">{tab.title}</span>
+            <span className="truncate min-w-0 flex-1">{tab.title}</span>
             {/* Close button on hover */}
             {tabs.length > 1 && (
               <span

--- a/src/renderer/components/terminal/TabBar.tsx
+++ b/src/renderer/components/terminal/TabBar.tsx
@@ -45,7 +45,7 @@ export function TabBar() {
               className="w-1.5 h-1.5 rounded-full shrink-0"
               style={{ backgroundColor: dotColor }}
             />
-            <span className="truncate min-w-0 flex-1">{tab.title}</span>
+            <span className="truncate min-w-0 flex-1" title={tab.title}>{tab.title}</span>
             {/* Close button on hover */}
             {tabs.length > 1 && (
               <span

--- a/src/renderer/components/terminal/TabBar.tsx
+++ b/src/renderer/components/terminal/TabBar.tsx
@@ -1,5 +1,6 @@
 import { useTerminalStore } from '../../stores/terminal-store';
 import { AgentDropdown } from './AgentDropdown';
+import { Tooltip } from '../ui/Tooltip';
 
 const AGENT_COLORS: Record<string, string> = {
   claude: 'var(--agent-claude)',
@@ -45,7 +46,9 @@ export function TabBar() {
               className="w-1.5 h-1.5 rounded-full shrink-0"
               style={{ backgroundColor: dotColor }}
             />
-            <span className="truncate min-w-0 flex-1" title={tab.title}>{tab.title}</span>
+            <Tooltip content={tab.title} placement="bottom" className="min-w-0 flex-1">
+              <span className="truncate block w-full text-left">{tab.title}</span>
+            </Tooltip>
             {/* Close button on hover */}
             {tabs.length > 1 && (
               <span

--- a/src/renderer/components/terminal/TabBar.tsx
+++ b/src/renderer/components/terminal/TabBar.tsx
@@ -26,7 +26,7 @@ export function TabBar() {
           <button
             key={tab.id}
             onClick={() => setActiveTab(tab.id)}
-            className={`group relative flex items-center gap-1.5 px-3 h-full text-[12px] font-mono transition-colors ${
+            className={`group relative flex items-center gap-1.5 px-3 h-full text-[12px] font-mono transition-colors min-w-[80px] max-w-[200px] min-w-0 ${
               isActive
                 ? 'bg-aide-tab-active-bg text-aide-text-primary'
                 : 'bg-aide-tab-inactive-bg text-aide-text-secondary hover:text-aide-text-primary'
@@ -44,7 +44,7 @@ export function TabBar() {
               className="w-1.5 h-1.5 rounded-full shrink-0"
               style={{ backgroundColor: dotColor }}
             />
-            <span>{tab.title}</span>
+            <span className="truncate">{tab.title}</span>
             {/* Close button on hover */}
             {tabs.length > 1 && (
               <span
@@ -74,7 +74,7 @@ export function TabBar() {
                     removeTab(tab.id);
                   }
                 }}
-                className="ml-1 opacity-0 group-hover:opacity-100 text-[10px] text-aide-text-tertiary hover:text-aide-text-primary transition-opacity leading-none"
+                className="ml-1 shrink-0 opacity-0 group-hover:opacity-100 text-[10px] text-aide-text-tertiary hover:text-aide-text-primary transition-opacity leading-none"
               >
                 ×
               </span>

--- a/src/renderer/components/ui/Tooltip.tsx
+++ b/src/renderer/components/ui/Tooltip.tsx
@@ -3,11 +3,12 @@
  * overflow:hidden / overflow:auto ancestors (e.g. the scrollable workspace list).
  *
  * Positioning uses position:fixed with coordinates read from
- * wrapperRef.getBoundingClientRect() at the moment of show.
+ * wrapperRef.getBoundingClientRect() at the moment of show. Centering is
+ * done via CSS transform translate(-50%, ...), so actual tooltip dimensions
+ * do not need to be measured.
  *
- * Known limitation: tooltip width is assumed to fit within max-w-xs (20rem).
- * No dimension measurement is performed — centering is best-effort.
- * Viewport edge clamping is not implemented.
+ * Known limitation: Viewport edge clamping is not implemented — tooltips
+ * near the viewport edge may overflow horizontally.
  */
 import { useEffect, useRef, useState, useId } from 'react';
 import { createPortal } from 'react-dom';
@@ -28,31 +29,26 @@ export function Tooltip({ content, children, placement = 'top', className }: Too
   const wrapperRef = useRef<HTMLDivElement>(null);
   const tooltipId = useId();
 
+  // Anchor point — actual centering is done via CSS transform in the tooltip div
   function computeCoords(): { top: number; left: number } {
     if (!wrapperRef.current) return { top: 0, left: 0 };
     const rect = wrapperRef.current.getBoundingClientRect();
-    // Assume max-w-xs = 320px, height ~28px for centering purposes
-    const assumedWidth = 320;
-    const assumedHeight = 28;
     switch (placement) {
       case 'bottom':
-        return {
-          top: rect.bottom + GAP,
-          left: rect.left + rect.width / 2 - assumedWidth / 2,
-        };
+        return { top: rect.bottom + GAP, left: rect.left + rect.width / 2 };
       case 'right':
-        return {
-          top: rect.top + rect.height / 2 - assumedHeight / 2,
-          left: rect.right + GAP,
-        };
+        return { top: rect.top + rect.height / 2, left: rect.right + GAP };
       case 'top':
       default:
-        return {
-          top: rect.top - assumedHeight - GAP,
-          left: rect.left + rect.width / 2 - assumedWidth / 2,
-        };
+        return { top: rect.top - GAP, left: rect.left + rect.width / 2 };
     }
   }
+
+  const transformByPlacement: Record<NonNullable<TooltipProps['placement']>, string> = {
+    top: 'translate(-50%, -100%)',
+    bottom: 'translate(-50%, 0)',
+    right: 'translate(0, -50%)',
+  };
 
   function show() {
     if (timerRef.current) clearTimeout(timerRef.current);
@@ -79,7 +75,7 @@ export function Tooltip({ content, children, placement = 'top', className }: Too
         <div
           id={tooltipId}
           role="tooltip"
-          style={{ top: coords.top, left: coords.left }}
+          style={{ top: coords.top, left: coords.left, transform: transformByPlacement[placement] }}
           className="fixed z-[9999] max-w-xs whitespace-pre-wrap rounded px-2 py-1 text-[10px] font-mono
             bg-aide-surface-elevated border border-aide-border text-aide-text-primary shadow-md
             pointer-events-none"

--- a/src/renderer/components/ui/Tooltip.tsx
+++ b/src/renderer/components/ui/Tooltip.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState, useId } from 'react';
+
+interface TooltipProps {
+  content: React.ReactNode;
+  children: React.ReactNode;
+  placement?: 'top' | 'bottom' | 'right';
+  className?: string;
+}
+
+export function Tooltip({ content, children, placement = 'top', className }: TooltipProps) {
+  const [visible, setVisible] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const tooltipId = useId();
+
+  function show() {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setVisible(true), 200);
+  }
+
+  function hide() {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = null;
+    setVisible(false);
+  }
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const placementClasses: Record<NonNullable<TooltipProps['placement']>, string> = {
+    top: 'bottom-full left-1/2 -translate-x-1/2 mb-1',
+    bottom: 'top-full left-1/2 -translate-x-1/2 mt-1',
+    right: 'left-full top-1/2 -translate-y-1/2 ml-1',
+  };
+
+  return (
+    <div
+      data-tooltip-wrapper
+      className={`relative inline-flex${className ? ` ${className}` : ''}`}
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+      aria-describedby={visible ? tooltipId : undefined}
+    >
+      {children}
+      {visible && (
+        <div
+          id={tooltipId}
+          role="tooltip"
+          className={`absolute z-50 whitespace-pre-wrap rounded px-2 py-1 text-[10px] font-mono
+            bg-aide-surface-elevated border border-aide-border text-aide-text-primary shadow-md
+            pointer-events-none ${placementClasses[placement]}`}
+        >
+          {content}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/components/ui/Tooltip.tsx
+++ b/src/renderer/components/ui/Tooltip.tsx
@@ -1,4 +1,16 @@
+/**
+ * Tooltip — renders via ReactDOM.createPortal into document.body to escape
+ * overflow:hidden / overflow:auto ancestors (e.g. the scrollable workspace list).
+ *
+ * Positioning uses position:fixed with coordinates read from
+ * wrapperRef.getBoundingClientRect() at the moment of show.
+ *
+ * Known limitation: tooltip width is assumed to fit within max-w-xs (20rem).
+ * No dimension measurement is performed — centering is best-effort.
+ * Viewport edge clamping is not implemented.
+ */
 import { useEffect, useRef, useState, useId } from 'react';
+import { createPortal } from 'react-dom';
 
 interface TooltipProps {
   content: React.ReactNode;
@@ -7,14 +19,47 @@ interface TooltipProps {
   className?: string;
 }
 
+const GAP = 6; // px between wrapper and tooltip
+
 export function Tooltip({ content, children, placement = 'top', className }: TooltipProps) {
   const [visible, setVisible] = useState(false);
+  const [coords, setCoords] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const tooltipId = useId();
+
+  function computeCoords(): { top: number; left: number } {
+    if (!wrapperRef.current) return { top: 0, left: 0 };
+    const rect = wrapperRef.current.getBoundingClientRect();
+    // Assume max-w-xs = 320px, height ~28px for centering purposes
+    const assumedWidth = 320;
+    const assumedHeight = 28;
+    switch (placement) {
+      case 'bottom':
+        return {
+          top: rect.bottom + GAP,
+          left: rect.left + rect.width / 2 - assumedWidth / 2,
+        };
+      case 'right':
+        return {
+          top: rect.top + rect.height / 2 - assumedHeight / 2,
+          left: rect.right + GAP,
+        };
+      case 'top':
+      default:
+        return {
+          top: rect.top - assumedHeight - GAP,
+          left: rect.left + rect.width / 2 - assumedWidth / 2,
+        };
+    }
+  }
 
   function show() {
     if (timerRef.current) clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => setVisible(true), 200);
+    timerRef.current = setTimeout(() => {
+      setCoords(computeCoords());
+      setVisible(true);
+    }, 200);
   }
 
   function hide() {
@@ -29,34 +74,38 @@ export function Tooltip({ content, children, placement = 'top', className }: Too
     };
   }, []);
 
-  const placementClasses: Record<NonNullable<TooltipProps['placement']>, string> = {
-    top: 'bottom-full left-1/2 -translate-x-1/2 mb-1',
-    bottom: 'top-full left-1/2 -translate-x-1/2 mt-1',
-    right: 'left-full top-1/2 -translate-y-1/2 ml-1',
-  };
+  const tooltip = visible
+    ? createPortal(
+        <div
+          id={tooltipId}
+          role="tooltip"
+          style={{ top: coords.top, left: coords.left }}
+          className="fixed z-[9999] max-w-xs whitespace-pre-wrap rounded px-2 py-1 text-[10px] font-mono
+            bg-aide-surface-elevated border border-aide-border text-aide-text-primary shadow-md
+            pointer-events-none"
+        >
+          {content}
+        </div>,
+        document.body,
+      )
+    : null;
 
   return (
     <div
+      ref={wrapperRef}
       data-tooltip-wrapper
       className={`relative inline-flex${className ? ` ${className}` : ''}`}
       onMouseEnter={show}
       onMouseLeave={hide}
       onFocus={show}
       onBlur={hide}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') hide();
+      }}
       aria-describedby={visible ? tooltipId : undefined}
     >
       {children}
-      {visible && (
-        <div
-          id={tooltipId}
-          role="tooltip"
-          className={`absolute z-50 whitespace-pre-wrap rounded px-2 py-1 text-[10px] font-mono
-            bg-aide-surface-elevated border border-aide-border text-aide-text-primary shadow-md
-            pointer-events-none ${placementClasses[placement]}`}
-        >
-          {content}
-        </div>
-      )}
+      {tooltip}
     </div>
   );
 }

--- a/src/renderer/components/workspace/WorkspaceNav.tsx
+++ b/src/renderer/components/workspace/WorkspaceNav.tsx
@@ -296,7 +296,8 @@ export function WorkspaceNav() {
                         <StatusDot status={tabStatus} />
                       </span>
 
-                      {/* Tab title */}
+                      {/* Tab title — sidebar list uses truncate+flex-1 without a min/max-w cap
+                          (different context from editor tab bar which enforces 80px/200px bounds) */}
                       <span className="text-[11px] font-mono text-aide-text-secondary truncate flex-1">
                         {tab.title}
                       </span>

--- a/src/renderer/components/workspace/WorkspaceNav.tsx
+++ b/src/renderer/components/workspace/WorkspaceNav.tsx
@@ -5,6 +5,7 @@ import { useTerminalStore } from '../../stores/terminal-store';
 import { useLayoutStore } from '../../stores/layout-store';
 import { isSplitLayout, type AgentStatus, type LayoutNode, type TerminalTab } from '../../../types/ipc';
 import { StatusDot, StatusBadge } from './StatusIndicator';
+import { Tooltip } from '../ui/Tooltip';
 import { UpdateNotice } from '../updater/UpdateNotice';
 import { AgentDropdown } from '../terminal/AgentDropdown';
 
@@ -222,6 +223,7 @@ export function WorkspaceNav() {
                     >
                       {ws.name[0]?.toUpperCase() ?? '?'}
                     </span>
+                    <Tooltip content={`${ws.name}\n${ws.path}`} placement="right" className="flex-1 min-w-0">
                     <div className="flex flex-col flex-1 min-w-0">
                       {editingWorkspaceId === ws.id ? (
                         <input
@@ -239,8 +241,11 @@ export function WorkspaceNav() {
                       ) : (
                         <span className="text-xs font-mono text-aide-text-primary truncate">{ws.name}</span>
                       )}
-                      <span className="text-[10px] font-mono text-aide-text-tertiary truncate">{ws.path}</span>
+                      <span dir="rtl" className="text-[10px] font-mono text-aide-text-tertiary truncate inline-block w-full text-left">
+                        <span dir="ltr">{ws.path}</span>
+                      </span>
                     </div>
+                    </Tooltip>
                     {/* Tab count */}
                     <span className="text-[10px] font-mono text-aide-text-tertiary shrink-0">
                       ({wsTabs.length})

--- a/src/renderer/components/workspace/WorkspaceNav.tsx
+++ b/src/renderer/components/workspace/WorkspaceNav.tsx
@@ -287,7 +287,7 @@ export function WorkspaceNav() {
                     <button
                       key={tab.id}
                       onClick={() => handleSelectTab(ws.id, tab.id)}
-                      className={`flex items-center gap-1.5 w-full pl-6 pr-2 py-1 rounded text-left transition-colors ${
+                      className={`flex items-center gap-1.5 w-full pl-6 pr-2 py-1 rounded text-left transition-colors min-w-0 ${
                         isTabActive ? 'bg-aide-surface-elevated' : 'hover:bg-aide-surface-elevated'
                       }`}
                     >

--- a/src/renderer/components/workspace/WorkspaceNav.tsx
+++ b/src/renderer/components/workspace/WorkspaceNav.tsx
@@ -241,6 +241,7 @@ export function WorkspaceNav() {
                       ) : (
                         <span className="text-xs font-mono text-aide-text-primary truncate">{ws.name}</span>
                       )}
+                      {/* dir="rtl" + inner dir="ltr" front-truncates long paths so the tail (last segment) stays visible */}
                       <span dir="rtl" className="text-[10px] font-mono text-aide-text-tertiary truncate inline-block w-full text-left">
                         <span dir="ltr">{ws.path}</span>
                       </span>

--- a/tests/unit/mcp-server-tool-schema.test.ts
+++ b/tests/unit/mcp-server-tool-schema.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { spawnSync } from 'child_process';
+
+const SERVER_PATH = path.resolve(__dirname, '../../src/main/mcp/server.js');
+
+function callToolsList(cwd: string): { tools: Array<Record<string, unknown>> } {
+  const req = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }) + '\n';
+  const result = spawnSync(process.execPath, [SERVER_PATH], {
+    cwd,
+    input: req,
+    encoding: 'utf-8',
+    timeout: 10_000,
+  });
+  if (result.error) throw result.error;
+  const lines = result.stdout.split('\n').filter(Boolean);
+  for (const line of lines) {
+    const msg = JSON.parse(line);
+    if (msg.id === 1 && msg.result) return msg.result;
+  }
+  throw new Error(`No response: stdout=${result.stdout} stderr=${result.stderr}`);
+}
+
+describe('MCP server getBuiltinTools — plugin tool schema', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aide-mcp-schema-'));
+    const pluginDir = path.join(tmpDir, '.aide', 'plugins', 'sample-plugin');
+    fs.mkdirSync(path.join(pluginDir, 'src'), { recursive: true });
+    const spec = {
+      name: 'sample-plugin',
+      version: '1.0.0',
+      description: 'sample',
+      entryPoint: 'src/index.js',
+      tools: [
+        {
+          name: 'do_thing',
+          description: 'does a thing',
+          parameters: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              status: { type: 'string', enum: ['todo', 'done'] },
+              note: { type: 'string', description: 'optional note' },
+            },
+            required: ['id'],
+          },
+        },
+      ],
+    };
+    fs.writeFileSync(path.join(pluginDir, 'plugin.spec.json'), JSON.stringify(spec));
+    fs.writeFileSync(path.join(pluginDir, 'src', 'index.js'), 'module.exports = {};');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('passes plugin parameters JSON Schema through verbatim into inputSchema', () => {
+    const { tools } = callToolsList(tmpDir);
+    const tool = tools.find((t) => t.name === 'plugin_sample-plugin_do_thing');
+    expect(tool, 'plugin tool should be advertised').toBeTruthy();
+
+    const schema = tool!.inputSchema as {
+      type: string;
+      properties: Record<string, { type: string; enum?: unknown[]; description?: string }>;
+      required: string[];
+    };
+
+    expect(schema.type).toBe('object');
+    expect(schema.required).toEqual(['id']);
+    expect(schema.properties.id).toEqual({ type: 'string' });
+    expect(schema.properties.status).toEqual({ type: 'string', enum: ['todo', 'done'] });
+    expect(schema.properties.note).toEqual({ type: 'string', description: 'optional note' });
+  });
+
+  it('does not flatten schema metadata (properties/required/type) into field names', () => {
+    const { tools } = callToolsList(tmpDir);
+    const tool = tools.find((t) => t.name === 'plugin_sample-plugin_do_thing');
+    const schema = tool!.inputSchema as { properties: Record<string, unknown> };
+    expect(schema.properties).not.toHaveProperty('properties');
+    expect(schema.properties).not.toHaveProperty('required');
+    expect(schema.properties).not.toHaveProperty('type');
+  });
+});

--- a/tests/unit/mcp-server-tool-schema.test.ts
+++ b/tests/unit/mcp-server-tool-schema.test.ts
@@ -11,16 +11,23 @@ function callToolsList(cwd: string): { tools: Array<Record<string, unknown>> } {
   const result = spawnSync(process.execPath, [SERVER_PATH], {
     cwd,
     input: req,
-    encoding: 'utf-8',
     timeout: 10_000,
   });
   if (result.error) throw result.error;
-  const lines = result.stdout.split('\n').filter(Boolean);
+  // Decode stdout from a Buffer in one pass — Node 20's spawnSync + encoding:'utf-8'
+  // has truncated multi-byte UTF-8 output across chunk boundaries on some platforms.
+  const stdout = Buffer.isBuffer(result.stdout)
+    ? result.stdout.toString('utf-8')
+    : String(result.stdout ?? '');
+  const stderr = Buffer.isBuffer(result.stderr)
+    ? result.stderr.toString('utf-8')
+    : String(result.stderr ?? '');
+  const lines = stdout.split('\n').filter(Boolean);
   for (const line of lines) {
     const msg = JSON.parse(line);
     if (msg.id === 1 && msg.result) return msg.result;
   }
-  throw new Error(`No response: stdout=${result.stdout} stderr=${result.stderr}`);
+  throw new Error(`No response: stdout=${stdout} stderr=${stderr}`);
 }
 
 describe('MCP server getBuiltinTools — plugin tool schema', () => {

--- a/tests/unit/tab-title-overflow.test.tsx
+++ b/tests/unit/tab-title-overflow.test.tsx
@@ -78,11 +78,42 @@ vi.mock('@dnd-kit/utilities', () => ({
   CSS: { Transform: { toString: vi.fn(() => '') } },
 }));
 
+vi.mock('../../src/renderer/stores/workspace-store', () => ({
+  useWorkspaceStore: vi.fn(() => ({
+    workspaces: [],
+    activeWorkspaceId: null,
+    navExpanded: false,
+    setActive: vi.fn(),
+    toggleNav: vi.fn(),
+    addWorkspace: vi.fn(),
+    removeWorkspace: vi.fn(),
+    renameWorkspace: vi.fn(),
+  })),
+}));
+
+vi.mock('../../src/renderer/stores/agent-store', () => ({
+  useAgentStore: vi.fn(() => ({
+    sessionStatuses: {},
+    setStatus: vi.fn(),
+  })),
+}));
+
+vi.mock('../../src/renderer/components/workspace/StatusIndicator', () => ({
+  StatusDot: () => null,
+  StatusBadge: () => null,
+}));
+
+vi.mock('../../src/renderer/components/updater/UpdateNotice', () => ({
+  UpdateNotice: () => null,
+}));
+
 // Minimal window.aide stub
 beforeEach(() => {
   if (!(globalThis as unknown as { aide?: unknown }).aide) {
     (globalThis as unknown as Record<string, unknown>).aide = {
       terminal: { kill: vi.fn() },
+      agent: { onStatus: vi.fn(() => vi.fn()) },
+      workspace: { openDialog: vi.fn(), create: vi.fn(), rename: vi.fn(), showInFinder: vi.fn(), remove: vi.fn() },
     };
   }
 });
@@ -92,19 +123,15 @@ afterEach(() => {
 });
 
 // ---------------------------------------------------------------------------
-// TabBar tests
+// Smoke test 1: TabBar — title span truncates, close button stays visible
 // ---------------------------------------------------------------------------
-describe('TabBar – tab title overflow', () => {
-  it('title span has truncate class', async () => {
+describe('TabBar – tab title overflow smoke test', () => {
+  it('title span has truncate class and close button has shrink-0', async () => {
     const { useTerminalStore } = await import('../../src/renderer/stores/terminal-store');
-    const mockTab = {
-      id: 't1',
-      title: 'A very long tab title that should be truncated with an ellipsis',
-      agentId: 'claude',
-      sessionId: null,
-    };
+    const tab1 = { id: 't1', title: 'A very long tab title that should be truncated with an ellipsis', agentId: 'claude', sessionId: null };
+    const tab2 = { id: 't2', title: 'Tab 2', agentId: 'shell', sessionId: null };
     (useTerminalStore as ReturnType<typeof vi.fn>).mockReturnValue({
-      tabs: [mockTab],
+      tabs: [tab1, tab2],
       activeTabId: 't1',
       setActiveTab: vi.fn(),
       removeTab: vi.fn(),
@@ -116,55 +143,10 @@ describe('TabBar – tab title overflow', () => {
     const { container } = render(<TabBar />);
 
     const titleSpan = Array.from(container.querySelectorAll('span')).find(
-      (s) => s.textContent === mockTab.title
+      (s) => s.textContent === tab1.title
     );
     expect(titleSpan, 'title span not found').toBeTruthy();
     expect(titleSpan!.className).toContain('truncate');
-  });
-
-  it('tab button has min-w-0 and max-w classes', async () => {
-    const { useTerminalStore } = await import('../../src/renderer/stores/terminal-store');
-    const mockTab = {
-      id: 't2',
-      title: 'Another very long tab title exceeding any reasonable width',
-      agentId: 'shell',
-      sessionId: null,
-    };
-    (useTerminalStore as ReturnType<typeof vi.fn>).mockReturnValue({
-      tabs: [mockTab],
-      activeTabId: 't2',
-      setActiveTab: vi.fn(),
-      removeTab: vi.fn(),
-      dropdownOpen: false,
-      toggleDropdown: vi.fn(),
-    });
-
-    const { TabBar } = await import('../../src/renderer/components/terminal/TabBar');
-    const { container } = render(<TabBar />);
-
-    // First button is the tab button (second is the + button)
-    const buttons = container.querySelectorAll('button');
-    const tabButton = buttons[0];
-    expect(tabButton, 'tab button not found').toBeTruthy();
-    expect(tabButton.className).toContain('min-w-0');
-    expect(tabButton.className).toMatch(/max-w-/);
-  });
-
-  it('close button has shrink-0 so it stays visible', async () => {
-    const { useTerminalStore } = await import('../../src/renderer/stores/terminal-store');
-    const tab1 = { id: 't3', title: 'Tab 1', agentId: 'claude', sessionId: null };
-    const tab2 = { id: 't4', title: 'Tab 2', agentId: 'gemini', sessionId: null };
-    (useTerminalStore as ReturnType<typeof vi.fn>).mockReturnValue({
-      tabs: [tab1, tab2],
-      activeTabId: 't3',
-      setActiveTab: vi.fn(),
-      removeTab: vi.fn(),
-      dropdownOpen: false,
-      toggleDropdown: vi.fn(),
-    });
-
-    const { TabBar } = await import('../../src/renderer/components/terminal/TabBar');
-    const { container } = render(<TabBar />);
 
     const closeButtons = Array.from(container.querySelectorAll('span[role="button"]'));
     expect(closeButtons.length, 'no close buttons found').toBeGreaterThan(0);
@@ -175,96 +157,39 @@ describe('TabBar – tab title overflow', () => {
 });
 
 // ---------------------------------------------------------------------------
-// PaneView DraggableTab tests
+// Smoke test 2: PaneView — title span truncates, close button stays visible
+// (DraggableTab tested indirectly via PaneView)
 // ---------------------------------------------------------------------------
-describe('PaneView DraggableTab – tab title overflow', () => {
-  it('title span has truncate class', async () => {
-    const { DraggableTab } = await import('../../src/renderer/components/layout/PaneView');
-
+describe('PaneView – tab title overflow smoke test', () => {
+  it('title span has truncate class and close button has shrink-0', async () => {
+    const { useLayoutStore } = await import('../../src/renderer/stores/layout-store');
     const mockTab = {
       id: 'p1',
       title: 'A very long pane tab title that must be truncated with ellipsis',
       type: 'terminal' as const,
       sessionId: 'sess1',
       agentId: 'claude',
-      isPlugin: false,
     };
+    const mockPane = { id: 'pane1', tabs: [mockTab], activeTabId: 'p1' };
+    (useLayoutStore as ReturnType<typeof vi.fn>).mockReturnValue({
+      focusedPaneId: 'pane1',
+      setFocusedPane: vi.fn(),
+      setActiveTab: vi.fn(),
+      removeTabFromPane: vi.fn(),
+      renameTabInPane: vi.fn(),
+      splitPane: vi.fn(),
+      closePane: vi.fn(),
+      moveTabToPane: vi.fn(),
+    });
 
-    const { container } = render(
-      <DraggableTab
-        tab={mockTab}
-        paneId="pane1"
-        isActive={false}
-        onActivate={vi.fn()}
-        onClose={vi.fn()}
-        onContextMenu={vi.fn()}
-        onRename={vi.fn()}
-        canClose={true}
-      />
-    );
+    const { PaneView } = await import('../../src/renderer/components/layout/PaneView');
+    const { container } = render(<PaneView pane={mockPane as Parameters<typeof PaneView>[0]['pane']} />);
 
     const titleSpan = Array.from(container.querySelectorAll('span')).find(
       (s) => s.textContent === mockTab.title
     );
     expect(titleSpan, 'title span not found').toBeTruthy();
     expect(titleSpan!.className).toContain('truncate');
-  });
-
-  it('tab button has min-w-0 and max-w classes', async () => {
-    const { DraggableTab } = await import('../../src/renderer/components/layout/PaneView');
-
-    const mockTab = {
-      id: 'p2',
-      title: 'Another long title',
-      type: 'terminal' as const,
-      sessionId: 'sess2',
-      agentId: 'shell',
-      isPlugin: false,
-    };
-
-    const { container } = render(
-      <DraggableTab
-        tab={mockTab}
-        paneId="pane2"
-        isActive={true}
-        onActivate={vi.fn()}
-        onClose={vi.fn()}
-        onContextMenu={vi.fn()}
-        onRename={vi.fn()}
-        canClose={false}
-      />
-    );
-
-    const button = container.querySelector('button');
-    expect(button, 'tab button not found').toBeTruthy();
-    expect(button!.className).toContain('min-w-0');
-    expect(button!.className).toMatch(/max-w-/);
-  });
-
-  it('close button has shrink-0', async () => {
-    const { DraggableTab } = await import('../../src/renderer/components/layout/PaneView');
-
-    const mockTab = {
-      id: 'p3',
-      title: 'Tab title',
-      type: 'terminal' as const,
-      sessionId: 'sess3',
-      agentId: 'claude',
-      isPlugin: false,
-    };
-
-    const { container } = render(
-      <DraggableTab
-        tab={mockTab}
-        paneId="pane3"
-        isActive={false}
-        onActivate={vi.fn()}
-        onClose={vi.fn()}
-        onContextMenu={vi.fn()}
-        onRename={vi.fn()}
-        canClose={true}
-      />
-    );
 
     const closeBtn = container.querySelector('span[role="button"]');
     expect(closeBtn, 'close button not found').toBeTruthy();
@@ -273,11 +198,61 @@ describe('PaneView DraggableTab – tab title overflow', () => {
 });
 
 // ---------------------------------------------------------------------------
-// WorkspaceNav tab row structural test
+// Smoke test 3: WorkspaceNav — sidebar workspace name span truncates
+// (sidebar list uses truncate+flex-1 without a min/max-w cap — different
+//  context from the editor tab bar which enforces 80px/200px bounds)
 // ---------------------------------------------------------------------------
-describe('WorkspaceNav tab row – title overflow', () => {
-  it('WorkspaceNav module exports WorkspaceNav component', async () => {
-    const mod = await import('../../src/renderer/components/workspace/WorkspaceNav');
-    expect(mod.WorkspaceNav).toBeDefined();
+describe('WorkspaceNav – tab title overflow smoke test', () => {
+  it('sidebar workspace name span has truncate class', async () => {
+    const { useWorkspaceStore } = await import('../../src/renderer/stores/workspace-store');
+    const { useTerminalStore } = await import('../../src/renderer/stores/terminal-store');
+    const { useLayoutStore } = await import('../../src/renderer/stores/layout-store');
+
+    const mockWs = { id: 'ws1', name: 'A very long workspace name that should truncate in the sidebar', path: '/home/user/project', color: '#3B82F6' };
+
+    (useWorkspaceStore as ReturnType<typeof vi.fn>).mockReturnValue({
+      workspaces: [mockWs],
+      activeWorkspaceId: 'ws1',
+      navExpanded: true,
+      setActive: vi.fn(),
+      toggleNav: vi.fn(),
+      addWorkspace: vi.fn(),
+      removeWorkspace: vi.fn(),
+      renameWorkspace: vi.fn(),
+    });
+
+    (useTerminalStore as ReturnType<typeof vi.fn>).mockReturnValue({
+      tabs: [],
+      activeTabId: null,
+      setActiveTab: vi.fn(),
+      removeTab: vi.fn(),
+      dropdownOpen: false,
+      toggleDropdown: vi.fn(),
+      workspaceTabs: {},
+    });
+
+    const layoutState = {
+      layout: { id: 'pane1', tabs: [], activeTabId: null },
+      focusedPaneId: null,
+      setFocusedPane: vi.fn(),
+      setActiveTab: vi.fn(),
+      removeTabFromPane: vi.fn(),
+      renameTabInPane: vi.fn(),
+      splitPane: vi.fn(),
+    };
+    (useLayoutStore as ReturnType<typeof vi.fn>).mockImplementation(
+      (selector: (s: typeof layoutState) => unknown) =>
+        typeof selector === 'function' ? selector(layoutState) : layoutState
+    );
+
+    const { WorkspaceNav } = await import('../../src/renderer/components/workspace/WorkspaceNav');
+    const { container } = render(<WorkspaceNav />);
+
+    // Workspace name is always visible in expanded mode and must truncate
+    const nameSpan = Array.from(container.querySelectorAll('span')).find(
+      (s) => s.textContent === mockWs.name
+    );
+    expect(nameSpan, 'workspace name span not found in sidebar').toBeTruthy();
+    expect(nameSpan!.className).toContain('truncate');
   });
 });

--- a/tests/unit/tab-title-overflow.test.tsx
+++ b/tests/unit/tab-title-overflow.test.tsx
@@ -1,0 +1,283 @@
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import React from 'react';
+
+// ---------------------------------------------------------------------------
+// Stub heavy electron / xterm dependencies so happy-dom can load the modules
+// ---------------------------------------------------------------------------
+vi.mock('../../src/renderer/stores/terminal-store', () => ({
+  useTerminalStore: vi.fn(() => ({
+    tabs: [],
+    activeTabId: null,
+    setActiveTab: vi.fn(),
+    removeTab: vi.fn(),
+    dropdownOpen: false,
+    toggleDropdown: vi.fn(),
+  })),
+}));
+
+vi.mock('../../src/renderer/components/terminal/AgentDropdown', () => ({
+  AgentDropdown: () => null,
+}));
+
+vi.mock('../../src/renderer/components/terminal/TerminalPanel', () => ({
+  TerminalPanel: () => null,
+}));
+
+vi.mock('../../src/renderer/components/plugin/PluginView', () => ({
+  PluginView: () => null,
+}));
+
+vi.mock('../../src/renderer/components/layout/EmptyState', () => ({
+  EmptyState: () => null,
+}));
+
+vi.mock('../../src/renderer/stores/layout-store', () => ({
+  useLayoutStore: vi.fn(() => ({
+    focusedPaneId: null,
+    setFocusedPane: vi.fn(),
+    setActiveTab: vi.fn(),
+    removeTabFromPane: vi.fn(),
+    renameTabInPane: vi.fn(),
+    splitPane: vi.fn(),
+    closePane: vi.fn(),
+    moveTabToPane: vi.fn(),
+  })),
+}));
+
+vi.mock('../../src/renderer/lib/xterm-cache', () => ({
+  get: vi.fn(),
+  set: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock('@dnd-kit/core', () => ({
+  DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useSensor: vi.fn(),
+  useSensors: vi.fn(() => []),
+  PointerSensor: vi.fn(),
+  closestCenter: vi.fn(),
+  useDroppable: vi.fn(() => ({ setNodeRef: vi.fn(), isOver: false })),
+  useDndMonitor: vi.fn(),
+}));
+
+vi.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useSortable: vi.fn(() => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false,
+  })),
+  horizontalListSortingStrategy: {},
+}));
+
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: { Transform: { toString: vi.fn(() => '') } },
+}));
+
+// Minimal window.aide stub
+beforeEach(() => {
+  if (!(globalThis as unknown as { aide?: unknown }).aide) {
+    (globalThis as unknown as Record<string, unknown>).aide = {
+      terminal: { kill: vi.fn() },
+    };
+  }
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// TabBar tests
+// ---------------------------------------------------------------------------
+describe('TabBar – tab title overflow', () => {
+  it('title span has truncate class', async () => {
+    const { useTerminalStore } = await import('../../src/renderer/stores/terminal-store');
+    const mockTab = {
+      id: 't1',
+      title: 'A very long tab title that should be truncated with an ellipsis',
+      agentId: 'claude',
+      sessionId: null,
+    };
+    (useTerminalStore as ReturnType<typeof vi.fn>).mockReturnValue({
+      tabs: [mockTab],
+      activeTabId: 't1',
+      setActiveTab: vi.fn(),
+      removeTab: vi.fn(),
+      dropdownOpen: false,
+      toggleDropdown: vi.fn(),
+    });
+
+    const { TabBar } = await import('../../src/renderer/components/terminal/TabBar');
+    const { container } = render(<TabBar />);
+
+    const titleSpan = Array.from(container.querySelectorAll('span')).find(
+      (s) => s.textContent === mockTab.title
+    );
+    expect(titleSpan, 'title span not found').toBeTruthy();
+    expect(titleSpan!.className).toContain('truncate');
+  });
+
+  it('tab button has min-w-0 and max-w classes', async () => {
+    const { useTerminalStore } = await import('../../src/renderer/stores/terminal-store');
+    const mockTab = {
+      id: 't2',
+      title: 'Another very long tab title exceeding any reasonable width',
+      agentId: 'shell',
+      sessionId: null,
+    };
+    (useTerminalStore as ReturnType<typeof vi.fn>).mockReturnValue({
+      tabs: [mockTab],
+      activeTabId: 't2',
+      setActiveTab: vi.fn(),
+      removeTab: vi.fn(),
+      dropdownOpen: false,
+      toggleDropdown: vi.fn(),
+    });
+
+    const { TabBar } = await import('../../src/renderer/components/terminal/TabBar');
+    const { container } = render(<TabBar />);
+
+    // First button is the tab button (second is the + button)
+    const buttons = container.querySelectorAll('button');
+    const tabButton = buttons[0];
+    expect(tabButton, 'tab button not found').toBeTruthy();
+    expect(tabButton.className).toContain('min-w-0');
+    expect(tabButton.className).toMatch(/max-w-/);
+  });
+
+  it('close button has shrink-0 so it stays visible', async () => {
+    const { useTerminalStore } = await import('../../src/renderer/stores/terminal-store');
+    const tab1 = { id: 't3', title: 'Tab 1', agentId: 'claude', sessionId: null };
+    const tab2 = { id: 't4', title: 'Tab 2', agentId: 'gemini', sessionId: null };
+    (useTerminalStore as ReturnType<typeof vi.fn>).mockReturnValue({
+      tabs: [tab1, tab2],
+      activeTabId: 't3',
+      setActiveTab: vi.fn(),
+      removeTab: vi.fn(),
+      dropdownOpen: false,
+      toggleDropdown: vi.fn(),
+    });
+
+    const { TabBar } = await import('../../src/renderer/components/terminal/TabBar');
+    const { container } = render(<TabBar />);
+
+    const closeButtons = Array.from(container.querySelectorAll('span[role="button"]'));
+    expect(closeButtons.length, 'no close buttons found').toBeGreaterThan(0);
+    closeButtons.forEach((btn) => {
+      expect(btn.className).toContain('shrink-0');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PaneView DraggableTab tests
+// ---------------------------------------------------------------------------
+describe('PaneView DraggableTab – tab title overflow', () => {
+  it('title span has truncate class', async () => {
+    const { DraggableTab } = await import('../../src/renderer/components/layout/PaneView');
+
+    const mockTab = {
+      id: 'p1',
+      title: 'A very long pane tab title that must be truncated with ellipsis',
+      type: 'terminal' as const,
+      sessionId: 'sess1',
+      agentId: 'claude',
+      isPlugin: false,
+    };
+
+    const { container } = render(
+      <DraggableTab
+        tab={mockTab}
+        paneId="pane1"
+        isActive={false}
+        onActivate={vi.fn()}
+        onClose={vi.fn()}
+        onContextMenu={vi.fn()}
+        onRename={vi.fn()}
+        canClose={true}
+      />
+    );
+
+    const titleSpan = Array.from(container.querySelectorAll('span')).find(
+      (s) => s.textContent === mockTab.title
+    );
+    expect(titleSpan, 'title span not found').toBeTruthy();
+    expect(titleSpan!.className).toContain('truncate');
+  });
+
+  it('tab button has min-w-0 and max-w classes', async () => {
+    const { DraggableTab } = await import('../../src/renderer/components/layout/PaneView');
+
+    const mockTab = {
+      id: 'p2',
+      title: 'Another long title',
+      type: 'terminal' as const,
+      sessionId: 'sess2',
+      agentId: 'shell',
+      isPlugin: false,
+    };
+
+    const { container } = render(
+      <DraggableTab
+        tab={mockTab}
+        paneId="pane2"
+        isActive={true}
+        onActivate={vi.fn()}
+        onClose={vi.fn()}
+        onContextMenu={vi.fn()}
+        onRename={vi.fn()}
+        canClose={false}
+      />
+    );
+
+    const button = container.querySelector('button');
+    expect(button, 'tab button not found').toBeTruthy();
+    expect(button!.className).toContain('min-w-0');
+    expect(button!.className).toMatch(/max-w-/);
+  });
+
+  it('close button has shrink-0', async () => {
+    const { DraggableTab } = await import('../../src/renderer/components/layout/PaneView');
+
+    const mockTab = {
+      id: 'p3',
+      title: 'Tab title',
+      type: 'terminal' as const,
+      sessionId: 'sess3',
+      agentId: 'claude',
+      isPlugin: false,
+    };
+
+    const { container } = render(
+      <DraggableTab
+        tab={mockTab}
+        paneId="pane3"
+        isActive={false}
+        onActivate={vi.fn()}
+        onClose={vi.fn()}
+        onContextMenu={vi.fn()}
+        onRename={vi.fn()}
+        canClose={true}
+      />
+    );
+
+    const closeBtn = container.querySelector('span[role="button"]');
+    expect(closeBtn, 'close button not found').toBeTruthy();
+    expect(closeBtn!.className).toContain('shrink-0');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WorkspaceNav tab row structural test
+// ---------------------------------------------------------------------------
+describe('WorkspaceNav tab row – title overflow', () => {
+  it('WorkspaceNav module exports WorkspaceNav component', async () => {
+    const mod = await import('../../src/renderer/components/workspace/WorkspaceNav');
+    expect(mod.WorkspaceNav).toBeDefined();
+  });
+});

--- a/tests/unit/tooltip.test.tsx
+++ b/tests/unit/tooltip.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
+import { render, cleanup, act, fireEvent } from '@testing-library/react';
+import { Tooltip } from '../../src/renderer/components/ui/Tooltip';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('Tooltip', () => {
+  it('renders children always', () => {
+    const { getByText } = render(
+      <Tooltip content="tip text">
+        <button>child</button>
+      </Tooltip>
+    );
+    expect(getByText('child')).toBeTruthy();
+  });
+
+  it('tooltip is not in DOM initially', () => {
+    const { queryByRole } = render(
+      <Tooltip content="tip text">
+        <button>child</button>
+      </Tooltip>
+    );
+    expect(queryByRole('tooltip')).toBeNull();
+  });
+
+  it('shows tooltip with content after mouseenter + delay', async () => {
+    const { getByText, queryByRole } = render(
+      <Tooltip content="tip text">
+        <button>child</button>
+      </Tooltip>
+    );
+    const wrapper = getByText('child').closest('[data-tooltip-wrapper]') as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    // before delay: still hidden
+    expect(queryByRole('tooltip')).toBeNull();
+    // advance past 200ms delay
+    act(() => { vi.advanceTimersByTime(250); });
+    expect(queryByRole('tooltip')).toBeTruthy();
+    expect(queryByRole('tooltip')?.textContent).toBe('tip text');
+  });
+
+  it('hides tooltip after mouseleave', async () => {
+    const { getByText, queryByRole } = render(
+      <Tooltip content="tip text">
+        <button>child</button>
+      </Tooltip>
+    );
+    const wrapper = getByText('child').closest('[data-tooltip-wrapper]') as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    act(() => { vi.advanceTimersByTime(250); });
+    expect(queryByRole('tooltip')).toBeTruthy();
+
+    fireEvent.mouseLeave(wrapper);
+    expect(queryByRole('tooltip')).toBeNull();
+  });
+
+  it('shows tooltip on focus (keyboard a11y)', () => {
+    const { getByText, queryByRole } = render(
+      <Tooltip content="focus tip">
+        <button>child</button>
+      </Tooltip>
+    );
+    const wrapper = getByText('child').closest('[data-tooltip-wrapper]') as HTMLElement;
+    fireEvent.focus(wrapper);
+    act(() => { vi.advanceTimersByTime(250); });
+    expect(queryByRole('tooltip')).toBeTruthy();
+  });
+
+  it('hides tooltip on blur', () => {
+    const { getByText, queryByRole } = render(
+      <Tooltip content="focus tip">
+        <button>child</button>
+      </Tooltip>
+    );
+    const wrapper = getByText('child').closest('[data-tooltip-wrapper]') as HTMLElement;
+    fireEvent.focus(wrapper);
+    act(() => { vi.advanceTimersByTime(250); });
+    expect(queryByRole('tooltip')).toBeTruthy();
+
+    fireEvent.blur(wrapper);
+    expect(queryByRole('tooltip')).toBeNull();
+  });
+
+  it('sets aria-describedby on wrapper pointing to tooltip when open', () => {
+    const { getByText } = render(
+      <Tooltip content="aria tip">
+        <button>child</button>
+      </Tooltip>
+    );
+    const wrapper = getByText('child').closest('[data-tooltip-wrapper]') as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    act(() => { vi.advanceTimersByTime(250); });
+    const tooltipEl = wrapper.querySelector('[role="tooltip"]') as HTMLElement;
+    expect(tooltipEl).toBeTruthy();
+    expect(wrapper.getAttribute('aria-describedby')).toBe(tooltipEl.id);
+  });
+});

--- a/tests/unit/tooltip.test.tsx
+++ b/tests/unit/tooltip.test.tsx
@@ -89,7 +89,7 @@ describe('Tooltip', () => {
   });
 
   it('sets aria-describedby on wrapper pointing to tooltip when open', () => {
-    const { getByText } = render(
+    const { getByText, queryByRole } = render(
       <Tooltip content="aria tip">
         <button>child</button>
       </Tooltip>
@@ -97,8 +97,41 @@ describe('Tooltip', () => {
     const wrapper = getByText('child').closest('[data-tooltip-wrapper]') as HTMLElement;
     fireEvent.mouseEnter(wrapper);
     act(() => { vi.advanceTimersByTime(250); });
-    const tooltipEl = wrapper.querySelector('[role="tooltip"]') as HTMLElement;
+    // Tooltip is portal-rendered into document.body — use queryByRole which searches full document
+    const tooltipEl = queryByRole('tooltip') as HTMLElement;
     expect(tooltipEl).toBeTruthy();
     expect(wrapper.getAttribute('aria-describedby')).toBe(tooltipEl.id);
+  });
+
+  it('cancels pending show when mouse leaves before delay', () => {
+    const { getByText, queryByRole } = render(
+      <Tooltip content="hi"><button>x</button></Tooltip>
+    );
+    const trigger = getByText('x').closest('[data-tooltip-wrapper]') as HTMLElement;
+    fireEvent.mouseEnter(trigger);
+    fireEvent.mouseLeave(trigger);
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(queryByRole('tooltip')).toBeNull();
+  });
+
+  it('clears pending timer on unmount', () => {
+    const { getByText, unmount } = render(
+      <Tooltip content="hi"><button>x</button></Tooltip>
+    );
+    fireEvent.mouseEnter(getByText('x').closest('[data-tooltip-wrapper]') as HTMLElement);
+    unmount();
+    expect(() => { act(() => { vi.advanceTimersByTime(500); }); }).not.toThrow();
+  });
+
+  it('dismisses tooltip on ESC keydown', () => {
+    const { getByText, queryByRole } = render(
+      <Tooltip content="hi"><button>x</button></Tooltip>
+    );
+    const wrapper = getByText('x').closest('[data-tooltip-wrapper]') as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    act(() => { vi.advanceTimersByTime(250); });
+    expect(queryByRole('tooltip')).not.toBeNull();
+    fireEvent.keyDown(wrapper, { key: 'Escape' });
+    expect(queryByRole('tooltip')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
Release v0.0.9 from develop. Highlights:

- **MCP plugin tool schemas** now pass through the full JSON Schema verbatim instead of flattening `properties`/`required`/`type` into field names, so external agents can call plugin tools correctly (#65).
- **Plugin iframe `<form>` submit** works again — sandbox now includes `allow-forms`, and the subtask-composer no longer loses clicks to the draggable card's native drag behavior.
- **Tab title overflow** — long titles now truncate with ellipsis under a min/max width, and hovering the tab shows the full title via the shared Tooltip component (#67, #70, #71).
- **Workspace path** uses front-truncation (keeping the basename visible) and a hover tooltip showing the full absolute path (#66).
- **Tooltip centering** — fixed a bug where tooltips were offset by ~160px to the left because a hardcoded `assumedWidth=320` was subtracted from the anchor; now centering uses a CSS transform (#71).
- **CI stability** — MCP schema tests decode stdout from a Buffer in one pass to avoid UTF-8 chunk-boundary truncation on Node 20 macOS runners.

## Version bump
- `package.json`: `0.0.8 → 0.0.9`

## Test plan
- [ ] `pnpm test` (176/176 passing on develop)
- [ ] Smoke-test a built DMG:
  - [ ] Tab hover shows full title
  - [ ] Workspace row hover shows full path
  - [ ] Plugin panel Add button adds a subtask
  - [ ] External MCP client can call a plugin tool with structured params
- [ ] Tag `v0.0.9` and publish GitHub Release after merge to trigger `release.yml` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)