### PR TITLE
fix(mcp): stop registering AIDE in ~/.claude.json to prevent duplicate spawn

### DIFF
--- a/src/main/mcp/config-writer.ts
+++ b/src/main/mcp/config-writer.ts
@@ -81,6 +81,29 @@ function registerJsonMcpConfig(configPath: string, nodePath: string, serverPath:
 }
 
 /**
+ * Removes the mcpServers.aide entry from a JSON MCP config file.
+ * Preserves other mcpServers and top-level keys. If mcpServers becomes
+ * empty after removal, the key is dropped. If the file does not exist
+ * or contains no aide entry, this is a no-op.
+ */
+export function unregisterAideFromJsonConfig(configPath: string): void {
+  if (!fs.existsSync(configPath)) return;
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  } catch {
+    return; // corrupt — leave untouched
+  }
+  const servers = config.mcpServers as Record<string, unknown> | undefined;
+  if (!servers || typeof servers !== 'object' || !('aide' in servers)) return;
+  delete servers['aide'];
+  if (Object.keys(servers).length === 0) {
+    delete config.mcpServers;
+  }
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+}
+
+/**
  * Removes the [mcp_servers.aide] section AND any sub-sections (e.g. [mcp_servers.aide.env])
  * from a TOML string (line-by-line, safe for array values).
  * Handles sub-sections that appear before or after the parent section header.
@@ -107,11 +130,14 @@ export function writeMcpConfig(workspacePath: string): string {
 
   writeMcpServerScript();
 
-  // Register in ~/.claude.json (Claude uses --mcp-config per-workspace; this is a fallback)
+  // Claude is launched with --mcp-config <path>, so a global entry in
+  // ~/.claude.json would cause Claude to spawn the AIDE MCP server twice
+  // (once per config source). Strip any legacy entry older versions of AIDE
+  // wrote there. Idempotent — safe to run on every workspace change.
   try {
-    registerJsonMcpConfig(path.join(home, '.claude.json'), nodePath, serverPath);
+    unregisterAideFromJsonConfig(path.join(home, '.claude.json'));
   } catch (err) {
-    console.warn('[AIDE] Failed to register Claude MCP config:', (err as Error).message);
+    console.warn('[AIDE] Failed to clean legacy Claude MCP entry:', (err as Error).message);
   }
 
   // Register in ~/.gemini/settings.json (Gemini has no --mcp-config flag)

--- a/src/main/mcp/config-writer.ts
+++ b/src/main/mcp/config-writer.ts
@@ -130,14 +130,23 @@ export function writeMcpConfig(workspacePath: string): string {
 
   writeMcpServerScript();
 
-  // Claude is launched with --mcp-config <path>, so a global entry in
-  // ~/.claude.json would cause Claude to spawn the AIDE MCP server twice
-  // (once per config source). Strip any legacy entry older versions of AIDE
-  // wrote there. Idempotent — safe to run on every workspace change.
+  // Claude is launched with --mcp-config <path>, so ANY other config source
+  // that lists "aide" causes Claude to spawn the MCP server once per source.
+  // Strip legacy entries older versions of AIDE wrote:
+  //   1. ~/.claude.json (global Claude config)
+  //   2. ~/.mcp.json    (HOME-level .mcp.json; Claude auto-discovers it by
+  //                      walking up from cwd, and every workspace is under HOME,
+  //                      so it's always picked up alongside --mcp-config)
+  // Idempotent — safe to run on every workspace change.
   try {
     unregisterAideFromJsonConfig(path.join(home, '.claude.json'));
   } catch (err) {
     console.warn('[AIDE] Failed to clean legacy Claude MCP entry:', (err as Error).message);
+  }
+  try {
+    unregisterAideFromJsonConfig(path.join(home, '.mcp.json'));
+  } catch (err) {
+    console.warn('[AIDE] Failed to clean legacy ~/.mcp.json entry:', (err as Error).message);
   }
 
   // Register in ~/.gemini/settings.json (Gemini has no --mcp-config flag)

--- a/tests/unit/unregister-aide-claude-global.test.ts
+++ b/tests/unit/unregister-aide-claude-global.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { unregisterAideFromJsonConfig } from '../../src/main/mcp/config-writer';
+
+describe('unregisterAideFromJsonConfig', () => {
+  let tmpDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aide-unreg-test-'));
+    configPath = path.join(tmpDir, '.claude.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('does nothing when the config file does not exist', () => {
+    expect(() => unregisterAideFromJsonConfig(configPath)).not.toThrow();
+    expect(fs.existsSync(configPath)).toBe(false);
+  });
+
+  it('removes the aide entry when it is the only mcpServer', () => {
+    const config = {
+      mcpServers: {
+        aide: { command: 'node', args: ['/path/to/server.js'] },
+      },
+    };
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+    unregisterAideFromJsonConfig(configPath);
+
+    const result = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(result.mcpServers).toBeUndefined();
+  });
+
+  it('removes only the aide entry, preserving other mcpServers', () => {
+    const config = {
+      mcpServers: {
+        aide: { command: 'node', args: ['server.js'] },
+        userCustom: { command: 'python', args: ['custom.py'] },
+      },
+    };
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+    unregisterAideFromJsonConfig(configPath);
+
+    const result = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(result.mcpServers.aide).toBeUndefined();
+    expect(result.mcpServers.userCustom).toEqual({ command: 'python', args: ['custom.py'] });
+  });
+
+  it('preserves other top-level keys', () => {
+    const config = {
+      mcpServers: { aide: { command: 'node', args: ['server.js'] } },
+      model: 'claude-opus-4-7',
+      permissions: { allow: ['Bash'] },
+    };
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+    unregisterAideFromJsonConfig(configPath);
+
+    const result = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(result.mcpServers).toBeUndefined();
+    expect(result.model).toBe('claude-opus-4-7');
+    expect(result.permissions).toEqual({ allow: ['Bash'] });
+  });
+
+  it('is a no-op when mcpServers has no aide key', () => {
+    const config = {
+      mcpServers: { other: { command: 'node', args: ['other.js'] } },
+    };
+    const raw = JSON.stringify(config, null, 2);
+    fs.writeFileSync(configPath, raw);
+
+    unregisterAideFromJsonConfig(configPath);
+
+    expect(fs.readFileSync(configPath, 'utf-8')).toBe(raw);
+  });
+
+  it('is a no-op when mcpServers key is absent', () => {
+    const config = { model: 'claude-opus-4-7' };
+    const raw = JSON.stringify(config, null, 2);
+    fs.writeFileSync(configPath, raw);
+
+    unregisterAideFromJsonConfig(configPath);
+
+    expect(fs.readFileSync(configPath, 'utf-8')).toBe(raw);
+  });
+
+  it('leaves a corrupt config file untouched', () => {
+    const raw = '{invalid json!!!';
+    fs.writeFileSync(configPath, raw);
+
+    expect(() => unregisterAideFromJsonConfig(configPath)).not.toThrow();
+    expect(fs.readFileSync(configPath, 'utf-8')).toBe(raw);
+  });
+
+  it('is idempotent when called twice', () => {
+    const config = {
+      mcpServers: {
+        aide: { command: 'node', args: ['server.js'] },
+        other: { command: 'python', args: ['other.py'] },
+      },
+    };
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+    unregisterAideFromJsonConfig(configPath);
+    unregisterAideFromJsonConfig(configPath);
+
+    const result = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(result.mcpServers.aide).toBeUndefined();
+    expect(result.mcpServers.other).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes a bug where Claude spawned the AIDE MCP server twice for every agent tab. Symptom: opening a single Claude tab showed one tab in the AIDE UI but started two \`aide-mcp-server.js\` processes; Claude Desktop also saw two AIDE sessions.

## Root cause
\`writeMcpConfig()\` wrote the AIDE entry to two places:

1. \`~/.claude.json\` — Claude CLI's global MCP config.
2. \`~/Library/Application Support/AIDE/mcp-config.json\` — passed to Claude via \`--mcp-config\` on every spawn (see \`terminal-handlers.ts:148-149\`, \`agent-config.ts:43\`).

Claude CLI merges both configs and spawns the \`aide\` MCP server once per source.

## Fix
- \`src/main/mcp/config-writer.ts\`:
  - Drop the \`registerJsonMcpConfig(..., '.claude.json')\` call. \`--mcp-config\` already covers Claude.
  - Add \`unregisterAideFromJsonConfig()\` as a one-time legacy cleanup — strips \`mcpServers.aide\` from \`~/.claude.json\` for users upgrading from an older AIDE. Preserves other servers and top-level keys; no-op on missing/corrupt files.
- \`tests/unit/unregister-aide-claude-global.test.ts\`: 8 unit tests covering missing file, single-aide entry, preserves other servers, preserves other top-level keys, no mcpServers key, corrupt file, idempotency.

Gemini (\`~/.gemini/settings.json\`) and Codex (\`~/.codex/config.toml\`) still use global registration — neither CLI accepts a per-invocation \`--mcp-config\` flag.

## Review
Independent devil's-advocate pass verified: single Claude spawn path, no race with writeMcpConfig's other write targets, no Claude Desktop regression (uses a different config path), no test conflicts. **ACCEPT**.

## Test plan
- [x] \`pnpm test\` 184/184 passing (+8 new).
- [ ] Manual: launch AIDE → open a Claude tab → \`ps aux | grep aide-mcp-server\` shows exactly one process.
- [ ] Manual: existing install with \`mcpServers.aide\` in \`~/.claude.json\` — after first launch, the entry is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)