### PR TITLE
fix(session): eliminate duplicate PTY spawn on initial workspace load

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { TitleBar } from './components/layout/TitleBar';
 import { StatusBar } from './components/layout/StatusBar';
 import { SplitContainer } from './components/layout/SplitContainer';
@@ -52,13 +52,10 @@ export function App() {
     }
   }, [theme]);
 
-  // Restore session on initial workspace load (workspace switches handled by setActive)
-  const initialRestoreDone = useRef(false);
-  useEffect(() => {
-    if (!activeWorkspaceId || initialRestoreDone.current) return;
-    initialRestoreDone.current = true;
-    useLayoutStore.getState().restoreSession(activeWorkspaceId);
-  }, [activeWorkspaceId]);
+  // Session restoration is owned by workspace-store.setActive(), which runs
+  // restoreSession() on first visit to each workspace. A duplicate call here
+  // would spawn every saved PTY twice — every tab would get an orphaned
+  // second claude/shell process running in the background.
 
   // Save session on app quit — use sendSync to guarantee write before window closes
   useEffect(() => {


### PR DESCRIPTION
## Summary
Fixes a double-spawn bug where every saved PTY (shell, claude, gemini, codex) was started twice on app launch. UI shows a single tab, but an orphaned second pty process runs in the background — which is why users saw two claude CLI processes spawning duplicate MCP servers (aide, serena, pencil, ...) for every restored tab.

## Evidence
\`\`\`
pid 57467  pts/s007  claude --mcp-config .../AIDE/mcp-config.json --resume dbe9834f-...
pid 57449  pts/s001  claude --mcp-config .../AIDE/mcp-config.json --resume dbe9834f-...
\`\`\`
Two claude processes on different ptys, both resuming the *same* session id — one UI tab, two live ptys.

## Root cause
\`restoreSession(workspaceId)\` is invoked from two places on the initial-load path:

1. \`workspace-store.setActive()\` — triggered by \`loadWorkspaces()\` auto-opening the most recent workspace (\`workspace-store.ts:61\`).
2. \`App.tsx\` \`useEffect([activeWorkspaceId])\` — fires once setActive sets \`activeWorkspaceId\`; the \`initialRestoreDone\` ref only prevented *subsequent* re-fires, not this first duplicate.

The second call's \`clearTabs()\` wipes the renderer-side tabs from the first run, but pty processes in the main process are not killed — they orphan. Each orphan claude CLI then spawns its own set of MCP servers, which is what the user observes.

## Fix
Remove the App-level \`useEffect\`. \`setActive\` is the sole owner of session restoration; it runs once per workspace entry.

Also removed the \`useRef\` import (now unused) and the \`initialRestoreDone\` guard (now unreachable).

## Note
This PR re-applies the change from #79, which was closed prematurely. The MCP-duplicate fix in #80 addresses a *separate* bug (Claude merging \`~/.claude.json\` + \`--mcp-config\`); both fixes are needed to fully eliminate MCP duplication.

## Test plan
- [x] \`pnpm lint\` (no new warnings) and \`pnpm test\` (176/176) pass.
- [ ] Manual: launch with a saved Claude tab → \`ps aux | grep claude\` shows exactly one \`claude --resume ...\` process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)