### PR TITLE
fix(plugin): open workspace and seed registry before restoreSession activates plugins

### DIFF
--- a/src/renderer/stores/workspace-store.ts
+++ b/src/renderer/stores/workspace-store.ts
@@ -54,7 +54,21 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         useTerminalStore.getState().switchWorkspace(prevId, id);
       }
 
-      // 2. Try in-memory layout cache first; fall back to disk restore on first visit.
+      // 2. Tell main about the new workspace and seed the plugin registry
+      //    BEFORE restoreSession runs. restoreSession calls
+      //    window.aide.plugin.activate(id) for every entry in
+      //    session.activePlugins, which needs registry.get(id) to succeed.
+      //    We call window.aide.plugin.list() directly (not via
+      //    usePluginStore.loadPlugins) so the renderer store does not flash
+      //    "0/N ACTIVE" between this seed call and the post-restore refresh.
+      const workspace = get().workspaces.find((w) => w.id === id);
+      if (workspace) {
+        await window.aide.workspace.open(workspace.path);
+      }
+      await window.aide.plugin.list();
+      invalidateSettingsCache();
+
+      // 3. Try in-memory layout cache first; fall back to disk restore on first visit.
       const loaded = useLayoutStore.getState().loadLayoutFromCache(id);
       if (!loaded) {
         // First visit to this workspace — spawn PTYs from disk session.
@@ -74,13 +88,12 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         }
       }
 
-      // 3. Notify main process so getActiveWorkspacePath() updates before loadPlugins().
-      const workspace = get().workspaces.find((w) => w.id === id);
-      if (workspace) {
-        await window.aide.workspace.open(workspace.path);
-      }
+      // 4. Single renderer-store refresh at the end so PluginPanel shows the
+      //    final active state in one commit. Covers both paths — the cache
+      //    branch also needs this because main-side plugin state may have
+      //    drifted (file watcher events, external toggles) since the last
+      //    time the renderer viewed this workspace.
       await usePluginStore.getState().loadPlugins();
-      invalidateSettingsCache();
     }
     set({ activeWorkspaceId: id });
   },

--- a/tests/unit/workspace-activate-ordering.test.ts
+++ b/tests/unit/workspace-activate-ordering.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Regression tests for workspace-store.setActive() call ordering.
+ *
+ * Bug: restoreSession() calls window.aide.plugin.activate(id) for each entry
+ * in session.activePlugins. If this runs before window.aide.workspace.open()
+ * and usePluginStore.loadPlugins(), the main-side plugin registry is empty
+ * and activate silently fails — the tab is restored but plugin.active stays
+ * false.
+ *
+ * Fix: setActive must open the workspace and load plugins into the registry
+ * BEFORE calling restoreSession, then reload after so the renderer reflects
+ * the main-side activation results.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useWorkspaceStore } from '../../src/renderer/stores/workspace-store';
+import { useLayoutStore, createPane } from '../../src/renderer/stores/layout-store';
+import { useTerminalStore } from '../../src/renderer/stores/terminal-store';
+import { usePluginStore } from '../../src/renderer/stores/plugin-store';
+
+describe('workspace-store.setActive — activation ordering', () => {
+  const calls: string[] = [];
+
+  beforeEach(() => {
+    calls.length = 0;
+
+    vi.stubGlobal('window', {
+      aide: {
+        workspace: {
+          open: vi.fn(async () => {
+            calls.push('workspace.open');
+          }),
+          list: vi.fn().mockResolvedValue([]),
+          recent: vi.fn().mockResolvedValue([]),
+        },
+        plugin: {
+          list: vi.fn(async () => {
+            calls.push('plugin.list');
+            return [];
+          }),
+          activate: vi.fn(async () => {
+            calls.push('plugin.activate');
+          }),
+          deactivate: vi.fn().mockResolvedValue(undefined),
+          onChanged: vi.fn(() => () => { /* unsub */ }),
+        },
+        session: {
+          load: vi.fn(async () => {
+            calls.push('session.load');
+            return {
+              version: 1,
+              workspaceId: 'ws-1',
+              savedAt: Date.now(),
+              layout: {
+                id: 'pane-1',
+                tabs: [
+                  {
+                    id: 'tab-plugin-1',
+                    type: 'plugin',
+                    title: 'agent-todo-board',
+                    isActive: true,
+                    pluginId: 'plugin-abc',
+                  },
+                ],
+                activeTabId: 'tab-plugin-1',
+              },
+              focusedPaneId: 'pane-1',
+              activePlugins: ['plugin-abc'],
+              sidePanelTab: 'files',
+            };
+          }),
+          save: vi.fn().mockResolvedValue(undefined),
+        },
+        terminal: { spawn: vi.fn().mockResolvedValue({ ok: true, sessionId: 'sess-1' }) },
+      },
+    });
+
+    const initialPane = createPane();
+    useLayoutStore.setState({ layout: initialPane, focusedPaneId: initialPane.id });
+    useTerminalStore.setState({ tabs: [], activeTabId: null, dropdownOpen: false, workspaceTabs: {} });
+    usePluginStore.setState({ plugins: [], loading: false, error: null, generating: false, generateError: null });
+    useWorkspaceStore.setState({
+      workspaces: [{ id: 'ws-1', name: 'ws', path: '/tmp/ws' }],
+      activeWorkspaceId: null,
+      recentProjects: [],
+      navExpanded: true,
+      sidePanelTab: 'files',
+    } as Parameters<typeof useWorkspaceStore.setState>[0]);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('opens the workspace and loads plugins BEFORE restoreSession activates them', async () => {
+    await useWorkspaceStore.getState().setActive('ws-1');
+
+    // Required: workspace.open and at least one plugin.list happen before the
+    // first plugin.activate, so the main-side registry is populated.
+    const firstOpen = calls.indexOf('workspace.open');
+    const firstList = calls.indexOf('plugin.list');
+    const firstActivate = calls.indexOf('plugin.activate');
+
+    expect(firstOpen, 'workspace.open should fire').toBeGreaterThanOrEqual(0);
+    expect(firstList, 'plugin.list should fire').toBeGreaterThanOrEqual(0);
+    expect(firstActivate, 'plugin.activate should fire for the saved activePlugin').toBeGreaterThanOrEqual(0);
+
+    expect(firstOpen).toBeLessThan(firstActivate);
+    expect(firstList).toBeLessThan(firstActivate);
+  });
+
+  it('reloads plugin list AFTER restoreSession so renderer reflects activate results', async () => {
+    await useWorkspaceStore.getState().setActive('ws-1');
+
+    // There should be at least TWO plugin.list calls: one before restoreSession
+    // (to populate registry) and one after (to refresh renderer with activate results).
+    const listCount = calls.filter((c) => c === 'plugin.list').length;
+    expect(listCount).toBeGreaterThanOrEqual(2);
+
+    const lastActivate = calls.lastIndexOf('plugin.activate');
+    const lastList = calls.lastIndexOf('plugin.list');
+    expect(lastActivate, 'plugin.activate should be invoked').toBeGreaterThanOrEqual(0);
+    expect(lastList).toBeGreaterThan(lastActivate);
+  });
+
+  it('switching into a workspace with no saved activePlugins still calls workspace.open and loadPlugins', async () => {
+    (window.aide.session.load as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      version: 1,
+      workspaceId: 'ws-1',
+      savedAt: Date.now(),
+      layout: { id: 'pane-1', tabs: [], activeTabId: null },
+      focusedPaneId: 'pane-1',
+      activePlugins: [],
+      sidePanelTab: 'files',
+    });
+
+    await useWorkspaceStore.getState().setActive('ws-1');
+
+    expect(calls).toContain('workspace.open');
+    expect(calls.filter((c) => c === 'plugin.list').length).toBeGreaterThanOrEqual(1);
+    expect(calls.filter((c) => c === 'plugin.activate').length).toBe(0);
+  });
+
+  it('cache-hit path still calls plugin.list so the renderer store reflects current main-side plugin state', async () => {
+    // Pre-seed the layout cache so loadLayoutFromCache returns true.
+    useLayoutStore.setState({
+      layout: createPane(),
+      focusedPaneId: null,
+      layoutCache: {
+        'ws-1': {
+          layout: createPane(),
+          focusedPaneId: null,
+          sidePanelTab: 'files',
+        },
+      } as unknown as Parameters<typeof useLayoutStore.setState>[0] extends infer S ? S : never,
+    } as Parameters<typeof useLayoutStore.setState>[0]);
+
+    await useWorkspaceStore.getState().setActive('ws-1');
+
+    // Even on a cache hit, plugin.list must fire at least once so the
+    // renderer picks up any main-side plugin changes (file watcher events,
+    // etc.) since the previous visit.
+    expect(calls.filter((c) => c === 'plugin.list').length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tests/unit/workspace-activate-ordering.test.ts
+++ b/tests/unit/workspace-activate-ordering.test.ts
@@ -141,24 +141,21 @@ describe('workspace-store.setActive — activation ordering', () => {
   });
 
   it('cache-hit path still calls plugin.list so the renderer store reflects current main-side plugin state', async () => {
-    // Pre-seed the layout cache so loadLayoutFromCache returns true.
-    useLayoutStore.setState({
-      layout: createPane(),
-      focusedPaneId: null,
-      layoutCache: {
-        'ws-1': {
-          layout: createPane(),
-          focusedPaneId: null,
-          sidePanelTab: 'files',
-        },
-      } as unknown as Parameters<typeof useLayoutStore.setState>[0] extends infer S ? S : never,
-    } as Parameters<typeof useLayoutStore.setState>[0]);
+    // Seed the module-level layout cache via the public API, then clear the
+    // recorded calls so we only observe the second setActive.
+    useWorkspaceStore.setState({
+      workspaces: [
+        { id: 'ws-1', name: 'ws', path: '/tmp/ws' },
+        { id: 'ws-2', name: 'ws2', path: '/tmp/ws2' },
+      ],
+    } as Parameters<typeof useWorkspaceStore.setState>[0]);
+    await useWorkspaceStore.getState().setActive('ws-1');
+    await useWorkspaceStore.getState().setActive('ws-2');
+    calls.length = 0;
 
     await useWorkspaceStore.getState().setActive('ws-1');
 
-    // Even on a cache hit, plugin.list must fire at least once so the
-    // renderer picks up any main-side plugin changes (file watcher events,
-    // etc.) since the previous visit.
+    expect(useLayoutStore.getState().loadLayoutFromCache).toBeTypeOf('function');
     expect(calls.filter((c) => c === 'plugin.list').length).toBeGreaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
## Summary
Fixes the regression where restored plugin tabs showed in the tab strip but the plugin panel reported "0/N ACTIVE". Follow-up to #85 — that PR kept tab and active state in sync but did not address *when* activation runs on workspace load.

## Evidence
User's \`aide-sessions.json\` for workspace-2 had
\`\`\`
activePlugins: ["plugin-65c44a66", "plugin-3e0eaf35"]
\`\`\`
plus both plugin tabs in \`layout.tabs\`. After a fresh build and restart, both tabs were visible but both plugins showed OFF in the PluginPanel.

## Root cause
\`workspace-store.setActive()\` called \`useLayoutStore.restoreSession(id)\` *before* \`window.aide.workspace.open()\` and \`usePluginStore.loadPlugins()\`.

\`restoreSession()\` iterates \`session.activePlugins\` and calls \`window.aide.plugin.activate(pluginId)\`. The main-side handler (\`plugin-handlers.ts:226-230\`) does \`registry.activate(pluginId, cwd)\`, which returns \`null\` if the registry has not been seeded. Since the registry is only populated by \`PLUGIN_LIST\` (\`refreshPlugins\` + \`rescanPluginsDir\`) — triggered by \`loadPlugins()\` — every activate call silently failed. The tabs still restored (they are serialized independently of active state), so the UI drifted.

## Fix
Reorder \`setActive\`:

1. save prev workspace state
2. \`window.aide.workspace.open(path)\`
3. \`window.aide.plugin.list()\` — direct IPC to seed the main registry **without** mutating the renderer \`plugin-store\` (avoids a "0/N ACTIVE" flicker in PluginPanel between steps 3 and 5)
4. cache-hit \`loadLayoutFromCache\` or disk \`restoreSession\`
5. \`usePluginStore.loadPlugins()\` once at the end — commits the final active state in a single renderer update (covers both the cache and disk paths)

This addresses the two critic findings on the first pass:
- **Major #1** cache-hit path had no plugin refresh → step 5 fires for both paths now
- **Major #2** UI flicker from double \`loadPlugins\` → step 3 uses the IPC directly, step 5 is the only renderer-visible refresh

## Tests
\`tests/unit/workspace-activate-ordering.test.ts\` (new, 4 cases):
1. \`workspace.open\` and \`plugin.list\` precede \`plugin.activate\`
2. A \`plugin.list\` call follows the last \`plugin.activate\` so the renderer reflects activation
3. Empty-activePlugins path still opens and lists, never activates
4. Cache-hit path still calls \`plugin.list\`

\`tests/unit/stores.test.ts\`: unchanged expectations — one \`loadPlugins\` per \`setActive\`.

\`pnpm test\` → 247/247 passing.

## Review
oh-my-claudecode:critic in THOROUGH mode. Initial verdict REVISE, flagging cache-hit regression and flicker. Both addressed in the pushed commit.

## Test plan
- [x] \`pnpm test\` 247/247 passing
- [x] \`pnpm lint\` no new warnings
- [ ] Manual: restart AIDE with a session that has \`activePlugins\` set → both PluginPanel toggles show ON and tabs are visible
- [ ] Manual: A → B → A workspace switch with active plugins on each → no flicker, final state correct
- [ ] Manual: \`ps aux | grep aide-mcp\` shows one MCP process per active plugin, no zombies

🤖 Generated with [Claude Code](https://claude.com/claude-code)