### PR TITLE
chore: back-merge main into develop after v0.0.10

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,6 +27,18 @@ DMG_TMP_PATH="out/AIDE-tmp.dmg"
 echo "[1/4] Installing dependencies..."
 pnpm install
 
+# Force-run native module install scripts. pnpm+cached store on CI has skipped
+# node-pty's prebuild/gyp step silently, leaving build/Release/pty.node absent.
+echo "      Rebuilding native modules..."
+pnpm rebuild node-pty
+
+# Sanity check: pty.node must exist before we try to package it.
+if [ ! -f "node_modules/node-pty/build/Release/pty.node" ]; then
+  echo "::error::pty.node missing from node_modules after rebuild. Aborting."
+  exit 1
+fi
+echo "      pty.node present ($(stat -f%z node_modules/node-pty/build/Release/pty.node) bytes)"
+
 # Lint
 echo "[2/4] Running lint..."
 pnpm run lint

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aide",
   "productName": "AIDE",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "AI-Driven IDE - Create n Play plugins with natural language",
   "main": ".vite/build/index.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aide",
   "productName": "AIDE",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "AI-Driven IDE - Create n Play plugins with natural language",
   "main": ".vite/build/index.js",
   "private": true,


### PR DESCRIPTION
Pulls the v0.0.9 → v0.0.10 bump and the build.sh native-module rebuild hotfix into develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)