### PR TITLE
release: v0.0.11 — accept node-pty prebuild as valid artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,22 +34,31 @@ jobs:
           ARCH=$(uname -m)
           if [ "$ARCH" = "arm64" ]; then
             APP_DIR="out/AIDE-darwin-arm64/AIDE.app"
+            PREBUILD_ARCH="arm64"
           else
             APP_DIR="out/AIDE-darwin-x64/AIDE.app"
+            PREBUILD_ARCH="x64"
           fi
-          PTY_PATH="$APP_DIR/Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/pty.node"
+          UNPACKED="$APP_DIR/Contents/Resources/app.asar.unpacked/node_modules/node-pty"
+          PTY_BUILT="$UNPACKED/build/Release/pty.node"
+          PTY_PREBUILD="$UNPACKED/prebuilds/darwin-$PREBUILD_ARCH/pty.node"
 
           echo "--- app.asar.unpacked contents ---"
           ls -la "$APP_DIR/Contents/Resources/app.asar.unpacked/" || true
 
-          if [ ! -f "$PTY_PATH" ]; then
-            echo "::error::Missing native module at $PTY_PATH"
+          # node-pty loads from build/Release, build/Debug, or prebuilds/<p>-<a>.
+          # Accept any of these paths; only fail when none exist.
+          if [ -f "$PTY_BUILT" ]; then
+            echo "pty.node verified (built): $PTY_BUILT ($(stat -f%z "$PTY_BUILT") bytes)"
+          elif [ -f "$PTY_PREBUILD" ]; then
+            echo "pty.node verified (prebuild): $PTY_PREBUILD ($(stat -f%z "$PTY_PREBUILD") bytes)"
+          else
+            echo "::error::Missing native module. Checked $PTY_BUILT and $PTY_PREBUILD."
             echo "This would ship a broken app that cannot spawn terminals."
             exit 1
           fi
-          echo "pty.node verified: $PTY_PATH ($(stat -f%z "$PTY_PATH") bytes)"
 
-          if ! unzip -l out/AIDE.app.zip | grep -q "node-pty/build/Release/pty.node"; then
+          if ! unzip -l out/AIDE.app.zip | grep -qE "node-pty/(build/Release|prebuilds/darwin-$PREBUILD_ARCH)/pty.node"; then
             echo "::error::pty.node missing from out/AIDE.app.zip"
             exit 1
           fi

--- a/build.sh
+++ b/build.sh
@@ -27,17 +27,25 @@ DMG_TMP_PATH="out/AIDE-tmp.dmg"
 echo "[1/4] Installing dependencies..."
 pnpm install
 
-# Force-run native module install scripts. pnpm+cached store on CI has skipped
-# node-pty's prebuild/gyp step silently, leaving build/Release/pty.node absent.
+# Force-run native module install scripts so node-pty's prebuild download is
+# triggered even when pnpm restores from cache.
 echo "      Rebuilding native modules..."
 pnpm rebuild node-pty
 
-# Sanity check: pty.node must exist before we try to package it.
-if [ ! -f "node_modules/node-pty/build/Release/pty.node" ]; then
-  echo "::error::pty.node missing from node_modules after rebuild. Aborting."
+# node-pty's loader (lib/utils.js) resolves the native binary from either
+# build/Release, build/Debug, or prebuilds/<platform>-<arch>. Accept any of
+# these; only fail if none exist.
+PTY_BUILT="node_modules/node-pty/build/Release/pty.node"
+PTY_PREBUILD_DIR="node_modules/node-pty/prebuilds/$(uname -s | tr 'A-Z' 'a-z')-$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')"
+PTY_PREBUILD="$PTY_PREBUILD_DIR/pty.node"
+if [ -f "$PTY_BUILT" ]; then
+  echo "      pty.node (built) present ($(stat -f%z "$PTY_BUILT") bytes)"
+elif [ -f "$PTY_PREBUILD" ]; then
+  echo "      pty.node (prebuild) present at $PTY_PREBUILD ($(stat -f%z "$PTY_PREBUILD") bytes)"
+else
+  echo "::error::pty.node missing: neither $PTY_BUILT nor $PTY_PREBUILD exists."
   exit 1
 fi
-echo "      pty.node present ($(stat -f%z node_modules/node-pty/build/Release/pty.node) bytes)"
 
 # Lint
 echo "[2/4] Running lint..."

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aide",
   "productName": "AIDE",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "AI-Driven IDE - Create n Play plugins with natural language",
   "main": ".vite/build/index.js",
   "private": true,


### PR DESCRIPTION
## Summary
The v0.0.10 release build still failed verification. Root cause: node-pty's loader (`lib/utils.js:19`) resolves its native binary from any of `build/Release/`, `build/Debug/`, or `prebuilds/<platform>-<arch>/`. On CI, node-pty's install script finds a matching prebuild, so electron-forge's rebuild step skips producing `build/Release/pty.node` — but the prebuild file at `prebuilds/darwin-arm64/pty.node` is present and fully functional.

Our verification scripts were only looking at `build/Release/pty.node`, which caused a false negative on a perfectly valid build.

## Changes
- **`build.sh`**: after `pnpm rebuild node-pty`, accept either `node_modules/node-pty/build/Release/pty.node` OR the platform-specific prebuild path.
- **`.github/workflows/release.yml`**: verification step now checks either location in the packaged app and in `AIDE.app.zip`.
- **`package.json`**: `0.0.10 → 0.0.11`.

## Test plan
- [ ] CI `Build DMG` step prints `pty.node (prebuild) present at ...`
- [ ] CI `Verify native modules` step prints `pty.node verified (prebuild): ...`
- [ ] `AIDE.app.zip` contains a `pty.node` at one of the expected paths
- [ ] DMG boots and terminals spawn

## Follow-up
- Tag `v0.0.11` on main HEAD after merge and publish GitHub Release to trigger `release.yml`.
- Back-merge `main → develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)