### PR TITLE
fix(plugin): keep plugin tab and active state in sync

### DIFF
--- a/src/renderer/stores/layout-store.ts
+++ b/src/renderer/stores/layout-store.ts
@@ -5,6 +5,7 @@ import { useTerminalStore } from './terminal-store';
 import { useWorkspaceStore } from './workspace-store';
 import { usePluginStore } from './plugin-store';
 import { useToastStore } from './toast-store';
+import { deactivatingPluginIds } from './plugin-deactivate-guard';
 
 let paneCounter = 0;
 let splitCounter = 0;
@@ -377,6 +378,8 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
   },
 
   removeTabFromPane: (paneId, tabId) => {
+    let removedPluginId: string | null = null;
+
     set((state) => {
       const layout = cloneNode(state.layout);
       const pane = findPane(layout, paneId);
@@ -384,6 +387,11 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
 
       const index = pane.tabs.findIndex((t) => t.id === tabId);
       if (index < 0) return state;
+
+      const removed = pane.tabs[index];
+      if (removed.type === 'plugin' && removed.pluginId) {
+        removedPluginId = removed.pluginId;
+      }
 
       pane.tabs.splice(index, 1);
 
@@ -403,6 +411,25 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
 
       return { layout };
     });
+
+    // Fix A: closing a plugin tab must also deactivate the plugin so the
+    // main-side sandbox stops and plugin.active reflects reality.
+    // plugin-store.deactivate sets the guard before calling removeTabFromPane
+    // to prevent infinite recursion here.
+    if (removedPluginId && !deactivatingPluginIds.has(removedPluginId)) {
+      const pluginId: string = removedPluginId;
+      void (async () => {
+        deactivatingPluginIds.add(pluginId);
+        try {
+          await window.aide.plugin.deactivate(pluginId);
+          await usePluginStore.getState().loadPlugins();
+          const wsId = useWorkspaceStore.getState().activeWorkspaceId;
+          if (wsId) await get().saveSession(wsId);
+        } finally {
+          deactivatingPluginIds.delete(pluginId);
+        }
+      })();
+    }
   },
 
   setActiveTab: (paneId, tabId) => {
@@ -631,6 +658,11 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
       (w) => w.id === workspaceId,
     )?.path;
 
+    // Fix B: plugin tabs are only restored when their pluginId appears in
+    // session.activePlugins. Prevents stale/ghost plugin tabs from a
+    // previous session where layout and activePlugins drifted apart.
+    const activePluginSet = new Set(session.activePlugins ?? []);
+
     async function rebuildNode(node: SerializableLayoutNode): Promise<LayoutNode> {
       if ('direction' in node && 'children' in node) {
         const split = node as SerializableSplitLayout;
@@ -649,6 +681,13 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
 
       for (const savedTab of savedPane.tabs) {
         if (savedTab.type === 'plugin') {
+          // Fix B: skip plugin tabs whose pluginId is not in activePlugins.
+          // Older saved sessions (or any inconsistency between layout and
+          // activePlugins) would otherwise restore a tab for a disabled
+          // plugin, producing the "tab visible but plugin off" state.
+          if (!savedTab.pluginId || !activePluginSet.has(savedTab.pluginId)) {
+            continue;
+          }
           const tab: TerminalTab = {
             id: savedTab.id,
             type: 'plugin',

--- a/src/renderer/stores/plugin-deactivate-guard.ts
+++ b/src/renderer/stores/plugin-deactivate-guard.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared set of plugin ids currently being deactivated.
+ *
+ * Lives in its own module to avoid a circular import between plugin-store
+ * (the primary deactivator) and layout-store (which also triggers deactivate
+ * when a plugin tab is closed directly via removeTabFromPane).
+ *
+ * When plugin-store.deactivate() runs it adds the id before calling
+ * removeTabFromPane so layout-store can skip the auto-deactivate side effect
+ * and avoid an infinite loop.
+ */
+export const deactivatingPluginIds = new Set<string>();

--- a/src/renderer/stores/plugin-store.ts
+++ b/src/renderer/stores/plugin-store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import type { PluginInfo, TerminalTab } from '../../types/ipc';
 import { useLayoutStore } from './layout-store';
 import { useTerminalStore } from './terminal-store';
+import { deactivatingPluginIds } from './plugin-deactivate-guard';
 
 interface PluginState {
   plugins: PluginInfo[];
@@ -70,6 +71,12 @@ export const usePluginStore = create<PluginState>((set, get) => ({
   },
 
   deactivate: async (id: string) => {
+    // Guard: layout-store.removeTabFromPane auto-deactivates plugin tabs when
+    // they are closed directly (× click, ⌘W). That path calls back into
+    // window.aide.plugin.deactivate, which would recurse here. By marking
+    // the id as in-flight, we tell the layout-store hook to skip its own
+    // deactivate side effect while this function owns the lifecycle.
+    deactivatingPluginIds.add(id);
     try {
       await window.aide.plugin.deactivate(id);
       const plugins = await window.aide.plugin.list();
@@ -92,6 +99,8 @@ export const usePluginStore = create<PluginState>((set, get) => ({
       }
     } catch (e) {
       set({ error: e instanceof Error ? e.message : 'Failed to deactivate plugin' });
+    } finally {
+      deactivatingPluginIds.delete(id);
     }
   },
 

--- a/tests/unit/plugin-deactivate.test.ts
+++ b/tests/unit/plugin-deactivate.test.ts
@@ -11,6 +11,7 @@ import { usePluginStore } from '../../src/renderer/stores/plugin-store';
 import { useLayoutStore, createPane } from '../../src/renderer/stores/layout-store';
 import { useTerminalStore } from '../../src/renderer/stores/terminal-store';
 import { useWorkspaceStore } from '../../src/renderer/stores/workspace-store';
+import { deactivatingPluginIds } from '../../src/renderer/stores/plugin-deactivate-guard';
 import type { TerminalTab, PluginInfo } from '../../src/types/ipc';
 
 // ── helpers ────────────────────────────────────────────────────────────────
@@ -54,6 +55,7 @@ describe('plugin deactivate – tab removal', () => {
     useTerminalStore.setState({ tabs: [], activeTabId: null, dropdownOpen: false, workspaceTabs: {} });
     usePluginStore.setState({ plugins: [], loading: false, error: null, generating: false, generateError: null });
     useWorkspaceStore.setState({ workspaces: [], activeWorkspaceId: 'ws-1', recentProjects: [], navExpanded: true });
+    deactivatingPluginIds.clear();
   });
 
   afterEach(() => {
@@ -192,5 +194,126 @@ describe('plugin deactivate – tab removal', () => {
       (t) => (t as Record<string, unknown>).pluginId === 'plugin-off',
     );
     expect(inactiveSavedTabs).toHaveLength(0);
+  });
+
+  // ── case (e) Fix A: closing a plugin tab directly auto-deactivates ────────
+
+  it('(e) removeTabFromPane on a plugin tab triggers window.aide.plugin.deactivate', async () => {
+    const plugin = makePlugin('plugin-close', true);
+    const tab = makePluginTab('plugin-close');
+
+    usePluginStore.setState({ plugins: [plugin], loading: false, error: null, generating: false, generateError: null });
+    const paneId = useLayoutStore.getState().getAllPanes()[0].id;
+    useLayoutStore.getState().addTabToPane(paneId, tab);
+    useTerminalStore.getState().addTab(tab);
+
+    (window.aide.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makePlugin('plugin-close', false),
+    ]);
+
+    // Simulate a × click on the plugin tab: layout-store removes the tab.
+    // The auto-deactivate side effect is fire-and-forget, so await a tick.
+    useLayoutStore.getState().removeTabFromPane(paneId, tab.id);
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(window.aide.plugin.deactivate).toHaveBeenCalledWith('plugin-close');
+  });
+
+  // ── case (f) Fix A idempotent: deactivate() does not recurse ──────────────
+
+  it('(f) plugin-store.deactivate does not cause recursive deactivate via removeTabFromPane', async () => {
+    const plugin = makePlugin('plugin-recur', true);
+    const tab = makePluginTab('plugin-recur');
+
+    usePluginStore.setState({ plugins: [plugin], loading: false, error: null, generating: false, generateError: null });
+    const paneId = useLayoutStore.getState().getAllPanes()[0].id;
+    useLayoutStore.getState().addTabToPane(paneId, tab);
+    useTerminalStore.getState().addTab(tab);
+
+    (window.aide.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makePlugin('plugin-recur', false),
+    ]);
+
+    await usePluginStore.getState().deactivate('plugin-recur');
+    // Give any fire-and-forget side effects a chance to run
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    // window.aide.plugin.deactivate is called exactly once by plugin-store
+    // itself — the layout-store hook must NOT call it a second time.
+    expect(window.aide.plugin.deactivate).toHaveBeenCalledTimes(1);
+  });
+
+  // ── case (g) Fix B: restoreSession skips plugin tabs not in activePlugins ─
+
+  it('(g) restoreSession skips plugin tabs missing from session.activePlugins', async () => {
+    // Tampered saved session: layout has a plugin tab for plugin-gone, but
+    // activePlugins does not list it. A shell tab is present too.
+    const tamperedSession = {
+      version: 1,
+      workspaceId: 'ws-1',
+      savedAt: Date.now(),
+      layout: {
+        id: 'pane-1',
+        tabs: [
+          { id: 'ghost-plugin', type: 'plugin', title: 'Gone', pluginId: 'plugin-gone', isActive: false },
+          { id: 'shell-1', type: 'shell', title: '$ shell', isActive: true },
+        ],
+        activeTabId: 'shell-1',
+      },
+      focusedPaneId: 'pane-1',
+      activePlugins: [],
+      sidePanelTab: 'files' as const,
+    };
+
+    (window.aide.session.load as ReturnType<typeof vi.fn>).mockResolvedValue(tamperedSession);
+    (window.aide.terminal.spawn as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true, sessionId: 'new-sess' });
+
+    useWorkspaceStore.setState({
+      workspaces: [{ id: 'ws-1', name: 'ws', path: '/tmp/ws' }],
+      activeWorkspaceId: 'ws-1',
+      recentProjects: [],
+      navExpanded: true,
+      sidePanelTab: 'files',
+    } as Parameters<typeof useWorkspaceStore.setState>[0]);
+
+    await useLayoutStore.getState().restoreSession('ws-1');
+
+    const restoredPluginTabs = useLayoutStore
+      .getState()
+      .getAllPanes()
+      .flatMap((p) => p.tabs.filter((t) => t.type === 'plugin'));
+    expect(restoredPluginTabs).toHaveLength(0);
+
+    const restoredShellTabs = useLayoutStore
+      .getState()
+      .getAllPanes()
+      .flatMap((p) => p.tabs.filter((t) => t.type === 'shell'));
+    expect(restoredShellTabs).toHaveLength(1);
+  });
+
+  // ── case (h) Fix A guard isolation: guard presence suppresses the hook ────
+
+  it('(h) removeTabFromPane skips auto-deactivate when pluginId is in the guard set', async () => {
+    const plugin = makePlugin('plugin-guarded', true);
+    const tab = makePluginTab('plugin-guarded');
+
+    usePluginStore.setState({ plugins: [plugin], loading: false, error: null, generating: false, generateError: null });
+    const paneId = useLayoutStore.getState().getAllPanes()[0].id;
+    useLayoutStore.getState().addTabToPane(paneId, tab);
+    useTerminalStore.getState().addTab(tab);
+
+    // Pre-populate the guard — simulates plugin-store.deactivate() being the
+    // caller, so the layout-store hook must NOT call deactivate again.
+    deactivatingPluginIds.add('plugin-guarded');
+    try {
+      useLayoutStore.getState().removeTabFromPane(paneId, tab.id);
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+      expect(window.aide.plugin.deactivate).not.toHaveBeenCalled();
+    } finally {
+      deactivatingPluginIds.delete('plugin-guarded');
+    }
   });
 });


### PR DESCRIPTION
## Summary
Fixes the \"plugin is off but still open\" bug (kanban \`task_ygec9x2b\`). \`plugin.active\` and the presence of a plugin tab can now drift apart through three paths; this PR closes all three.

## Root cause
- **Path 1 (zombie on tab × close)**: \`layout-store.removeTabFromPane\` removed the tab but never called back into \`window.aide.plugin.deactivate\`. The main-side sandbox and \`plugin-store.plugins[].active\` stayed true, so the plugin kept running in the background with no UI.
- **Path 2 (stale session restore)**: If a session was ever saved with \`layout.tabs\` containing a plugin tab but \`activePlugins\` empty, \`restoreSession\` would faithfully rebuild the tab without activating the plugin, leaving a visible-but-inactive tab.
- **Path 3 (zombie serialization)**: \`buildSavedSession\` serialized every tab regardless of plugin active state, so any transient desync got persisted.

## Fix layers
1. **Fix A — `layout-store.removeTabFromPane`**: when the removed tab is a plugin tab, fire-and-forget \`window.aide.plugin.deactivate → loadPlugins → saveSession\`. A module-level \`deactivatingPluginIds: Set<string>\` (new file \`plugin-deactivate-guard.ts\`) prevents recursion with \`plugin-store.deactivate\`, which now adds its id to the set before calling removeTabFromPane and deletes it in a finally block.
2. **Fix B — `layout-store.restoreSession`**: build a Set from \`session.activePlugins\` and \`continue\` past saved plugin tabs whose pluginId is not in the set.
3. **Fix C — `layout-store.buildSavedSession`** (already merged as prior commit in this branch): filter plugin tabs against the active-plugin id set before serialization.

## Tests
\`tests/unit/plugin-deactivate.test.ts\` — 8 cases (a)–(h):
- (a)(b)(c) deactivate removes tab from layout, terminal store, and across multiple panes (regression guards for the existing behavior).
- (d) buildSavedSession excludes tabs for inactive plugins (Fix C).
- (e) removeTabFromPane on a plugin tab triggers deactivate (Fix A).
- (f) plugin-store.deactivate is called exactly once — no recursion (Fix A net effect).
- (g) restoreSession with a plugin tab missing from activePlugins is dropped, non-plugin tabs survive (Fix B).
- (h) guard isolation: if deactivatingPluginIds already contains the id, the hook must NOT call deactivate.

Full suite 191/191 passing.

## Review
oh-my-claudecode:critic reviewed in THOROUGH mode. Initial verdict was REVISE because Fix A / Fix B / guard file / tests (e)(f)(g) were still uncommitted working-tree changes and test (f) did not isolate the guard. Both findings addressed: all changes now committed in this branch; test (h) added to isolate the guard mechanism (removes the \"net-effect only\" gap).

## Test plan
- [x] \`pnpm test\` 191/191 passing
- [x] \`pnpm lint\` (no new warnings; pre-existing chokidar / no-require-imports warnings unchanged)
- [ ] Manual: activate a plugin, click the × on its tab → \`ps aux | grep aide-mcp\` shows the sandbox gone, \`OFF\` shown in the plugin panel
- [ ] Manual: restart AIDE with a previously-active plugin → tab and plugin reactivate together

🤖 Generated with [Claude Code](https://claude.com/claude-code)