### PR TITLE
chore: back-merge main into develop after v0.0.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,22 +34,31 @@ jobs:
           ARCH=$(uname -m)
           if [ "$ARCH" = "arm64" ]; then
             APP_DIR="out/AIDE-darwin-arm64/AIDE.app"
+            PREBUILD_ARCH="arm64"
           else
             APP_DIR="out/AIDE-darwin-x64/AIDE.app"
+            PREBUILD_ARCH="x64"
           fi
-          PTY_PATH="$APP_DIR/Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/pty.node"
+          UNPACKED="$APP_DIR/Contents/Resources/app.asar.unpacked/node_modules/node-pty"
+          PTY_BUILT="$UNPACKED/build/Release/pty.node"
+          PTY_PREBUILD="$UNPACKED/prebuilds/darwin-$PREBUILD_ARCH/pty.node"
 
           echo "--- app.asar.unpacked contents ---"
           ls -la "$APP_DIR/Contents/Resources/app.asar.unpacked/" || true
 
-          if [ ! -f "$PTY_PATH" ]; then
-            echo "::error::Missing native module at $PTY_PATH"
+          # node-pty loads from build/Release, build/Debug, or prebuilds/<p>-<a>.
+          # Accept any of these paths; only fail when none exist.
+          if [ -f "$PTY_BUILT" ]; then
+            echo "pty.node verified (built): $PTY_BUILT ($(stat -f%z "$PTY_BUILT") bytes)"
+          elif [ -f "$PTY_PREBUILD" ]; then
+            echo "pty.node verified (prebuild): $PTY_PREBUILD ($(stat -f%z "$PTY_PREBUILD") bytes)"
+          else
+            echo "::error::Missing native module. Checked $PTY_BUILT and $PTY_PREBUILD."
             echo "This would ship a broken app that cannot spawn terminals."
             exit 1
           fi
-          echo "pty.node verified: $PTY_PATH ($(stat -f%z "$PTY_PATH") bytes)"
 
-          if ! unzip -l out/AIDE.app.zip | grep -q "node-pty/build/Release/pty.node"; then
+          if ! unzip -l out/AIDE.app.zip | grep -qE "node-pty/(build/Release|prebuilds/darwin-$PREBUILD_ARCH)/pty.node"; then
             echo "::error::pty.node missing from out/AIDE.app.zip"
             exit 1
           fi

--- a/build.sh
+++ b/build.sh
@@ -27,17 +27,25 @@ DMG_TMP_PATH="out/AIDE-tmp.dmg"
 echo "[1/4] Installing dependencies..."
 pnpm install
 
-# Force-run native module install scripts. pnpm+cached store on CI has skipped
-# node-pty's prebuild/gyp step silently, leaving build/Release/pty.node absent.
+# Force-run native module install scripts so node-pty's prebuild download is
+# triggered even when pnpm restores from cache.
 echo "      Rebuilding native modules..."
 pnpm rebuild node-pty
 
-# Sanity check: pty.node must exist before we try to package it.
-if [ ! -f "node_modules/node-pty/build/Release/pty.node" ]; then
-  echo "::error::pty.node missing from node_modules after rebuild. Aborting."
+# node-pty's loader (lib/utils.js) resolves the native binary from either
+# build/Release, build/Debug, or prebuilds/<platform>-<arch>. Accept any of
+# these; only fail if none exist.
+PTY_BUILT="node_modules/node-pty/build/Release/pty.node"
+PTY_PREBUILD_DIR="node_modules/node-pty/prebuilds/$(uname -s | tr 'A-Z' 'a-z')-$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')"
+PTY_PREBUILD="$PTY_PREBUILD_DIR/pty.node"
+if [ -f "$PTY_BUILT" ]; then
+  echo "      pty.node (built) present ($(stat -f%z "$PTY_BUILT") bytes)"
+elif [ -f "$PTY_PREBUILD" ]; then
+  echo "      pty.node (prebuild) present at $PTY_PREBUILD ($(stat -f%z "$PTY_PREBUILD") bytes)"
+else
+  echo "::error::pty.node missing: neither $PTY_BUILT nor $PTY_PREBUILD exists."
   exit 1
 fi
-echo "      pty.node present ($(stat -f%z node_modules/node-pty/build/Release/pty.node) bytes)"
 
 # Lint
 echo "[2/4] Running lint..."

--- a/build.sh
+++ b/build.sh
@@ -27,6 +27,18 @@ DMG_TMP_PATH="out/AIDE-tmp.dmg"
 echo "[1/4] Installing dependencies..."
 pnpm install
 
+# Force-run native module install scripts. pnpm+cached store on CI has skipped
+# node-pty's prebuild/gyp step silently, leaving build/Release/pty.node absent.
+echo "      Rebuilding native modules..."
+pnpm rebuild node-pty
+
+# Sanity check: pty.node must exist before we try to package it.
+if [ ! -f "node_modules/node-pty/build/Release/pty.node" ]; then
+  echo "::error::pty.node missing from node_modules after rebuild. Aborting."
+  exit 1
+fi
+echo "      pty.node present ($(stat -f%z node_modules/node-pty/build/Release/pty.node) bytes)"
+
 # Lint
 echo "[2/4] Running lint..."
 pnpm run lint

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aide",
   "productName": "AIDE",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "AI-Driven IDE - Create n Play plugins with natural language",
   "main": ".vite/build/index.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aide",
   "productName": "AIDE",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "AI-Driven IDE - Create n Play plugins with natural language",
   "main": ".vite/build/index.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aide",
   "productName": "AIDE",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "AI-Driven IDE - Create n Play plugins with natural language",
   "main": ".vite/build/index.js",
   "private": true,


### PR DESCRIPTION
Pulls v0.0.9 → v0.0.11 (release bumps, build.sh native-module rebuild, and the prebuild-aware verification) into develop so the two branches are fully aligned after the v0.0.11 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)