### PR TITLE
fix(session): eliminate duplicate PTY spawn on initial workspace load

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { TitleBar } from './components/layout/TitleBar';
 import { StatusBar } from './components/layout/StatusBar';
 import { SplitContainer } from './components/layout/SplitContainer';
@@ -52,13 +52,9 @@ export function App() {
     }
   }, [theme]);
 
-  // Restore session on initial workspace load (workspace switches handled by setActive)
-  const initialRestoreDone = useRef(false);
-  useEffect(() => {
-    if (!activeWorkspaceId || initialRestoreDone.current) return;
-    initialRestoreDone.current = true;
-    useLayoutStore.getState().restoreSession(activeWorkspaceId);
-  }, [activeWorkspaceId]);
+  // Session restoration is owned by workspace-store.setActive(), which runs
+  // restoreSession() on first visit to each workspace. No App-level restore
+  // effect here — a duplicate call would spawn every saved PTY twice.
 
   // Save session on app quit — use sendSync to guarantee write before window closes
   useEffect(() => {


### PR DESCRIPTION
## Summary
Fixes a double-spawn bug where every saved PTY (shell, claude, gemini, codex) was created twice on app launch. Symptoms: opening the app with a previously-saved Claude tab would start two \`claude\` processes and show two tabs in the UI.

## Root cause
\`restoreSession(workspaceId)\` was called from two places on the initial workspace-load path:

1. \`workspace-store.setActive()\` — triggered by \`loadWorkspaces()\` auto-opening the most recent workspace (line 61 of \`workspace-store.ts\`).
2. \`App.tsx\` \`useEffect([activeWorkspaceId])\` — fired when \`setActive\` set \`activeWorkspaceId\`, passing the \`initialRestoreDone\` guard once.

Both paths ran \`restoreSession\` for the same workspace, each spawning every saved PTY from scratch.

## Fix
Delete the App-level \`useEffect\` that called \`restoreSession\`. \`workspace-store.setActive\` is the sole owner of session restoration, covering all workspace entry points (auto-open on boot, WorkspaceNav switch, WelcomePage selection).

Also removed the unused \`useRef\` import that was the guard variable's only consumer.

## Review
Ran devil's-advocate critic pass over the change (five candidate regressions: missing boot path, re-entry behavior, cache staleness, hidden side effects of the deleted effect, StrictMode double-fire). All five verified clean against the current code.

## Test plan
- [x] \`pnpm lint\` and \`pnpm test\` (176/176) pass.
- [ ] Manual: app launches with a saved Claude tab → exactly one \`claude\` process and one tab.
- [ ] Manual: switching workspaces back and forth still restores the correct tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)