### PR TITLE
release: v0.0.10 (native module rebuild hotfix)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,6 +27,18 @@ DMG_TMP_PATH="out/AIDE-tmp.dmg"
 echo "[1/4] Installing dependencies..."
 pnpm install
 
+# Force-run native module install scripts. pnpm+cached store on CI has skipped
+# node-pty's prebuild/gyp step silently, leaving build/Release/pty.node absent.
+echo "      Rebuilding native modules..."
+pnpm rebuild node-pty
+
+# Sanity check: pty.node must exist before we try to package it.
+if [ ! -f "node_modules/node-pty/build/Release/pty.node" ]; then
+  echo "::error::pty.node missing from node_modules after rebuild. Aborting."
+  exit 1
+fi
+echo "      pty.node present ($(stat -f%z node_modules/node-pty/build/Release/pty.node) bytes)"
+
 # Lint
 echo "[2/4] Running lint..."
 pnpm run lint

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aide",
   "productName": "AIDE",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "AI-Driven IDE - Create n Play plugins with natural language",
   "main": ".vite/build/index.js",
   "private": true,


### PR DESCRIPTION
## Summary
The v0.0.9 release workflow failed at artifact verification because `pty.node` was missing from `app.asar.unpacked/node_modules/node-pty/build/Release/`. Root cause: the pnpm lockfile cache on CI restored node-pty's source files but its install script (which fetches or builds the prebuild via prebuildify/node-gyp) never ran, so the binary was never present in the source `node_modules/` to be copied into the app bundle.

This PR:
- Adds an explicit `pnpm rebuild node-pty` step in `build.sh` after install, with a fail-fast assertion that `pty.node` is on disk.
- Bumps the version to **0.0.10** so we re-release with a proper DMG (v0.0.9 never shipped a usable binary).

## Test plan
- [ ] CI log shows `pty.node present (N bytes)` after install
- [ ] `release.yml` verification confirms `pty.node` in both `app.asar.unpacked` and `AIDE.app.zip`
- [ ] DMG boots and terminal spawns

## Follow-up
- After merge, tag `v0.0.10` on the merge commit and publish a GitHub Release to trigger the build.
- Back-merge `main → develop` to pick up the build fix and version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)