### PR TITLE
feat(filetree): add file name search and filter

### DIFF
--- a/src/renderer/components/file-explorer/FileExplorer.tsx
+++ b/src/renderer/components/file-explorer/FileExplorer.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { FileTreeNode, FsReadTreeError } from '../../../types/ipc';
 import { emitFileEvent } from '../../lib/event-bus';
 import { useWorkspaceStore } from '../../stores/workspace-store';
 import { usePluginStore } from '../../stores/plugin-store';
+import { filterTree } from '../../utils/file-search';
 import { PermissionBanner } from './PermissionBanner';
 
 interface TreeNodeProps {
@@ -12,10 +13,12 @@ interface TreeNodeProps {
   onSelect: (path: string) => void;
   revealPath: string | null;
   nodeRefs: React.MutableRefObject<Map<string, HTMLDivElement>>;
+  forceExpanded?: boolean;
 }
 
-function TreeNode({ node, depth, selectedPath, onSelect, revealPath, nodeRefs }: TreeNodeProps) {
+function TreeNode({ node, depth, selectedPath, onSelect, revealPath, nodeRefs, forceExpanded = false }: TreeNodeProps) {
   const [expanded, setExpanded] = useState(false);
+  const effectiveExpanded = expanded || forceExpanded;
   const [fetchedChildren, setFetchedChildren] = useState<FileTreeNode[] | undefined>(node.children);
   const [childError, setChildError] = useState<FsReadTreeError | null>(null);
   const ref = useRef<HTMLDivElement>(null);
@@ -29,14 +32,14 @@ function TreeNode({ node, depth, selectedPath, onSelect, revealPath, nodeRefs }:
 
   // Lazy-fetch children when a directory is expanded for the first time
   useEffect(() => {
-    if (!expanded || node.type !== 'directory') return;
+    if (!effectiveExpanded || node.type !== 'directory') return;
     window.aide.fs.readTreeWithError(node.path)
       .then(({ nodes: children, error }) => {
         setFetchedChildren(children);
         setChildError(error ?? null);
       })
       .catch(() => {});
-  }, [expanded, node.path, node.type]);
+  }, [effectiveExpanded, node.path, node.type]);
 
   // Auto-expand ancestor when a child is being revealed
   useEffect(() => {
@@ -94,7 +97,7 @@ function TreeNode({ node, depth, selectedPath, onSelect, revealPath, nodeRefs }:
           title={hasChildError ? 'Access denied — click to retry' : undefined}
         >
           <span className="text-[10px] text-aide-text-tertiary w-3 shrink-0">
-            {expanded ? '▼' : '▶'}
+            {effectiveExpanded ? '▼' : '▶'}
           </span>
           <span className={`truncate ${hasChildError ? 'text-[#5C5E6A]' : ''}`}>{node.name}</span>
           {hasChildError && (
@@ -106,7 +109,7 @@ function TreeNode({ node, depth, selectedPath, onSelect, revealPath, nodeRefs }:
             </span>
           )}
         </div>
-        {expanded && sortedChildren.map((child) => (
+        {effectiveExpanded && sortedChildren.map((child) => (
           <TreeNode
             key={child.path}
             node={child}
@@ -115,6 +118,7 @@ function TreeNode({ node, depth, selectedPath, onSelect, revealPath, nodeRefs }:
             onSelect={onSelect}
             revealPath={revealPath}
             nodeRefs={nodeRefs}
+            forceExpanded={forceExpanded}
           />
         ))}
       </div>
@@ -151,7 +155,11 @@ export function FileExplorer({ cwd }: FileExplorerProps) {
   const [revealPath, setRevealPath] = useState<string | null>(null);
   const [error, setError] = useState<FsReadTreeError | null>(null);
   const [dismissed, setDismissed] = useState(false);
+  const [query, setQuery] = useState('');
   const nodeRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const trimmedQuery = query.trim();
+  const filteredTree = useMemo(() => filterTree(tree, trimmedQuery), [tree, trimmedQuery]);
+  const isSearching = trimmedQuery.length > 0;
 
   const handleFileSelect = useCallback((filePath: string) => {
     setSelectedPath(filePath);
@@ -248,6 +256,26 @@ export function FileExplorer({ cwd }: FileExplorerProps) {
         />
       )}
 
+      {!error && tree.length > 0 && (
+        <div className="px-2 py-1.5 border-b border-aide-border shrink-0">
+          <input
+            type="text"
+            role="searchbox"
+            aria-label="Search files"
+            placeholder="Search files…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                setQuery('');
+              }
+            }}
+            className="w-full h-[26px] px-2 rounded bg-aide-background border border-aide-border text-[11px] font-mono text-aide-text-primary placeholder:text-aide-text-tertiary focus:outline-none focus:border-aide-accent"
+          />
+        </div>
+      )}
+
       {!error && tree.length === 0 && (
         <div
           style={{
@@ -267,7 +295,13 @@ export function FileExplorer({ cwd }: FileExplorerProps) {
         </div>
       )}
 
-      {tree.map((node) => (
+      {isSearching && filteredTree.length === 0 && tree.length > 0 && (
+        <div className="px-3 py-2 text-[11px] font-mono text-aide-text-tertiary">
+          No matches in loaded files.
+        </div>
+      )}
+
+      {filteredTree.map((node) => (
         <TreeNode
           key={node.path}
           node={node}
@@ -276,6 +310,7 @@ export function FileExplorer({ cwd }: FileExplorerProps) {
           onSelect={handleFileSelect}
           revealPath={revealPath}
           nodeRefs={nodeRefs}
+          forceExpanded={isSearching}
         />
       ))}
     </div>

--- a/src/renderer/utils/file-search.ts
+++ b/src/renderer/utils/file-search.ts
@@ -1,0 +1,38 @@
+import type { FileTreeNode } from '../../types/ipc';
+
+export function matchNode(name: string, query: string): boolean {
+  if (!query) return true;
+  return name.toLowerCase().includes(query.toLowerCase());
+}
+
+/**
+ * Filter file tree nodes by a case-insensitive substring query on node names.
+ *
+ * - Empty query returns the input unchanged.
+ * - File nodes are kept only when their name matches.
+ * - Directory nodes are kept when the directory's own name matches (children preserved as-is)
+ *   or when at least one already-loaded descendant matches (non-matching siblings pruned).
+ *
+ * Only traverses already-loaded `children`; unloaded subtrees are not fetched.
+ */
+export function filterTree(nodes: FileTreeNode[], query: string): FileTreeNode[] {
+  if (!query) return nodes;
+  const q = query.toLowerCase();
+  const out: FileTreeNode[] = [];
+  for (const node of nodes) {
+    const nameMatches = node.name.toLowerCase().includes(q);
+    if (node.type === 'file') {
+      if (nameMatches) out.push(node);
+      continue;
+    }
+    if (nameMatches) {
+      out.push(node);
+      continue;
+    }
+    if (node.children && node.children.length > 0) {
+      const filtered = filterTree(node.children, query);
+      if (filtered.length > 0) out.push({ ...node, children: filtered });
+    }
+  }
+  return out;
+}

--- a/tests/unit/file-search.test.ts
+++ b/tests/unit/file-search.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import type { FileTreeNode } from '../../src/types/ipc';
+import { matchNode, filterTree } from '../../src/renderer/utils/file-search';
+
+function file(name: string, path = `/${name}`): FileTreeNode {
+  return { name, path, type: 'file' };
+}
+function dir(name: string, children: FileTreeNode[] = [], path = `/${name}`): FileTreeNode {
+  return { name, path, type: 'directory', children };
+}
+
+describe('matchNode', () => {
+  it('returns true for an empty query', () => {
+    expect(matchNode('foo.ts', '')).toBe(true);
+  });
+  it('is case insensitive', () => {
+    expect(matchNode('README.md', 'readme')).toBe(true);
+    expect(matchNode('index.ts', 'IDX')).toBe(false);
+  });
+  it('matches a substring anywhere in the name', () => {
+    expect(matchNode('file-search.ts', 'search')).toBe(true);
+    expect(matchNode('file-search.ts', 'xyz')).toBe(false);
+  });
+});
+
+describe('filterTree', () => {
+  it('returns the input unchanged when the query is empty', () => {
+    const tree = [file('a.ts'), dir('src', [file('b.ts')])];
+    expect(filterTree(tree, '')).toBe(tree);
+  });
+
+  it('keeps files whose name matches and drops the rest', () => {
+    const tree = [file('foo.ts'), file('bar.md')];
+    expect(filterTree(tree, 'foo')).toEqual([file('foo.ts')]);
+  });
+
+  it('keeps ancestor directories when a descendant matches, pruning non-matching siblings', () => {
+    const tree = [
+      dir('src', [
+        dir('utils', [file('file-search.ts'), file('logger.ts')]),
+        file('index.ts'),
+      ]),
+      dir('tests', [file('unrelated.test.ts')]),
+    ];
+    const result = filterTree(tree, 'search');
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('src');
+    expect(result[0].children).toHaveLength(1);
+    expect(result[0].children?.[0].name).toBe('utils');
+    expect(result[0].children?.[0].children?.map((c) => c.name)).toEqual(['file-search.ts']);
+  });
+
+  it('keeps all children when the directory name itself matches', () => {
+    const original = dir('search', [file('a.ts'), file('b.ts')]);
+    const result = filterTree([original], 'search');
+    expect(result[0]).toBe(original);
+    expect(result[0].children?.map((c) => c.name)).toEqual(['a.ts', 'b.ts']);
+  });
+
+  it('drops directories whose descendants do not match', () => {
+    const tree = [dir('src', [file('x.ts')]), dir('docs', [file('y.md')])];
+    expect(filterTree(tree, 'unknown')).toEqual([]);
+  });
+
+  it('is case insensitive', () => {
+    const tree = [file('README.md'), file('index.ts')];
+    expect(filterTree(tree, 'readme')).toEqual([file('README.md')]);
+  });
+
+  it('does not mutate the input tree', () => {
+    const utils = dir('utils', [file('file-search.ts'), file('logger.ts')]);
+    const src = dir('src', [utils]);
+    const tree = [src];
+    filterTree(tree, 'search');
+    expect(src.children).toHaveLength(1);
+    expect(utils.children).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a search input above the file tree that filters nodes by case-insensitive substring match on their names.
- Matching files surface along with their ancestor folders; non-matching siblings are hidden while the query is active.
- An empty query restores the original tree; Escape clears the search.

## UX
- Input sits directly below the \"// explorer\" header, styled to match the existing plugin-name inputs from the design system.
- While searching, directories are force-expanded so deep matches surface without manual clicks. When the query is cleared, each directory returns to its user-toggled expanded state.
- `role=\"searchbox\"` + `aria-label=\"Search files\"` + placeholder for accessibility.

## Scope (MVP)
- Filter operates on the already-loaded tree. Lazy-fetch is keyed off the effective expanded state, so matching branches populate their children on demand, but unfetched siblings are not pre-fetched.
- Directories whose already-loaded children contain no match are pruned up-front, so the fetch cascade is bounded to relevant subtrees.
- No fuzzy matching, no match-range highlighting, no shortcut binding. Those are easy follow-ups once the base filter lands.

## Files
- `src/renderer/utils/file-search.ts` (new) — `matchNode` + `filterTree` pure helpers.
- `tests/unit/file-search.test.ts` (new) — 10 unit tests covering empty query, case, directory-name match, descendant match, pruning, and immutability.
- `src/renderer/components/file-explorer/FileExplorer.tsx` — adds `query` state, the search input, filter application, and a \`forceExpanded\` prop threaded through \`TreeNode\`.

## Test plan
- [x] \`pnpm test\` — 194/194 passing (20 files).
- [x] \`pnpm lint\` — exit 0; no new issues on changed files.
- [ ] Manual sanity in-app: type a query, verify ancestor folders remain visible, Escape clears, empty query restores the tree.

## design.pen
Added \`SearchBar\` frame (id \`nMSQu\`) between \`SidebarHeader\` and \`FileTree\` inside \`FileExplorer\` (id \`pUK3B\`), containing \`searchInput\`, \`searchIcon\`, and \`searchPlaceholder\`. Matches the existing input styling tokens.

## Notes
- Overlaps with #83 (filetree icons) in \`FileExplorer.tsx\`. This branch is cut from \`develop\` and expected to rebase cleanly on top of #83 once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)