### PR TITLE
chore: back-merge main into develop after v0.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aide",
   "productName": "AIDE",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "AI-Driven IDE - Create n Play plugins with natural language",
   "main": ".vite/build/index.js",
   "private": true,


### PR DESCRIPTION
## Summary
Back-merge `main` into `develop` after the v0.0.9 release so develop picks up the version bump commit (`chore(release): bump version to 0.0.9`) and stays strictly ancestor-consistent with main.

Only `package.json` changes — the content is the same `0.0.8 → 0.0.9` bump already tagged as `v0.0.9`.

## Test plan
- [ ] Confirm `git log main..develop` is empty after merge
- [ ] No test or build changes required

🤖 Generated with [Claude Code](https://claude.com/claude-code)