### PR TITLE
release: v0.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aide",
   "productName": "AIDE",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "AI-Driven IDE - Create n Play plugins with natural language",
   "main": ".vite/build/index.js",
   "private": true,

--- a/src/main/ipc/channels.ts
+++ b/src/main/ipc/channels.ts
@@ -17,6 +17,7 @@ export const IPC_CHANNELS = {
   FS_WRITE_FILE: 'fs:write-file',
   FS_DELETE: 'fs:delete',
   FS_CHANGED: 'fs:changed',
+  FS_SEARCH_FILES: 'fs:search-files',
 
   // System
   OPEN_PRIVACY_SETTINGS: 'system:open-privacy-settings',

--- a/src/main/ipc/file-index.ts
+++ b/src/main/ipc/file-index.ts
@@ -1,0 +1,210 @@
+import fs from 'fs';
+import fsPromises from 'fs/promises';
+import path from 'path';
+import type { FileTreeNode } from '../../types/ipc';
+import { WATCHER_EXCLUSIONS } from './watcher-exclusions';
+
+export interface FileIndexEntry {
+  name: string;
+  path: string;
+  type: 'file' | 'directory';
+}
+
+function isExcluded(fullPath: string): boolean {
+  for (const pattern of WATCHER_EXCLUSIONS) {
+    if (typeof pattern === 'string') {
+      if (fullPath === pattern || fullPath.includes(pattern)) return true;
+    } else if (pattern.test(fullPath)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function walkDir(dirPath: string, entries: Map<string, FileIndexEntry>): Promise<void> {
+  let dirents: fs.Dirent[];
+  try {
+    dirents = await fsPromises.readdir(dirPath, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  const subDirs: string[] = [];
+  for (const dirent of dirents) {
+    const full = path.join(dirPath, dirent.name);
+    if (isExcluded(full)) continue;
+    if (dirent.isDirectory()) {
+      entries.set(full, { name: dirent.name, path: full, type: 'directory' });
+      subDirs.push(full);
+    } else if (dirent.isFile() || dirent.isSymbolicLink()) {
+      entries.set(full, { name: dirent.name, path: full, type: 'file' });
+    }
+  }
+
+  // Concurrent child directory walk, bounded by Node's implicit FD limit.
+  await Promise.all(subDirs.map((d) => walkDir(d, entries)));
+}
+
+interface BuildTreeNode {
+  entry: FileIndexEntry;
+  children: Map<string, BuildTreeNode>;
+}
+
+function compareTreeChildren(a: FileTreeNode, b: FileTreeNode): number {
+  if (a.type !== b.type) return a.type === 'directory' ? -1 : 1;
+  return a.name.localeCompare(b.name);
+}
+
+function buildFileTree(matches: FileIndexEntry[], rootPath: string): FileTreeNode[] {
+  const rootChildren = new Map<string, BuildTreeNode>();
+
+  const ensurePath = (targetPath: string, entry: FileIndexEntry): BuildTreeNode | null => {
+    if (targetPath === rootPath || !targetPath.startsWith(rootPath + path.sep)) return null;
+
+    const relative = targetPath.slice(rootPath.length + 1);
+    const parts = relative.split(path.sep).filter(Boolean);
+    if (parts.length === 0) return null;
+
+    let cursor = rootChildren;
+    let parent: BuildTreeNode | null = null;
+    let accumulated = rootPath;
+
+    for (let i = 0; i < parts.length; i++) {
+      const name = parts[i];
+      accumulated = path.join(accumulated, name);
+      const isLeaf = i === parts.length - 1;
+
+      let node = cursor.get(name);
+      if (!node) {
+        const nodeEntry: FileIndexEntry = isLeaf
+          ? entry
+          : { name, path: accumulated, type: 'directory' };
+        node = { entry: nodeEntry, children: new Map() };
+        cursor.set(name, node);
+      } else if (isLeaf) {
+        // Upgrade to the real entry metadata in case synthesized earlier as a directory.
+        node.entry = entry;
+      }
+
+      parent = node;
+      cursor = node.children;
+    }
+
+    return parent;
+  };
+
+  for (const match of matches) {
+    ensurePath(match.path, match);
+  }
+
+  const toTree = (node: BuildTreeNode): FileTreeNode => {
+    const children = Array.from(node.children.values()).map(toTree);
+    children.sort(compareTreeChildren);
+    return {
+      name: node.entry.name,
+      path: node.entry.path,
+      type: node.entry.type,
+      children: node.entry.type === 'directory' ? children : undefined,
+    };
+  };
+
+  const out = Array.from(rootChildren.values()).map(toTree);
+  out.sort(compareTreeChildren);
+  return out;
+}
+
+export class FileIndex {
+  private entries = new Map<string, FileIndexEntry>();
+  private rootPath: string | null = null;
+  private initializingFor: string | null = null;
+
+  async initialize(workspacePath: string): Promise<void> {
+    this.entries.clear();
+    this.rootPath = workspacePath;
+    this.initializingFor = workspacePath;
+    const entries = new Map<string, FileIndexEntry>();
+    try {
+      await walkDir(workspacePath, entries);
+    } catch {
+      // Leave index empty on catastrophic failure; subsequent events still populate.
+    }
+    // Guard against a workspace switch that happened mid-walk.
+    if (this.initializingFor === workspacePath) {
+      this.entries = entries;
+      this.initializingFor = null;
+    }
+  }
+
+  clear(): void {
+    this.entries.clear();
+    this.rootPath = null;
+    this.initializingFor = null;
+  }
+
+  addPath(fullPath: string, type: 'file' | 'directory'): void {
+    if (!this.rootPath) return;
+    if (isExcluded(fullPath)) return;
+    this.entries.set(fullPath, { name: path.basename(fullPath), path: fullPath, type });
+  }
+
+  removePath(fullPath: string): void {
+    this.entries.delete(fullPath);
+  }
+
+  removeDir(fullPath: string): void {
+    // Remove the directory and all descendants under it.
+    this.entries.delete(fullPath);
+    const prefix = fullPath + path.sep;
+    for (const key of this.entries.keys()) {
+      if (key.startsWith(prefix)) this.entries.delete(key);
+    }
+  }
+
+  /**
+   * Case-insensitive substring search on file and folder names.
+   * A matching directory implicitly includes all of its descendants so the
+   * folder surfaces with its contents, mirroring the existing inline-filter UX.
+   * Returns a reconstructed tree relative to the workspace root.
+   */
+  search(query: string, limit = 500): FileTreeNode[] {
+    if (!this.rootPath) return [];
+    const q = query.trim().toLowerCase();
+    if (!q) return [];
+
+    const matchedDirs = new Set<string>();
+    for (const entry of this.entries.values()) {
+      if (entry.type === 'directory' && entry.name.toLowerCase().includes(q)) {
+        matchedDirs.add(entry.path);
+      }
+    }
+
+    const root = this.rootPath;
+    const results: FileIndexEntry[] = [];
+    for (const entry of this.entries.values()) {
+      if (results.length >= limit) break;
+      const selfMatch = entry.name.toLowerCase().includes(q);
+      if (selfMatch) {
+        results.push(entry);
+        continue;
+      }
+      // Ancestor-is-matched-dir check: walk up until root.
+      let parent = path.dirname(entry.path);
+      let ancestorHit = false;
+      while (parent.length >= root.length && parent.startsWith(root)) {
+        if (matchedDirs.has(parent)) { ancestorHit = true; break; }
+        if (parent === root) break;
+        const next = path.dirname(parent);
+        if (next === parent) break;
+        parent = next;
+      }
+      if (ancestorHit) results.push(entry);
+    }
+
+    return buildFileTree(results, root);
+  }
+
+  /** Test-only helper — expose entry count. */
+  size(): number {
+    return this.entries.size;
+  }
+}

--- a/src/main/ipc/fs-handlers.ts
+++ b/src/main/ipc/fs-handlers.ts
@@ -5,7 +5,10 @@ import path from 'path';
 import chokidar, { type FSWatcher } from 'chokidar';
 import { IPC_CHANNELS } from './channels';
 import { WATCHER_EXCLUSIONS } from './watcher-exclusions';
+import { FileIndex } from './file-index';
 import type { FileTreeNode, FsReadTreeError } from '../../types/ipc';
+
+const fileIndex = new FileIndex();
 
 /** Returns immediate children only — no recursion. Directories have no children
  *  populated; the renderer fetches them lazily on expand. */
@@ -73,7 +76,14 @@ export function setWorkspaceWatcher(workspacePath: string | null): void {
     clearTimeout(watcherDebounceTimer);
     watcherDebounceTimer = null;
   }
-  if (!workspacePath) return;
+  if (!workspacePath) {
+    fileIndex.clear();
+    return;
+  }
+
+  // Kick off the async index build; search queries arriving before it resolves
+  // simply return an empty tree until the walk completes.
+  void fileIndex.initialize(workspacePath);
 
   activeWatcher = chokidar
     .watch(workspacePath, {
@@ -81,6 +91,10 @@ export function setWorkspaceWatcher(workspacePath: string | null): void {
       depth: 3,
       ignored: WATCHER_EXCLUSIONS,
     })
+    .on('add', (p) => fileIndex.addPath(p, 'file'))
+    .on('addDir', (p) => fileIndex.addPath(p, 'directory'))
+    .on('unlink', (p) => fileIndex.removePath(p))
+    .on('unlinkDir', (p) => fileIndex.removeDir(p))
     .on('all', () => {
       if (watcherDebounceTimer) clearTimeout(watcherDebounceTimer);
       watcherDebounceTimer = setTimeout(() => {
@@ -118,5 +132,9 @@ export function registerFsHandlers(ipcMain: IpcMain): void {
 
   ipcMain.handle(IPC_CHANNELS.FS_DELETE, (_event, filePath: string) => {
     fs.rmSync(filePath, { recursive: true });
+  });
+
+  ipcMain.handle(IPC_CHANNELS.FS_SEARCH_FILES, (_event, query: string, limit?: number) => {
+    return fileIndex.search(query, limit);
   });
 }

--- a/src/main/mcp/config-writer.ts
+++ b/src/main/mcp/config-writer.ts
@@ -81,6 +81,29 @@ function registerJsonMcpConfig(configPath: string, nodePath: string, serverPath:
 }
 
 /**
+ * Removes the mcpServers.aide entry from a JSON MCP config file.
+ * Preserves other mcpServers and top-level keys. If mcpServers becomes
+ * empty after removal, the key is dropped. If the file does not exist
+ * or contains no aide entry, this is a no-op.
+ */
+export function unregisterAideFromJsonConfig(configPath: string): void {
+  if (!fs.existsSync(configPath)) return;
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  } catch {
+    return; // corrupt — leave untouched
+  }
+  const servers = config.mcpServers as Record<string, unknown> | undefined;
+  if (!servers || typeof servers !== 'object' || !('aide' in servers)) return;
+  delete servers['aide'];
+  if (Object.keys(servers).length === 0) {
+    delete config.mcpServers;
+  }
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+}
+
+/**
  * Removes the [mcp_servers.aide] section AND any sub-sections (e.g. [mcp_servers.aide.env])
  * from a TOML string (line-by-line, safe for array values).
  * Handles sub-sections that appear before or after the parent section header.
@@ -107,11 +130,14 @@ export function writeMcpConfig(workspacePath: string): string {
 
   writeMcpServerScript();
 
-  // Register in ~/.claude.json (Claude uses --mcp-config per-workspace; this is a fallback)
+  // Claude is launched with --mcp-config <path>, so a global entry in
+  // ~/.claude.json would cause Claude to spawn the AIDE MCP server twice
+  // (once per config source). Strip any legacy entry older versions of AIDE
+  // wrote there. Idempotent — safe to run on every workspace change.
   try {
-    registerJsonMcpConfig(path.join(home, '.claude.json'), nodePath, serverPath);
+    unregisterAideFromJsonConfig(path.join(home, '.claude.json'));
   } catch (err) {
-    console.warn('[AIDE] Failed to register Claude MCP config:', (err as Error).message);
+    console.warn('[AIDE] Failed to clean legacy Claude MCP entry:', (err as Error).message);
   }
 
   // Register in ~/.gemini/settings.json (Gemini has no --mcp-config flag)

--- a/src/main/mcp/config-writer.ts
+++ b/src/main/mcp/config-writer.ts
@@ -130,14 +130,23 @@ export function writeMcpConfig(workspacePath: string): string {
 
   writeMcpServerScript();
 
-  // Claude is launched with --mcp-config <path>, so a global entry in
-  // ~/.claude.json would cause Claude to spawn the AIDE MCP server twice
-  // (once per config source). Strip any legacy entry older versions of AIDE
-  // wrote there. Idempotent — safe to run on every workspace change.
+  // Claude is launched with --mcp-config <path>, so ANY other config source
+  // that lists "aide" causes Claude to spawn the MCP server once per source.
+  // Strip legacy entries older versions of AIDE wrote:
+  //   1. ~/.claude.json (global Claude config)
+  //   2. ~/.mcp.json    (HOME-level .mcp.json; Claude auto-discovers it by
+  //                      walking up from cwd, and every workspace is under HOME,
+  //                      so it's always picked up alongside --mcp-config)
+  // Idempotent — safe to run on every workspace change.
   try {
     unregisterAideFromJsonConfig(path.join(home, '.claude.json'));
   } catch (err) {
     console.warn('[AIDE] Failed to clean legacy Claude MCP entry:', (err as Error).message);
+  }
+  try {
+    unregisterAideFromJsonConfig(path.join(home, '.mcp.json'));
+  } catch (err) {
+    console.warn('[AIDE] Failed to clean legacy ~/.mcp.json entry:', (err as Error).message);
   }
 
   // Register in ~/.gemini/settings.json (Gemini has no --mcp-config flag)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -26,6 +26,9 @@ const aideAPI: AideAPI = {
         ipcRenderer.removeListener(IPC_CHANNELS.FS_CHANGED, listener);
       };
     },
+
+    searchFiles: (query: string, limit?: number): Promise<FileTreeNode[]> =>
+      ipcRenderer.invoke(IPC_CHANNELS.FS_SEARCH_FILES, query, limit),
   },
 
   git: {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { TitleBar } from './components/layout/TitleBar';
 import { StatusBar } from './components/layout/StatusBar';
 import { SplitContainer } from './components/layout/SplitContainer';
@@ -52,13 +52,10 @@ export function App() {
     }
   }, [theme]);
 
-  // Restore session on initial workspace load (workspace switches handled by setActive)
-  const initialRestoreDone = useRef(false);
-  useEffect(() => {
-    if (!activeWorkspaceId || initialRestoreDone.current) return;
-    initialRestoreDone.current = true;
-    useLayoutStore.getState().restoreSession(activeWorkspaceId);
-  }, [activeWorkspaceId]);
+  // Session restoration is owned by workspace-store.setActive(), which runs
+  // restoreSession() on first visit to each workspace. A duplicate call here
+  // would spawn every saved PTY twice — every tab would get an orphaned
+  // second claude/shell process running in the background.
 
   // Save session on app quit — use sendSync to guarantee write before window closes
   useEffect(() => {

--- a/src/renderer/components/file-explorer/FileExplorer.tsx
+++ b/src/renderer/components/file-explorer/FileExplorer.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { FileTreeNode, FsReadTreeError } from '../../../types/ipc';
 import { emitFileEvent } from '../../lib/event-bus';
 import { useWorkspaceStore } from '../../stores/workspace-store';
 import { usePluginStore } from '../../stores/plugin-store';
+import { filterTree } from '../../utils/file-search';
 import { PermissionBanner } from './PermissionBanner';
 
 interface TreeNodeProps {
@@ -12,10 +13,12 @@ interface TreeNodeProps {
   onSelect: (path: string) => void;
   revealPath: string | null;
   nodeRefs: React.MutableRefObject<Map<string, HTMLDivElement>>;
+  forceExpanded?: boolean;
 }
 
-function TreeNode({ node, depth, selectedPath, onSelect, revealPath, nodeRefs }: TreeNodeProps) {
+function TreeNode({ node, depth, selectedPath, onSelect, revealPath, nodeRefs, forceExpanded = false }: TreeNodeProps) {
   const [expanded, setExpanded] = useState(false);
+  const effectiveExpanded = expanded || forceExpanded;
   const [fetchedChildren, setFetchedChildren] = useState<FileTreeNode[] | undefined>(node.children);
   const [childError, setChildError] = useState<FsReadTreeError | null>(null);
   const ref = useRef<HTMLDivElement>(null);
@@ -29,14 +32,14 @@ function TreeNode({ node, depth, selectedPath, onSelect, revealPath, nodeRefs }:
 
   // Lazy-fetch children when a directory is expanded for the first time
   useEffect(() => {
-    if (!expanded || node.type !== 'directory') return;
+    if (!effectiveExpanded || node.type !== 'directory') return;
     window.aide.fs.readTreeWithError(node.path)
       .then(({ nodes: children, error }) => {
         setFetchedChildren(children);
         setChildError(error ?? null);
       })
       .catch(() => {});
-  }, [expanded, node.path, node.type]);
+  }, [effectiveExpanded, node.path, node.type]);
 
   // Auto-expand ancestor when a child is being revealed
   useEffect(() => {
@@ -94,7 +97,7 @@ function TreeNode({ node, depth, selectedPath, onSelect, revealPath, nodeRefs }:
           title={hasChildError ? 'Access denied — click to retry' : undefined}
         >
           <span className="text-[10px] text-aide-text-tertiary w-3 shrink-0">
-            {expanded ? '▼' : '▶'}
+            {effectiveExpanded ? '▼' : '▶'}
           </span>
           <span className={`truncate ${hasChildError ? 'text-[#5C5E6A]' : ''}`}>{node.name}</span>
           {hasChildError && (
@@ -106,7 +109,7 @@ function TreeNode({ node, depth, selectedPath, onSelect, revealPath, nodeRefs }:
             </span>
           )}
         </div>
-        {expanded && sortedChildren.map((child) => (
+        {effectiveExpanded && sortedChildren.map((child) => (
           <TreeNode
             key={child.path}
             node={child}
@@ -115,6 +118,7 @@ function TreeNode({ node, depth, selectedPath, onSelect, revealPath, nodeRefs }:
             onSelect={onSelect}
             revealPath={revealPath}
             nodeRefs={nodeRefs}
+            forceExpanded={forceExpanded}
           />
         ))}
       </div>
@@ -151,7 +155,11 @@ export function FileExplorer({ cwd }: FileExplorerProps) {
   const [revealPath, setRevealPath] = useState<string | null>(null);
   const [error, setError] = useState<FsReadTreeError | null>(null);
   const [dismissed, setDismissed] = useState(false);
+  const [query, setQuery] = useState('');
   const nodeRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const trimmedQuery = query.trim();
+  const filteredTree = useMemo(() => filterTree(tree, trimmedQuery), [tree, trimmedQuery]);
+  const isSearching = trimmedQuery.length > 0;
 
   const handleFileSelect = useCallback((filePath: string) => {
     setSelectedPath(filePath);
@@ -248,6 +256,26 @@ export function FileExplorer({ cwd }: FileExplorerProps) {
         />
       )}
 
+      {!error && tree.length > 0 && (
+        <div className="px-2 py-1.5 border-b border-aide-border shrink-0">
+          <input
+            type="text"
+            role="searchbox"
+            aria-label="Search files"
+            placeholder="Search files…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                setQuery('');
+              }
+            }}
+            className="w-full h-[26px] px-2 rounded bg-aide-background border border-aide-border text-[11px] font-mono text-aide-text-primary placeholder:text-aide-text-tertiary focus:outline-none focus:border-aide-accent"
+          />
+        </div>
+      )}
+
       {!error && tree.length === 0 && (
         <div
           style={{
@@ -267,7 +295,13 @@ export function FileExplorer({ cwd }: FileExplorerProps) {
         </div>
       )}
 
-      {tree.map((node) => (
+      {isSearching && filteredTree.length === 0 && tree.length > 0 && (
+        <div className="px-3 py-2 text-[11px] font-mono text-aide-text-tertiary">
+          No matches in loaded files.
+        </div>
+      )}
+
+      {filteredTree.map((node) => (
         <TreeNode
           key={node.path}
           node={node}
@@ -276,6 +310,7 @@ export function FileExplorer({ cwd }: FileExplorerProps) {
           onSelect={handleFileSelect}
           revealPath={revealPath}
           nodeRefs={nodeRefs}
+          forceExpanded={isSearching}
         />
       ))}
     </div>

--- a/src/renderer/components/file-explorer/FileExplorer.tsx
+++ b/src/renderer/components/file-explorer/FileExplorer.tsx
@@ -3,7 +3,40 @@ import type { FileTreeNode, FsReadTreeError } from '../../../types/ipc';
 import { emitFileEvent } from '../../lib/event-bus';
 import { useWorkspaceStore } from '../../stores/workspace-store';
 import { usePluginStore } from '../../stores/plugin-store';
+import { getFileIcon, getFolderIcon, getIconPath } from '../../utils/file-icon';
 import { PermissionBanner } from './PermissionBanner';
+
+// Chevron paths (not in ICON_PATHS to keep file-icon.ts focused on file types)
+const CHEVRON_PATHS: Record<string, string> = {
+  chevron_right: 'M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z',
+  chevron_down: 'M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z',
+};
+
+interface FileIconProps {
+  iconName: string;
+  color: string;
+  size?: number;
+  'aria-hidden'?: boolean | 'true' | 'false';
+  className?: string;
+}
+
+function FileIcon({ iconName, color, size = 14, className = '', ...rest }: FileIconProps) {
+  const d = CHEVRON_PATHS[iconName] ?? getIconPath(iconName);
+  const ariaHidden = rest['aria-hidden'];
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill={color}
+      aria-hidden={ariaHidden === true || ariaHidden === 'true' ? 'true' : undefined}
+      className={className}
+      style={{ flexShrink: 0 }}
+    >
+      <path d={d} />
+    </svg>
+  );
+}
 
 interface TreeNodeProps {
   node: FileTreeNode;
@@ -93,9 +126,20 @@ function TreeNode({ node, depth, selectedPath, onSelect, revealPath, nodeRefs }:
           onContextMenu={handleContextMenu}
           title={hasChildError ? 'Access denied — click to retry' : undefined}
         >
-          <span className="text-[10px] text-aide-text-tertiary w-3 shrink-0">
-            {expanded ? '▼' : '▶'}
-          </span>
+          <FileIcon
+            iconName={expanded ? 'chevron_down' : 'chevron_right'}
+            color="var(--text-tertiary)"
+            size={10}
+            aria-hidden
+            className="shrink-0"
+          />
+          <FileIcon
+            iconName={getFolderIcon(expanded, node.name).iconName}
+            color={getFolderIcon(expanded, node.name).color}
+            size={14}
+            aria-hidden
+            className="shrink-0"
+          />
           <span className={`truncate ${hasChildError ? 'text-[#5C5E6A]' : ''}`}>{node.name}</span>
           {hasChildError && (
             <span
@@ -133,6 +177,13 @@ function TreeNode({ node, depth, selectedPath, onSelect, revealPath, nodeRefs }:
       onClick={handleClick}
       onContextMenu={handleContextMenu}
     >
+      <FileIcon
+        iconName={getFileIcon(node.name).iconName}
+        color={getFileIcon(node.name).color}
+        size={14}
+        aria-hidden
+        className="shrink-0"
+      />
       <span className="truncate">{node.name}</span>
     </div>
   );

--- a/src/renderer/components/file-explorer/FileExplorer.tsx
+++ b/src/renderer/components/file-explorer/FileExplorer.tsx
@@ -1,10 +1,9 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { FileTreeNode, FsReadTreeError } from '../../../types/ipc';
 import { emitFileEvent } from '../../lib/event-bus';
 import { useWorkspaceStore } from '../../stores/workspace-store';
 import { usePluginStore } from '../../stores/plugin-store';
 import { getFileIcon, getFolderIcon, getIconPath } from '../../utils/file-icon';
-import { filterTree } from '../../utils/file-search';
 import { PermissionBanner } from './PermissionBanner';
 
 // Chevron paths (not in ICON_PATHS to keep file-icon.ts focused on file types)
@@ -63,16 +62,19 @@ function TreeNode({ node, depth, selectedPath, onSelect, revealPath, nodeRefs, f
     return () => { nodeRefs.current.delete(node.path); };
   }, [node.path, nodeRefs]);
 
-  // Lazy-fetch children when a directory is expanded for the first time
+  // Lazy-fetch children when a directory is expanded for the first time.
+  // When `node.children` is already populated (search-mode tree from the
+  // backend index), skip the fetch so we don't clobber the filtered subtree.
   useEffect(() => {
     if (!effectiveExpanded || node.type !== 'directory') return;
+    if (node.children) return;
     window.aide.fs.readTreeWithError(node.path)
       .then(({ nodes: children, error }) => {
         setFetchedChildren(children);
         setChildError(error ?? null);
       })
       .catch(() => {});
-  }, [effectiveExpanded, node.path, node.type]);
+  }, [effectiveExpanded, node.path, node.type, node.children]);
 
   // Auto-expand ancestor when a child is being revealed
   useEffect(() => {
@@ -209,8 +211,37 @@ export function FileExplorer({ cwd }: FileExplorerProps) {
   const [query, setQuery] = useState('');
   const nodeRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const trimmedQuery = query.trim();
-  const filteredTree = useMemo(() => filterTree(tree, trimmedQuery), [tree, trimmedQuery]);
   const isSearching = trimmedQuery.length > 0;
+  const [searchResults, setSearchResults] = useState<FileTreeNode[] | null>(null);
+  const [searchPending, setSearchPending] = useState(false);
+
+  useEffect(() => {
+    if (!isSearching) {
+      setSearchResults(null);
+      setSearchPending(false);
+      return;
+    }
+    setSearchPending(true);
+    let cancelled = false;
+    const handle = setTimeout(() => {
+      window.aide.fs
+        .searchFiles(trimmedQuery, 500)
+        .then((nodes) => {
+          if (cancelled) return;
+          setSearchResults(nodes);
+          setSearchPending(false);
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setSearchResults([]);
+          setSearchPending(false);
+        });
+    }, 150);
+    return () => { cancelled = true; clearTimeout(handle); };
+  }, [trimmedQuery, isSearching]);
+
+  const displayTree: FileTreeNode[] = isSearching ? (searchResults ?? []) : tree;
+  const treeKey = isSearching ? 'search' : 'tree';
 
   const handleFileSelect = useCallback((filePath: string) => {
     setSelectedPath(filePath);
@@ -346,15 +377,21 @@ export function FileExplorer({ cwd }: FileExplorerProps) {
         </div>
       )}
 
-      {isSearching && filteredTree.length === 0 && tree.length > 0 && (
+      {isSearching && searchPending && searchResults === null && (
         <div className="px-3 py-2 text-[11px] font-mono text-aide-text-tertiary">
-          No matches in loaded files.
+          Searching…
         </div>
       )}
 
-      {filteredTree.map((node) => (
+      {isSearching && !searchPending && searchResults !== null && searchResults.length === 0 && (
+        <div className="px-3 py-2 text-[11px] font-mono text-aide-text-tertiary">
+          No matches.
+        </div>
+      )}
+
+      {displayTree.map((node) => (
         <TreeNode
-          key={node.path}
+          key={`${treeKey}:${node.path}`}
           node={node}
           depth={0}
           selectedPath={selectedPath}

--- a/src/renderer/stores/layout-store.ts
+++ b/src/renderer/stores/layout-store.ts
@@ -550,6 +550,10 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
   buildSavedSession: (workspaceId) => {
     const { layout, focusedPaneId } = get();
 
+    const activePluginIds = new Set(
+      usePluginStore.getState().plugins.filter((p) => p.active).map((p) => p.id),
+    );
+
     function serializeNode(node: LayoutNode): SerializableLayoutNode {
       if (isSplitLayout(node)) {
         const split = node as SplitLayout;
@@ -561,15 +565,17 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
         } as SerializableSplitLayout;
       }
       const pane = node as Pane;
-      const tabs: SavedTab[] = pane.tabs.map((tab) => ({
-        id: tab.id,
-        type: tab.type,
-        title: tab.title,
-        isActive: tab.id === pane.activeTabId,
-        agentId: tab.agentId,
-        pluginId: tab.pluginId,
-        agentSessionId: tab.agentSessionId,
-      }));
+      const tabs: SavedTab[] = pane.tabs
+        .filter((tab) => tab.type !== 'plugin' || activePluginIds.has(tab.pluginId ?? ''))
+        .map((tab) => ({
+          id: tab.id,
+          type: tab.type,
+          title: tab.title,
+          isActive: tab.id === pane.activeTabId,
+          agentId: tab.agentId,
+          pluginId: tab.pluginId,
+          agentSessionId: tab.agentSessionId,
+        }));
       return {
         id: pane.id,
         tabs,
@@ -577,9 +583,7 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
       } as SerializablePane;
     }
 
-    const activePlugins = usePluginStore.getState().plugins
-      .filter((p) => p.active)
-      .map((p) => p.id);
+    const activePlugins = [...activePluginIds];
     const sidePanelTab = useWorkspaceStore.getState().sidePanelTab;
 
     return {

--- a/src/renderer/stores/layout-store.ts
+++ b/src/renderer/stores/layout-store.ts
@@ -5,6 +5,7 @@ import { useTerminalStore } from './terminal-store';
 import { useWorkspaceStore } from './workspace-store';
 import { usePluginStore } from './plugin-store';
 import { useToastStore } from './toast-store';
+import { deactivatingPluginIds } from './plugin-deactivate-guard';
 
 let paneCounter = 0;
 let splitCounter = 0;
@@ -377,6 +378,8 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
   },
 
   removeTabFromPane: (paneId, tabId) => {
+    let removedPluginId: string | null = null;
+
     set((state) => {
       const layout = cloneNode(state.layout);
       const pane = findPane(layout, paneId);
@@ -384,6 +387,11 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
 
       const index = pane.tabs.findIndex((t) => t.id === tabId);
       if (index < 0) return state;
+
+      const removed = pane.tabs[index];
+      if (removed.type === 'plugin' && removed.pluginId) {
+        removedPluginId = removed.pluginId;
+      }
 
       pane.tabs.splice(index, 1);
 
@@ -403,6 +411,25 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
 
       return { layout };
     });
+
+    // Fix A: closing a plugin tab must also deactivate the plugin so the
+    // main-side sandbox stops and plugin.active reflects reality.
+    // plugin-store.deactivate sets the guard before calling removeTabFromPane
+    // to prevent infinite recursion here.
+    if (removedPluginId && !deactivatingPluginIds.has(removedPluginId)) {
+      const pluginId: string = removedPluginId;
+      void (async () => {
+        deactivatingPluginIds.add(pluginId);
+        try {
+          await window.aide.plugin.deactivate(pluginId);
+          await usePluginStore.getState().loadPlugins();
+          const wsId = useWorkspaceStore.getState().activeWorkspaceId;
+          if (wsId) await get().saveSession(wsId);
+        } finally {
+          deactivatingPluginIds.delete(pluginId);
+        }
+      })();
+    }
   },
 
   setActiveTab: (paneId, tabId) => {
@@ -631,6 +658,11 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
       (w) => w.id === workspaceId,
     )?.path;
 
+    // Fix B: plugin tabs are only restored when their pluginId appears in
+    // session.activePlugins. Prevents stale/ghost plugin tabs from a
+    // previous session where layout and activePlugins drifted apart.
+    const activePluginSet = new Set(session.activePlugins ?? []);
+
     async function rebuildNode(node: SerializableLayoutNode): Promise<LayoutNode> {
       if ('direction' in node && 'children' in node) {
         const split = node as SerializableSplitLayout;
@@ -649,6 +681,13 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
 
       for (const savedTab of savedPane.tabs) {
         if (savedTab.type === 'plugin') {
+          // Fix B: skip plugin tabs whose pluginId is not in activePlugins.
+          // Older saved sessions (or any inconsistency between layout and
+          // activePlugins) would otherwise restore a tab for a disabled
+          // plugin, producing the "tab visible but plugin off" state.
+          if (!savedTab.pluginId || !activePluginSet.has(savedTab.pluginId)) {
+            continue;
+          }
           const tab: TerminalTab = {
             id: savedTab.id,
             type: 'plugin',

--- a/src/renderer/stores/plugin-deactivate-guard.ts
+++ b/src/renderer/stores/plugin-deactivate-guard.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared set of plugin ids currently being deactivated.
+ *
+ * Lives in its own module to avoid a circular import between plugin-store
+ * (the primary deactivator) and layout-store (which also triggers deactivate
+ * when a plugin tab is closed directly via removeTabFromPane).
+ *
+ * When plugin-store.deactivate() runs it adds the id before calling
+ * removeTabFromPane so layout-store can skip the auto-deactivate side effect
+ * and avoid an infinite loop.
+ */
+export const deactivatingPluginIds = new Set<string>();

--- a/src/renderer/stores/plugin-store.ts
+++ b/src/renderer/stores/plugin-store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import type { PluginInfo, TerminalTab } from '../../types/ipc';
 import { useLayoutStore } from './layout-store';
 import { useTerminalStore } from './terminal-store';
+import { deactivatingPluginIds } from './plugin-deactivate-guard';
 
 interface PluginState {
   plugins: PluginInfo[];
@@ -70,6 +71,12 @@ export const usePluginStore = create<PluginState>((set, get) => ({
   },
 
   deactivate: async (id: string) => {
+    // Guard: layout-store.removeTabFromPane auto-deactivates plugin tabs when
+    // they are closed directly (× click, ⌘W). That path calls back into
+    // window.aide.plugin.deactivate, which would recurse here. By marking
+    // the id as in-flight, we tell the layout-store hook to skip its own
+    // deactivate side effect while this function owns the lifecycle.
+    deactivatingPluginIds.add(id);
     try {
       await window.aide.plugin.deactivate(id);
       const plugins = await window.aide.plugin.list();
@@ -92,6 +99,8 @@ export const usePluginStore = create<PluginState>((set, get) => ({
       }
     } catch (e) {
       set({ error: e instanceof Error ? e.message : 'Failed to deactivate plugin' });
+    } finally {
+      deactivatingPluginIds.delete(id);
     }
   },
 

--- a/src/renderer/stores/workspace-store.ts
+++ b/src/renderer/stores/workspace-store.ts
@@ -54,7 +54,21 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         useTerminalStore.getState().switchWorkspace(prevId, id);
       }
 
-      // 2. Try in-memory layout cache first; fall back to disk restore on first visit.
+      // 2. Tell main about the new workspace and seed the plugin registry
+      //    BEFORE restoreSession runs. restoreSession calls
+      //    window.aide.plugin.activate(id) for every entry in
+      //    session.activePlugins, which needs registry.get(id) to succeed.
+      //    We call window.aide.plugin.list() directly (not via
+      //    usePluginStore.loadPlugins) so the renderer store does not flash
+      //    "0/N ACTIVE" between this seed call and the post-restore refresh.
+      const workspace = get().workspaces.find((w) => w.id === id);
+      if (workspace) {
+        await window.aide.workspace.open(workspace.path);
+      }
+      await window.aide.plugin.list();
+      invalidateSettingsCache();
+
+      // 3. Try in-memory layout cache first; fall back to disk restore on first visit.
       const loaded = useLayoutStore.getState().loadLayoutFromCache(id);
       if (!loaded) {
         // First visit to this workspace — spawn PTYs from disk session.
@@ -74,13 +88,12 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         }
       }
 
-      // 3. Notify main process so getActiveWorkspacePath() updates before loadPlugins().
-      const workspace = get().workspaces.find((w) => w.id === id);
-      if (workspace) {
-        await window.aide.workspace.open(workspace.path);
-      }
+      // 4. Single renderer-store refresh at the end so PluginPanel shows the
+      //    final active state in one commit. Covers both paths — the cache
+      //    branch also needs this because main-side plugin state may have
+      //    drifted (file watcher events, external toggles) since the last
+      //    time the renderer viewed this workspace.
       await usePluginStore.getState().loadPlugins();
-      invalidateSettingsCache();
     }
     set({ activeWorkspaceId: id });
   },

--- a/src/renderer/utils/file-icon.ts
+++ b/src/renderer/utils/file-icon.ts
@@ -1,0 +1,554 @@
+/**
+ * file-icon.ts
+ * Zero-dependency VSCode material-icon-theme–style file/folder icon mapper.
+ * Returns iconName (Material Symbols Rounded glyph name) + color hex.
+ */
+
+export interface FileIconInfo {
+  /** Material Symbols Rounded icon name */
+  iconName: string;
+  /** CSS color hex string */
+  color: string;
+}
+
+// ---------------------------------------------------------------------------
+// Exact filename overrides (checked before extension mapping)
+// ---------------------------------------------------------------------------
+const FILENAME_MAP: Record<string, FileIconInfo> = {
+  // Git
+  '.gitignore': { iconName: 'git', color: '#F05133' },
+  '.gitattributes': { iconName: 'git', color: '#F05133' },
+  '.gitmodules': { iconName: 'git', color: '#F05133' },
+  '.gitkeep': { iconName: 'git', color: '#F05133' },
+
+  // Docker
+  'Dockerfile': { iconName: 'docker', color: '#2496ED' },
+  'dockerfile': { iconName: 'docker', color: '#2496ED' },
+  'docker-compose.yml': { iconName: 'docker', color: '#2496ED' },
+  'docker-compose.yaml': { iconName: 'docker', color: '#2496ED' },
+  'docker-compose.dev.yml': { iconName: 'docker', color: '#2496ED' },
+  'docker-compose.prod.yml': { iconName: 'docker', color: '#2496ED' },
+  'docker-compose.override.yml': { iconName: 'docker', color: '#2496ED' },
+
+  // License
+  'LICENSE': { iconName: 'license', color: '#D0A85C' },
+  'LICENSE.md': { iconName: 'license', color: '#D0A85C' },
+  'LICENSE.txt': { iconName: 'license', color: '#D0A85C' },
+  'LICENCE': { iconName: 'license', color: '#D0A85C' },
+
+  // Node / package managers
+  'package.json': { iconName: 'json', color: '#F5A623' },
+  'package-lock.json': { iconName: 'json', color: '#F5A623' },
+  'pnpm-lock.yaml': { iconName: 'yaml', color: '#CB171E' },
+  'yarn.lock': { iconName: 'lock', color: '#2C8EBB' },
+  '.npmrc': { iconName: 'npm', color: '#CB3837' },
+  '.nvmrc': { iconName: 'npm', color: '#CB3837' },
+  '.node-version': { iconName: 'npm', color: '#CB3837' },
+
+  // Env
+  '.env': { iconName: 'dotenv', color: '#ECD53F' },
+  '.env.local': { iconName: 'dotenv', color: '#ECD53F' },
+  '.env.development': { iconName: 'dotenv', color: '#ECD53F' },
+  '.env.production': { iconName: 'dotenv', color: '#ECD53F' },
+  '.env.test': { iconName: 'dotenv', color: '#ECD53F' },
+  '.env.example': { iconName: 'dotenv', color: '#ECD53F' },
+
+  // Configs
+  'tsconfig.json': { iconName: 'json', color: '#3178C6' },
+  'tsconfig.base.json': { iconName: 'json', color: '#3178C6' },
+  'jsconfig.json': { iconName: 'json', color: '#F7DF1E' },
+  '.eslintrc': { iconName: 'settings', color: '#4B32C3' },
+  '.eslintrc.js': { iconName: 'settings', color: '#4B32C3' },
+  '.eslintrc.cjs': { iconName: 'settings', color: '#4B32C3' },
+  '.eslintrc.json': { iconName: 'settings', color: '#4B32C3' },
+  '.eslintrc.yaml': { iconName: 'settings', color: '#4B32C3' },
+  '.eslintrc.yml': { iconName: 'settings', color: '#4B32C3' },
+  '.eslintignore': { iconName: 'settings', color: '#4B32C3' },
+  '.prettierrc': { iconName: 'settings', color: '#EA5E5E' },
+  '.prettierrc.js': { iconName: 'settings', color: '#EA5E5E' },
+  '.prettierrc.json': { iconName: 'settings', color: '#EA5E5E' },
+  '.prettierrc.yaml': { iconName: 'settings', color: '#EA5E5E' },
+  '.prettierrc.yml': { iconName: 'settings', color: '#EA5E5E' },
+  '.prettierignore': { iconName: 'settings', color: '#EA5E5E' },
+  'vite.config.ts': { iconName: 'settings', color: '#646CFF' },
+  'vite.config.js': { iconName: 'settings', color: '#646CFF' },
+  'vitest.config.ts': { iconName: 'settings', color: '#646CFF' },
+  'vitest.config.js': { iconName: 'settings', color: '#646CFF' },
+  'webpack.config.js': { iconName: 'settings', color: '#8DD6F9' },
+  'webpack.config.ts': { iconName: 'settings', color: '#8DD6F9' },
+  'rollup.config.js': { iconName: 'settings', color: '#FF3333' },
+  'rollup.config.ts': { iconName: 'settings', color: '#FF3333' },
+  'tailwind.config.js': { iconName: 'settings', color: '#38BDF8' },
+  'tailwind.config.ts': { iconName: 'settings', color: '#38BDF8' },
+  'postcss.config.js': { iconName: 'settings', color: '#DD3A0A' },
+  'postcss.config.ts': { iconName: 'settings', color: '#DD3A0A' },
+  'babel.config.js': { iconName: 'settings', color: '#F5DA55' },
+  'babel.config.json': { iconName: 'settings', color: '#F5DA55' },
+  '.babelrc': { iconName: 'settings', color: '#F5DA55' },
+  'jest.config.js': { iconName: 'settings', color: '#C21325' },
+  'jest.config.ts': { iconName: 'settings', color: '#C21325' },
+  'playwright.config.ts': { iconName: 'settings', color: '#2EAD33' },
+  'playwright.config.js': { iconName: 'settings', color: '#2EAD33' },
+
+  // Readme
+  'README.md': { iconName: 'markdown', color: '#4A9EBF' },
+  'readme.md': { iconName: 'markdown', color: '#4A9EBF' },
+  'CHANGELOG.md': { iconName: 'markdown', color: '#4A9EBF' },
+  'CONTRIBUTING.md': { iconName: 'markdown', color: '#4A9EBF' },
+
+  // Makefile
+  'Makefile': { iconName: 'makefile', color: '#6D8086' },
+  'makefile': { iconName: 'makefile', color: '#6D8086' },
+  'GNUmakefile': { iconName: 'makefile', color: '#6D8086' },
+};
+
+// ---------------------------------------------------------------------------
+// Extension → icon mapping
+// ---------------------------------------------------------------------------
+const EXT_MAP: Record<string, FileIconInfo> = {
+  // TypeScript
+  ts: { iconName: 'typescript', color: '#3178C6' },
+  mts: { iconName: 'typescript', color: '#3178C6' },
+  cts: { iconName: 'typescript', color: '#3178C6' },
+  tsx: { iconName: 'react_ts', color: '#61DAFB' },
+
+  // JavaScript
+  js: { iconName: 'javascript', color: '#F7DF1E' },
+  mjs: { iconName: 'javascript', color: '#F7DF1E' },
+  cjs: { iconName: 'javascript', color: '#F7DF1E' },
+  jsx: { iconName: 'react', color: '#61DAFB' },
+
+  // Web
+  html: { iconName: 'html', color: '#E44D26' },
+  htm: { iconName: 'html', color: '#E44D26' },
+  css: { iconName: 'css', color: '#264de4' },
+  scss: { iconName: 'sass', color: '#CC6699' },
+  sass: { iconName: 'sass', color: '#CC6699' },
+  less: { iconName: 'css', color: '#1D365D' },
+  styl: { iconName: 'css', color: '#FF6347' },
+  vue: { iconName: 'vue', color: '#42B883' },
+  svelte: { iconName: 'svelte', color: '#FF3E00' },
+
+  // Data / Config
+  json: { iconName: 'json', color: '#F5A623' },
+  jsonc: { iconName: 'json', color: '#F5A623' },
+  json5: { iconName: 'json', color: '#F5A623' },
+  yaml: { iconName: 'yaml', color: '#CB171E' },
+  yml: { iconName: 'yaml', color: '#CB171E' },
+  toml: { iconName: 'toml', color: '#9C4121' },
+  ini: { iconName: 'settings', color: '#6D8086' },
+  env: { iconName: 'dotenv', color: '#ECD53F' },
+  xml: { iconName: 'xml', color: '#F47742' },
+  plist: { iconName: 'xml', color: '#F47742' },
+
+  // Documentation
+  md: { iconName: 'markdown', color: '#4A9EBF' },
+  mdx: { iconName: 'markdown', color: '#4A9EBF' },
+  rst: { iconName: 'markdown', color: '#4A9EBF' },
+  txt: { iconName: 'text', color: '#6D8086' },
+  pdf: { iconName: 'pdf', color: '#E8291C' },
+
+  // Images
+  png: { iconName: 'image', color: '#A074C4' },
+  jpg: { iconName: 'image', color: '#A074C4' },
+  jpeg: { iconName: 'image', color: '#A074C4' },
+  gif: { iconName: 'image', color: '#A074C4' },
+  webp: { iconName: 'image', color: '#A074C4' },
+  bmp: { iconName: 'image', color: '#A074C4' },
+  ico: { iconName: 'image', color: '#A074C4' },
+  tif: { iconName: 'image', color: '#A074C4' },
+  tiff: { iconName: 'image', color: '#A074C4' },
+  svg: { iconName: 'svg', color: '#FFB13B' },
+
+  // Audio / Video
+  mp3: { iconName: 'audio', color: '#EE82EE' },
+  wav: { iconName: 'audio', color: '#EE82EE' },
+  ogg: { iconName: 'audio', color: '#EE82EE' },
+  flac: { iconName: 'audio', color: '#EE82EE' },
+  mp4: { iconName: 'video', color: '#EE82EE' },
+  webm: { iconName: 'video', color: '#EE82EE' },
+  mov: { iconName: 'video', color: '#EE82EE' },
+  avi: { iconName: 'video', color: '#EE82EE' },
+
+  // Shell / Scripts
+  sh: { iconName: 'shell', color: '#89E051' },
+  bash: { iconName: 'shell', color: '#89E051' },
+  zsh: { iconName: 'shell', color: '#89E051' },
+  fish: { iconName: 'shell', color: '#89E051' },
+  ps1: { iconName: 'shell', color: '#012456' },
+  bat: { iconName: 'shell', color: '#C1F12E' },
+  cmd: { iconName: 'shell', color: '#C1F12E' },
+
+  // Python
+  py: { iconName: 'python', color: '#3572A5' },
+  pyw: { iconName: 'python', color: '#3572A5' },
+  pyi: { iconName: 'python', color: '#3572A5' },
+  ipynb: { iconName: 'python', color: '#3572A5' },
+
+  // Rust
+  rs: { iconName: 'rust', color: '#DEA584' },
+  toml_cargo: { iconName: 'rust', color: '#DEA584' }, // internal key, not real ext
+
+  // Go
+  go: { iconName: 'go', color: '#00ADD8' },
+
+  // Java / JVM
+  java: { iconName: 'java', color: '#B07219' },
+  class: { iconName: 'java', color: '#B07219' },
+  jar: { iconName: 'java', color: '#B07219' },
+  kt: { iconName: 'kotlin', color: '#A97BFF' },
+  kts: { iconName: 'kotlin', color: '#A97BFF' },
+  groovy: { iconName: 'groovy', color: '#4298B8' },
+  scala: { iconName: 'scala', color: '#DC322F' },
+
+  // C / C++ / C#
+  c: { iconName: 'c', color: '#555555' },
+  h: { iconName: 'c', color: '#555555' },
+  cpp: { iconName: 'cpp', color: '#F34B7D' },
+  cc: { iconName: 'cpp', color: '#F34B7D' },
+  cxx: { iconName: 'cpp', color: '#F34B7D' },
+  hpp: { iconName: 'cpp', color: '#F34B7D' },
+  cs: { iconName: 'csharp', color: '#178600' },
+
+  // Swift / Objective-C
+  swift: { iconName: 'swift', color: '#F05138' },
+  m: { iconName: 'objc', color: '#438EFF' },
+  mm: { iconName: 'objc', color: '#438EFF' },
+
+  // Ruby
+  rb: { iconName: 'ruby', color: '#CC342D' },
+  rake: { iconName: 'ruby', color: '#CC342D' },
+  gemspec: { iconName: 'ruby', color: '#CC342D' },
+  erb: { iconName: 'ruby', color: '#CC342D' },
+
+  // PHP
+  php: { iconName: 'php', color: '#777BB4' },
+
+  // Dart / Flutter
+  dart: { iconName: 'dart', color: '#00B4AB' },
+
+  // Lua
+  lua: { iconName: 'lua', color: '#000080' },
+
+  // R
+  r: { iconName: 'r', color: '#198CE7' },
+  rmd: { iconName: 'r', color: '#198CE7' },
+
+  // SQL / DB
+  sql: { iconName: 'database', color: '#336791' },
+  sqlite: { iconName: 'database', color: '#003B57' },
+  db: { iconName: 'database', color: '#6D8086' },
+
+  // GraphQL
+  graphql: { iconName: 'graphql', color: '#E535AB' },
+  gql: { iconName: 'graphql', color: '#E535AB' },
+
+  // Terraform / Infrastructure
+  tf: { iconName: 'terraform', color: '#7B42BC' },
+  tfvars: { iconName: 'terraform', color: '#7B42BC' },
+
+  // Prisma
+  prisma: { iconName: 'database', color: '#0C344B' },
+
+  // Binary / Archive
+  zip: { iconName: 'archive', color: '#6D8086' },
+  tar: { iconName: 'archive', color: '#6D8086' },
+  gz: { iconName: 'archive', color: '#6D8086' },
+  rar: { iconName: 'archive', color: '#6D8086' },
+  '7z': { iconName: 'archive', color: '#6D8086' },
+  dmg: { iconName: 'archive', color: '#6D8086' },
+  exe: { iconName: 'archive', color: '#6D8086' },
+
+  // Fonts
+  ttf: { iconName: 'font', color: '#AAAAAA' },
+  otf: { iconName: 'font', color: '#AAAAAA' },
+  woff: { iconName: 'font', color: '#AAAAAA' },
+  woff2: { iconName: 'font', color: '#AAAAAA' },
+  eot: { iconName: 'font', color: '#AAAAAA' },
+
+  // Certificates / Keys
+  pem: { iconName: 'key', color: '#ECD53F' },
+  crt: { iconName: 'key', color: '#ECD53F' },
+  cer: { iconName: 'key', color: '#ECD53F' },
+  key: { iconName: 'key', color: '#ECD53F' },
+  p12: { iconName: 'key', color: '#ECD53F' },
+  pfx: { iconName: 'key', color: '#ECD53F' },
+
+  // Lock files
+  lock: { iconName: 'lock', color: '#2C8EBB' },
+};
+
+// ---------------------------------------------------------------------------
+// Default fallback
+// ---------------------------------------------------------------------------
+const DEFAULT_FILE_ICON: FileIconInfo = { iconName: 'file', color: '#6D8086' };
+
+// ---------------------------------------------------------------------------
+// Material Symbols → SVG path lookup
+// Maps iconName keys to SVG path data for rendering without a font dependency.
+// ---------------------------------------------------------------------------
+export const ICON_PATHS: Record<string, string> = {
+  // Folder states
+  folder_open:
+    'M20 6h-8l-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 12H4V8h16v10z',
+  folder:
+    'M10 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z',
+  folder_src:
+    'M10 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2zm2 11.5L8.5 12 12 8.5l1.41 1.41L11.33 12l2.08 2.09L12 15.5zm4 0l-1.41-1.41L16.67 12l-2.08-2.09L16 8.5 19.5 12 16 15.5z',
+  folder_node_modules:
+    'M10 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2zm2 9.5c-1.38 0-2.5-1.12-2.5-2.5S10.62 8.5 12 8.5s2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5zm0-3.5c-.55 0-1 .45-1 1s.45 1 1 1 1-.45 1-1-.45-1-1-1z',
+  folder_git:
+    'M10 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2zm3 10h-1v-3.59l-1.5 1.5-1.06-1.06L12 8.29l2.56 2.56L13.5 11.91V14z',
+
+  // Generic file
+  file: 'M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm-1 1.5L18.5 9H13V3.5zM6 20V4h5v7h7v9H6z',
+
+  // Code
+  code: 'M9.4 16.6 4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0 4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z',
+
+  // TypeScript / JavaScript
+  typescript:
+    'M3 3h18v18H3V3zm10.71 14.86c.5.98 1.51 1.57 2.59 1.57 1.53 0 2.5-.81 2.5-2.05 0-1.16-.74-1.75-2.05-2.21l-.58-.2c-.68-.22-.97-.44-.97-.87 0-.36.28-.63.74-.63.43 0 .73.2.91.62l1.29-.86c-.54-1.02-1.42-1.4-2.2-1.4-1.38 0-2.27.86-2.27 2.01 0 1.08.68 1.68 1.87 2.11l.58.2c.73.26 1.15.48 1.15.97 0 .43-.4.72-1 .72-.67 0-1.17-.32-1.47-.98l-1.09.99zm-3.44-.14V14.5H12V13H7v1.5h1.71v3.22H10.27z',
+  javascript:
+    'M3 3h18v18H3V3zm16 16V5H5v14h14zm-8.56-4.14c.23.42.64.74 1.15.74.52 0 .85-.26.85-.64 0-.44-.34-.6-1.03-.86l-.36-.15c-1.04-.44-1.73-.99-1.73-2.16 0-1.07.82-1.89 2.1-1.89.91 0 1.57.32 2.04 1.15l-1.12.72c-.24-.44-.5-.61-.92-.61-.41 0-.67.26-.67.61 0 .43.26.6.86.86l.36.15c1.22.52 1.91 1.05 1.91 2.24 0 1.28-.99 2-2.33 2-1.3 0-2.15-.62-2.56-1.43l1.45-.73z',
+
+  // React
+  react:
+    'M12 10.11c1.03 0 1.87.84 1.87 1.89 0 1-.84 1.85-1.87 1.85-1.03 0-1.87-.85-1.87-1.85 0-1.05.84-1.89 1.87-1.89M7.37 20c.63.38 2.01-.2 3.6-1.7-.52-.59-1.03-1.23-1.51-1.9-.82-.08-1.63-.2-2.4-.36-.51 2.14-.32 3.61.31 3.96m.71-5.74l-.29-.51c-.11.29-.22.58-.29.86.27.06.57.11.88.16l-.3-.51m6.54-.76l.81-1.5-.81-1.5c-.3-.53-.62-1-.91-1.47C13.17 9 12.6 9 12 9c-.6 0-1.17 0-1.71.03-.29.47-.61.94-.91 1.47L8.57 12l.81 1.5c.3.53.62 1 .91 1.47.54.03 1.11.03 1.71.03.6 0 1.17 0 1.71-.03.29-.47.61-.94.91-1.47m-7.07-.9c.36-.51.8-1.05 1.27-1.59-.82.06-1.57.17-2.26.3.21.76.48 1.5.99 2.29zm9.35 0l-.99-1.59c.51-.79.78-1.53.99-2.29-.69-.13-1.44-.24-2.26-.3.47.54.91 1.08 1.27 1.59l-.01.59zM16.62 4c-.63-.38-2.01.2-3.6 1.7.52.59 1.03 1.23 1.51 1.9.82.08 1.63.2 2.4.36.51-2.14.32-3.61-.31-3.96m-.71 5.74l.29.51c.11-.29.22-.58.29-.86-.27-.06-.57-.11-.88-.16l.3.51m-3.54-5.48c-.36.52-.8 1.06-1.27 1.6.82-.06 1.57-.17 2.26-.3-.21-.76-.48-1.5-.99-2.3zm-4.71 13.23c-.36.52-.8 1.06-1.27 1.6.82-.06 1.57-.17 2.26-.3-.21-.76-.48-1.5-.99-2.3zm9.13-.33c.51 2.14.32 3.61-.31 3.96-.63.38-2.01-.2-3.6-1.7.52-.59 1.03-1.23 1.51-1.9.82-.08 1.63-.2 2.4-.36zm-4.71-1.9l.29.51.3-.51c-.1 0-.2-.01-.3-.01-.1 0-.2.01-.29.01z',
+  react_ts:
+    'M12 10.11c1.03 0 1.87.84 1.87 1.89 0 1-.84 1.85-1.87 1.85-1.03 0-1.87-.85-1.87-1.85 0-1.05.84-1.89 1.87-1.89M7.37 20c.63.38 2.01-.2 3.6-1.7-.52-.59-1.03-1.23-1.51-1.9-.82-.08-1.63-.2-2.4-.36-.51 2.14-.32 3.61.31 3.96m.71-5.74l-.29-.51c-.11.29-.22.58-.29.86.27.06.57.11.88.16l-.3-.51m6.54-.76l.81-1.5-.81-1.5c-.3-.53-.62-1-.91-1.47C13.17 9 12.6 9 12 9c-.6 0-1.17 0-1.71.03-.29.47-.61.94-.91 1.47L8.57 12l.81 1.5c.3.53.62 1 .91 1.47.54.03 1.11.03 1.71.03.6 0 1.17 0 1.71-.03.29-.47.61-.94.91-1.47m-7.07-.9c.36-.51.8-1.05 1.27-1.59-.82.06-1.57.17-2.26.3.21.76.48 1.5.99 2.29zm9.35 0l-.99-1.59c.51-.79.78-1.53.99-2.29-.69-.13-1.44-.24-2.26-.3.47.54.91 1.08 1.27 1.59l-.01.59zM16.62 4c-.63-.38-2.01.2-3.6 1.7.52.59 1.03 1.23 1.51 1.9.82.08 1.63.2 2.4.36.51-2.14.32-3.61-.31-3.96m-.71 5.74l.29.51c.11-.29.22-.58.29-.86-.27-.06-.57-.11-.88-.16l.3.51m-3.54-5.48c-.36.52-.8 1.06-1.27 1.6.82-.06 1.57-.17 2.26-.3-.21-.76-.48-1.5-.99-2.3zm-4.71 13.23c-.36.52-.8 1.06-1.27 1.6.82-.06 1.57-.17 2.26-.3-.21-.76-.48-1.5-.99-2.3zm9.13-.33c.51 2.14.32 3.61-.31 3.96-.63.38-2.01-.2-3.6-1.7.52-.59 1.03-1.23 1.51-1.9.82-.08 1.63-.2 2.4-.36zm-4.71-1.9l.29.51.3-.51c-.1 0-.2-.01-.3-.01-.1 0-.2.01-.29.01z',
+
+  // Markup / Style
+  html: 'M4 2h16l-1.5 14-6.5 2-6.5-2L4 2zm13.1 3H6.9l.3 3.5h9.6l-.3 3H9.5l.2 2.5 2.3.6 2.3-.6.2-2h2.6l-.4 4L12 19.1 7.3 17.5l-.3-3.5H9.4l.2 1.7 2.4.7 2.4-.7.2-2.1H6.7L6.1 5h11.8z',
+  css: 'M4 2h16l-1.5 14-6.5 2-6.5-2L4 2zm13 3H7l.3 2.5h9.1l-.3 2H9.5l.3 2.5h6.4l-.4 3.3L12 16l-3.8-1.2-.2-2.8h2.3l.1 1.7 1.6.4 1.6-.4.2-2.3H6.4L5.9 5h12.1z',
+  sass: 'M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm3.83 14.17c-.31.19-.67.29-1.04.29-.56 0-1.08-.23-1.46-.64-.74.4-1.57.61-2.41.61-2.2 0-3.99-1.79-3.99-3.99 0-2.2 1.79-3.99 3.99-3.99.55 0 1.08.11 1.56.32.48-.21.99-.32 1.51-.32 1.2 0 2.27.59 2.93 1.5.37.51.59 1.12.59 1.79 0 .72-.22 1.39-.59 1.95l.08.48c.22-.1.46-.16.71-.16.97 0 1.75.78 1.75 1.75 0 .51-.22.97-.57 1.3l-.11-.54c.22-.21.35-.49.35-.79 0-.58-.47-1.05-1.05-1.05-.2 0-.38.05-.54.15l.29 1.34z',
+
+  // Data
+  json: 'M5 3h2v2H5v5a2 2 0 01-2 2 2 2 0 012 2v5h2v2H5c-1.07-.27-2-.9-2-2v-4a2 2 0 00-2-2H0v-2h1a2 2 0 002-2V5a2 2 0 012-2m14 0c1.07.27 2 .9 2 2v4a2 2 0 002 2h1v2h-1a2 2 0 00-2 2v4a2 2 0 01-2 2h-2v-2h2v-5a2 2 0 012-2 2 2 0 01-2-2V5h-2V3h2z',
+  yaml: 'M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5',
+  toml: 'M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8l-6-6zm-1 1.5L18.5 9H13V3.5zM8 13h8v1H8v-1zm0 3h6v1H8v-1zm0-6h3v1H8v-1z',
+  xml: 'M12.89 3L14.85 3.4L11.11 21L9.15 20.6L12.89 3M19.8 12L16 8.2V5.4L22.6 12L16 18.6V15.8L19.8 12M1.4 12L8 5.4V8.2L4.2 12L8 15.8V18.6L1.4 12Z',
+
+  // Markdown / Text
+  markdown:
+    'M20.56 18H3.44C2.65 18 2 17.37 2 16.59V7.41C2 6.63 2.65 6 3.44 6h17.12C21.35 6 22 6.63 22 7.41v9.18c0 .78-.65 1.41-1.44 1.41zM9.61 15.5V12l2.39 2.94 2.39-2.94v3.5H16V9h-1.61l-2.39 2.94L9.61 9H8v6.5h1.61zM4 15l3.5-3.5L4 8l-.9.9 2.1 2.6H2v1h3.2l-2.1 2.6z',
+  text: 'M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8l-6-6zm-1 1.5L18.5 9H13V3.5zM8 17v-1h8v1H8zm0-3v-1h8v1H8zm0-3V10h5v1H8z',
+  pdf: 'M20 2H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-8.5 7.5c0 .83-.67 1.5-1.5 1.5H9v2H7.5V7H10c.83 0 1.5.67 1.5 1.5v1zm5 2c0 .83-.67 1.5-1.5 1.5h-2.5V7H15c.83 0 1.5.67 1.5 1.5v3zm4-3H19v1h1.5V11H19v2h-1.5V7h3v1.5zM9 9.5h1v-1H9v1zM4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm10 5.5h1v-3h-1v3z',
+
+  // Images
+  image:
+    'M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z',
+  svg: 'M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z',
+
+  // Audio / Video
+  audio:
+    'M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z',
+  video:
+    'M17 10.5V7c0-.55-.45-1-1-1H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1v-3.5l4 4v-11l-4 4z',
+
+  // Shell
+  shell:
+    'M20 19.59V8l-6-6H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c.45 0 .85-.15 1.19-.4l-4.43-4.43c-.8.52-1.74.83-2.76.83-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5c0 1.02-.31 1.96-.83 2.75L20 19.59zM9 13c0 1.66 1.34 3 3 3s3-1.34 3-3-1.34-3-3-3-3 1.34-3 3z',
+
+  // Languages
+  python:
+    'M12 2c-5.52 0-10 4.48-10 10s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-1-13H9v2h2v-2zm4 0h-2v2h2V7zm-6 4H7v2h2v-2zm8 0h-2v2h2v-2zm-4 0h-2v2h2v-2z',
+  rust: 'M19.55 9.56L17.5 8.34V6.5a.5.5 0 00-.5-.5h-1a.5.5 0 00-.5.5v1L12 5.5 8.5 7.5v-1a.5.5 0 00-.5-.5H7a.5.5 0 00-.5.5v1.84L4.45 9.56A1 1 0 004 10.44v3.12a1 1 0 00.45.88l2.05 1.22V17.5a.5.5 0 00.5.5h1a.5.5 0 00.5-.5v-1l3.5 2 3.5-2v1a.5.5 0 00.5.5h1a.5.5 0 00.5-.5v-1.84l2.05-1.22a1 1 0 00.45-.88v-3.12a1 1 0 00-.45-.88zM12 15.5L9 13.87V10.13L12 8.5l3 1.63v3.74L12 15.5z',
+  go: 'M1.811 10.231c-.047 0-.058-.023-.035-.059l.246-.315c.023-.035.081-.058.128-.058h4.172c.046 0 .058.035.035.07l-.199.303c-.023.036-.082.07-.117.07l-4.23-.011zm-1.235 1.234c-.047 0-.059-.023-.035-.058l.245-.316c.023-.035.082-.058.129-.058h5.328c.047 0 .07.035.058.07l-.093.28c-.012.047-.058.07-.105.07l-5.527.012zm2.006 1.234c-.047 0-.059-.023-.035-.058l.163-.292c.023-.035.07-.07.117-.07h2.337c.047 0 .07.035.07.082l-.023.28c0 .047-.047.082-.082.082l-2.547-.024zm11.532-3.104c-.736.187-1.239.327-1.963.514-.176.046-.187.058-.34-.117-.175-.199-.303-.327-.548-.444-.737-.362-1.45-.257-2.11.175-.795.514-1.204 1.274-1.192 2.22.011.935.654 1.706 1.577 1.835.795.105 1.46-.175 1.987-.771.105-.13.198-.27.315-.434H8.843c-.257 0-.316-.163-.234-.374.163-.41.467-1.099.64-1.45.035-.07.105-.175.257-.175h5.562c-.023.316-.023.631-.07.947-.198 1.285-.7 2.397-1.578 3.304-.174.187-.35.362-.513.527-.339.339-.783.56-1.204.713-.562.2-1.143.27-1.716.2-.315-.047-.618-.117-.9-.257-.515-.245-.947-.596-1.204-1.087-.362-.678-.433-1.39-.233-2.116.046-.177.105-.352.175-.515.222-.503.527-.947.9-1.344.129-.134.269-.257.408-.374.175-.14.363-.257.55-.363l.34-.175c.374-.175.771-.28 1.19-.316.409-.024.806.012 1.192.128.385.117.736.3 1.04.562.2.163.373.363.502.585a.5.5 0 00.444.245z',
+  java: 'M8.5 19c-.32 0-.5-.14-.5-.35v-1.3c0-.21.18-.35.5-.35h7c.32 0 .5.14.5.35v1.3c0 .21-.18.35-.5.35h-7zm3.5-3v-1h1v1h-1zm-1.5-1v-1h1v1h-1zm3 0v-1h1v1h-1zm-1.5-1v-1h1v1h-1zM8 5V3h8v2H8zm-2 0c0-1.1.9-2 2-2h8c1.1 0 2 .9 2 2v9c0 1.1-.9 2-2 2H8c-1.1 0-2-.9-2-2V5z',
+  kotlin:
+    'M3 3h9.5L3 12.5V3zm9.5 0H21L12 12 3 21h9.5L21 9.5 12.5 3h-.998zM3 21l9-9 9 9H3z',
+  groovy: 'M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z',
+  scala:
+    'M3 16.5v-2l18-6v2L3 16.5zm0-4v-2l18-6v2L3 12.5zm0-4v-2l18-6v2L3 8.5z',
+  c: 'M9.26 12c0-.37.07-.73.2-1.07l-1.64-.84C7.3 10.7 7 11.33 7 12c0 .67.3 1.3.82 1.91l1.64-.84A3.41 3.41 0 019.26 12zM12 9.26c.37 0 .73.07 1.07.2l.84-1.64C13.3 7.3 12.67 7 12 7c-.67 0-1.3.3-1.91.82l.84 1.64A3.41 3.41 0 0112 9.26zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z',
+  cpp: 'M14.5 2.5c0 1.5-1.5 3-1.5 3s-1.5-1.5-1.5-3 1.5-1 1.5-1 1.5-.5 1.5 1zm3 3.5c-1.5 0-3 1.5-3 1.5s1.5 1.5 3 1.5 1-1.5 1-1.5-.5-1.5-1-1.5zm-11 0c1.5 0 3 1.5 3 1.5S8 9 6.5 9 5.5 7.5 5.5 7.5 5 6 6.5 6zm2 8c-1.5 0-3 1.5-3 1.5s1.5 1.5 3 1.5 1-1.5 1-1.5-.5-1.5-1-1.5zm7 0c1.5 0 3 1.5 3 1.5s-1.5 1.5-3 1.5-1-1.5-1-1.5.5-1.5 1-1.5zm-3.5 3.5c0-1.5-1.5-3-1.5-3s-1.5 1.5-1.5 3 1.5 1 1.5 1 1.5-.5 1.5-1zM12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4z',
+  csharp:
+    'M11.5 15.97l.41 2.44c-.26.14-.68.27-1.24.39-.57.13-1.24.2-2.01.2-2.21-.04-3.87-.7-4.98-1.96C2.56 15.77 2 14.16 2 12.21c.05-2.31.72-4.08 2-5.32C5.32 5.64 6.96 5 8.94 5c.75 0 1.4.07 1.94.19s.88.25 1.12.4l-.51 2.4-.71-.26c-.29-.08-.71-.12-1.25-.12-1.17.01-2.09.45-2.77 1.32S6.5 10.62 6.5 11.9c0 1.41.36 2.5 1.07 3.26s1.63 1.14 2.77 1.14c.45 0 .88-.05 1.28-.16.4-.11.69-.24.88-.4zM13 11h2V9h1.5v2H18v1.5h-1.5V14H15v-1.5h-2V11z',
+
+  // Swift
+  swift:
+    'M19.32 15.89C17.39 19.86 13 22.13 8.46 21.29 4.98 20.64 2.2 18.06 1.21 14.69.46 12.18.79 9.44 2.1 7.18c.07.83.33 1.64.77 2.37C1.6 12.3 1.82 15.35 3.35 17.6c1.07 1.57 2.7 2.72 4.55 3.12C10.92 21.47 14.38 20 16.2 17.3c-2.5-.64-5.16-.16-7.34 1.28-.49-.49-.94-1.03-1.3-1.61C6 14.94 5.18 12.08 6.2 9.52c.24-.58.57-1.12.97-1.6l.16-.19c-.07-.61-.04-1.23.07-1.83.55-2.75 2.61-4.97 5.35-5.69 2.95-.78 6.07.18 8.04 2.5l-.1.06C19.1 3.21 18.08 3.5 17.2 4c2.12 1.42 3.46 3.82 3.46 6.37 0 2.01-.78 3.85-2.06 5.22l-.04-.04c.77-.54 1.47-1.18 2.11-1.93l.65 2.27z',
+  objc: 'M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-1-5h2V7h-2v8z',
+
+  // Ruby
+  ruby: 'M3.11 14.86L2 19l4.16-.35L9 21.65V19.5l-2.96-1.39L3.11 14.86zm17.78 0l-2.96 3.25L15 19.5v2.15l2.84-2.65L22 19l-1.11-4.14zM12 2L7.33 4.02 4 7.42 2.43 12 4 16.58 7.33 19.98 12 22l4.67-2.02L20 16.58 21.57 12 20 7.42l-3.33-3.4L12 2zm0 3.38L15.38 7 17 10.38 15.38 13.77 12 15.38l-3.38-1.62L7 10.38 8.62 7 12 5.38z',
+
+  // PHP
+  php: 'M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1.17 13H8.67l.33-2h-2l-.33 2H5l1.07-6h2.67l-.34 2h2l.34-2h2.67L12 15zm5.83 0h-2l.5-3.17c.04-.24-.04-.47-.33-.57-.19-.06-.67-.09-.83-.07l-.67 3.81H11.5l1.17-6.47c.5-.11 1.33-.23 2.5-.23 1 0 1.67.23 2 .68.34.44.43 1.04.28 1.82L17 13.11c-.2.65-.2.96.83.89v1z',
+
+  // Dart
+  dart: 'M4.37 2h15.26l2.37 2.37v15.26l-2.37 2.37H4.37L2 19.63V4.37L4.37 2zm.33 14.95L12 20.58l7.3-3.63V7.05L12 3.42 4.7 7.05v9.9z',
+
+  // Lua
+  lua: 'M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 15H9V7h2v10zm4 0h-2V7h2v10z',
+
+  // R
+  r: 'M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6H9V9h6v2h-2v6z',
+
+  // SQL
+  database:
+    'M12 2C8.13 2 5 3.79 5 6v12c0 2.21 3.13 4 7 4s7-1.79 7-4V6c0-2.21-3.13-4-7-4zm0 2c3.31 0 5 1.34 5 2s-1.69 2-5 2-5-1.34-5-2 1.69-2 5-2zm0 16c-3.31 0-5-1.34-5-2v-2.23C8.31 16.55 10.08 17 12 17s3.69-.45 5-1.23V18c0 .66-1.69 2-5 2zm0-4c-3.31 0-5-1.34-5-2v-2.23C8.31 12.55 10.08 13 12 13s3.69-.45 5-1.23V14c0 .66-1.69 2-5 2zm0-4c-3.31 0-5-1.34-5-2V8.77C8.31 9.55 10.08 10 12 10s3.69-.45 5-1.23V10c0 .66-1.69 2-5 2z',
+
+  // GraphQL
+  graphql:
+    'M12 2L2 7l10 5 10-5-10-5zm0 15l-8-4v-5l8 4 8-4v5l-8 4z',
+
+  // Terraform
+  terraform:
+    'M14.85 2L20 5.13v9.43L14.85 17.7V8.27L9.7 5.14l5.15-3.14zm-5.85 3.73l5.15 3.13v9.43L9 21.42V11.99L3.85 8.86l5.15-3.13z',
+
+  // DevOps
+  docker:
+    'M13.5 13H8.5v-2h5v2zm0-3H8.5V8h5v2zm0-3H8.5V5h5v2zM6.5 10h-2V8h2v2zm0 3h-2v-2h2v2zm2.5 3h5v2h-5v-2zm5-3h2v-2h-2v2zm0-3h2V8h-2v2zm0-3h2V5h-2v2zm4.56 2.26C20.55 9.41 21 10.28 21 11c0 2.21-2.24 4-5 4H8c-2.76 0-5-1.79-5-4 0-.89.38-1.73 1.05-2.45l-.3-.55-.05.09A2.38 2.38 0 011.5 9c-.73 0-1.3-.34-1.5-.9.1-.4.47-.68.93-.78l.07-.02c.04 0 .08-.01.12-.01.42 0 .86.22 1.11.57l.14.2.41-.72c.44-.77 1.16-1.3 2.12-1.34H5c.55 0 1 .2 1.41.5V6h-.01c-.33-.35-.78-.56-1.34-.61l.09-.01C5.1 5.38 5.05 5.38 5 5.38c-.7 0-1.32.27-1.78.71L2.88 5.7A4.5 4.5 0 015 4.5h1l-.5-.87C5.24 3.25 5 2.89 5 2.5c0-.72.63-1.26 1.37-1.14.5.09.91.5 1 1.01l.09.5A4.4 4.4 0 0110 2c.49 0 .97.07 1.41.2l.09-.5c.09-.51.5-.92 1-.1.75-.12 1.38.42 1.38 1.14 0 .39-.24.75-.5 1.13l-.5.87H14c.9 0 1.7.35 2.3.88l-.35.4A3.57 3.57 0 0013.5 6h-.09c-.56.05-1.01.26-1.34.61H12V6.5c.41-.3.86-.5 1.41-.5h.09c.96.04 1.68.57 2.12 1.34l.41.72.14-.2c.25-.35.69-.57 1.11-.57.04 0 .08.01.12.01l.07.02c.46.1.83.38.93.78-.2.56-.77.9-1.5.9a2.38 2.38 0 01-2.2-1.17l-.05-.09-.3.55z',
+  git: 'M6.28 3a7 7 0 11-3.28 3.28l2.01 2.01A4 4 0 103.28 6.28L1.27 4.27A7 7 0 016.28 3zm8.14 2.72l-1.41 1.41A3 3 0 1116 9h-2a1 1 0 100 2h2a3 3 0 01-1.58 2.63l1.41 1.41A5 5 0 0016 9a5 5 0 00-1.58-3.28z',
+
+  // Settings / Config
+  settings:
+    'M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z',
+
+  // Env
+  dotenv:
+    'M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm-5 3h2v1h-2V7zm0 2h2v1h-2V9zm-3-2h2v1h-2V7zm0 2h2v1h-2V9zm-3-2h2v1H9V7zm0 2h2v1H9V9zm-2 0H5V8h2v1zm0-2H5V6h2v1zm12 8H5v-5h14v5zm0-6h-2V6h2v3z',
+
+  // Lock
+  lock: 'M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z',
+
+  // License
+  license:
+    'M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8l-6-6zM9 17H7v-1h2v1zm0-3H7v-1h2v1zm0-3H7V9h2v2zm7 6h-5v-1h5v1zm0-3h-5v-1h5v1zm0-3h-5V9h5v2zm-1-5V3.5L18.5 9H15z',
+
+  // Makefile
+  makefile:
+    'M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8l-6-6zM7 14h10v1H7v-1zm0 3h7v1H7v-1zm0-6h10v1H7v-1zM7 8h2v1H7V8zm4 0h5v1h-5V8zm-4-2h5V5l1.5 1.5L14 8H7V6z',
+
+  // Archive
+  archive:
+    'M20.54 5.23l-1.39-1.68C18.88 3.21 18.47 3 18 3H6c-.47 0-.88.21-1.16.55L3.46 5.23C3.17 5.57 3 6.02 3 6.5V19c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V6.5c0-.48-.17-.93-.46-1.27zM12 17.5L6.5 12H10v-2h4v2h3.5L12 17.5zM5.12 5l.81-1h12l.94 1H5.12z',
+
+  // Font
+  font: 'M9.93 13.5h4.14L12 7.98 9.93 13.5zM20 2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-4.05 16.5l-1.14-3H9.17l-1.12 3H5.96l5.11-13h1.86l5.11 13h-2.09z',
+
+  // Key / Certificate
+  key: 'M12.65 10C11.83 7.67 9.61 6 7 6c-3.31 0-6 2.69-6 6s2.69 6 6 6c2.61 0 4.83-1.67 5.65-4H17v4h4v-4h2v-4H12.65zM7 14c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2z',
+
+  // Npm
+  npm: 'M0 7v10h6v-7h3v7h3V7H0zm21 0H9v10h6v-7h3v7h3V7z',
+
+  // Vue
+  vue: 'M2 3l10 18L22 3h-4l-6 10.5L6 3H2z',
+
+  // Svelte
+  svelte:
+    'M19.07 4.47c-1.58-2.28-4.72-2.93-7.02-1.43l-4.03 2.65c-1.95 1.28-2.59 3.82-1.5 5.87-.71 1.01-.97 2.27-.7 3.51.44 2.01 2.13 3.48 4.13 3.58.58.81 1.4 1.41 2.33 1.72 2.55.83 5.38-.54 6.29-3.08.46-1.35.3-2.82-.44-4.04.71-1.01.97-2.27.7-3.51-.14-.64-.43-1.23-.82-1.77.37-.5.65-1.07.84-1.7zM11.14 17.1c-.92-.31-1.6-1.16-1.6-2.16 0-1.24.98-2.25 2.2-2.25 1.22 0 2.2 1.01 2.2 2.25 0 1.31-1.05 2.38-2.37 2.38l-.43-.22zm5.34-6.54c-.43.38-.99.59-1.58.59H8.9c-.8 0-1.49-.43-1.88-1.07.21-.39.54-.71.96-.88.44-.18.93-.18 1.38 0 .37.15.68.41.9.74.38-.62 1.04-1 1.77-1 .73 0 1.39.38 1.77 1 .21-.32.51-.58.87-.73.44-.18.93-.18 1.38 0 .42.17.75.49.96.88-.3.49-.71.82-1.19.97l-.39.5z',
+
+  // GraphQL
+  graphql2:
+    'M12 2L2 7l10 5 10-5-10-5zm0 15l-8-4v-5l8 4 8-4v5l-8 4z',
+
+  // Generic image as fallback for unknown icon names
+  article:
+    'M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-5 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z',
+  data_object:
+    'M4 7l2-2h12l2 2v10l-2 2H6l-2-2V7zm0 0v10m16-10v10M7 5v14M17 5v14M7 9h10M7 12h10M7 15h10',
+};
+
+// ---------------------------------------------------------------------------
+// Named folder icon overrides
+// ---------------------------------------------------------------------------
+const NAMED_FOLDER_MAP: Record<string, FileIconInfo> = {
+  src: { iconName: 'folder_src', color: '#E8AB53' },
+  source: { iconName: 'folder_src', color: '#E8AB53' },
+  node_modules: { iconName: 'folder_node_modules', color: '#8BC34A' },
+  '.git': { iconName: 'folder_git', color: '#F05133' },
+  '.github': { iconName: 'folder_git', color: '#F05133' },
+  dist: { iconName: 'folder', color: '#90A4AE' },
+  build: { iconName: 'folder', color: '#90A4AE' },
+  out: { iconName: 'folder', color: '#90A4AE' },
+  public: { iconName: 'folder', color: '#E8AB53' },
+  assets: { iconName: 'folder', color: '#E8AB53' },
+  components: { iconName: 'folder', color: '#61DAFB' },
+  pages: { iconName: 'folder', color: '#61DAFB' },
+  views: { iconName: 'folder', color: '#61DAFB' },
+  hooks: { iconName: 'folder', color: '#61DAFB' },
+  utils: { iconName: 'folder', color: '#E8AB53' },
+  lib: { iconName: 'folder', color: '#E8AB53' },
+  types: { iconName: 'folder', color: '#3178C6' },
+  styles: { iconName: 'folder', color: '#CC6699' },
+  tests: { iconName: 'folder', color: '#C21325' },
+  __tests__: { iconName: 'folder', color: '#C21325' },
+  test: { iconName: 'folder', color: '#C21325' },
+  docs: { iconName: 'folder', color: '#4A9EBF' },
+  '.vscode': { iconName: 'folder', color: '#007ACC' },
+  '.idea': { iconName: 'folder', color: '#FE315D' },
+};
+
+const FOLDER_OPEN_COLOR = '#DCB67A';
+const FOLDER_CLOSED_COLOR = '#DCB67A';
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the icon descriptor for a given filename or path.
+ * Checks exact filename first, then extension, then falls back to default.
+ */
+export function getFileIcon(fileNameOrPath: string): FileIconInfo {
+  const basename = fileNameOrPath.split('/').pop() ?? fileNameOrPath;
+  const lower = basename.toLowerCase();
+
+  // 1. Exact filename match (case-insensitive key lookup)
+  const exactMatch =
+    FILENAME_MAP[basename] ?? FILENAME_MAP[lower];
+  if (exactMatch) return exactMatch;
+
+  // 2. Special multi-dot patterns (.env.*)
+  if (lower.startsWith('.env')) {
+    return { iconName: 'dotenv', color: '#ECD53F' };
+  }
+
+  // 3. Extension-based match
+  const dotIdx = lower.lastIndexOf('.');
+  if (dotIdx !== -1) {
+    const ext = lower.slice(dotIdx + 1);
+    const extMatch = EXT_MAP[ext];
+    if (extMatch) return extMatch;
+  }
+
+  return DEFAULT_FILE_ICON;
+}
+
+/**
+ * Returns the icon descriptor for a folder.
+ * @param expanded - Whether the folder is expanded/open
+ * @param name - Optional folder name for specific icon overrides
+ */
+export function getFolderIcon(expanded: boolean, name?: string): FileIconInfo {
+  if (name) {
+    const named = NAMED_FOLDER_MAP[name];
+    if (named) {
+      return {
+        iconName: expanded
+          ? named.iconName === 'folder'
+            ? 'folder_open'
+            : named.iconName
+          : named.iconName,
+        color: named.color,
+      };
+    }
+  }
+
+  return {
+    iconName: expanded ? 'folder_open' : 'folder',
+    color: expanded ? FOLDER_OPEN_COLOR : FOLDER_CLOSED_COLOR,
+  };
+}
+
+/**
+ * Renders a file/folder icon as an SVG element string.
+ * Returns the SVG path data for use in React components.
+ */
+export function getIconPath(iconName: string): string {
+  return ICON_PATHS[iconName] ?? ICON_PATHS['file'];
+}

--- a/src/renderer/utils/file-search.ts
+++ b/src/renderer/utils/file-search.ts
@@ -1,0 +1,38 @@
+import type { FileTreeNode } from '../../types/ipc';
+
+export function matchNode(name: string, query: string): boolean {
+  if (!query) return true;
+  return name.toLowerCase().includes(query.toLowerCase());
+}
+
+/**
+ * Filter file tree nodes by a case-insensitive substring query on node names.
+ *
+ * - Empty query returns the input unchanged.
+ * - File nodes are kept only when their name matches.
+ * - Directory nodes are kept when the directory's own name matches (children preserved as-is)
+ *   or when at least one already-loaded descendant matches (non-matching siblings pruned).
+ *
+ * Only traverses already-loaded `children`; unloaded subtrees are not fetched.
+ */
+export function filterTree(nodes: FileTreeNode[], query: string): FileTreeNode[] {
+  if (!query) return nodes;
+  const q = query.toLowerCase();
+  const out: FileTreeNode[] = [];
+  for (const node of nodes) {
+    const nameMatches = node.name.toLowerCase().includes(q);
+    if (node.type === 'file') {
+      if (nameMatches) out.push(node);
+      continue;
+    }
+    if (nameMatches) {
+      out.push(node);
+      continue;
+    }
+    if (node.children && node.children.length > 0) {
+      const filtered = filterTree(node.children, query);
+      if (filtered.length > 0) out.push({ ...node, children: filtered });
+    }
+  }
+  return out;
+}

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -254,6 +254,7 @@ export interface AideAPI {
     writeFile(filePath: string, content: string): Promise<void>;
     delete(filePath: string): Promise<void>;
     onChanged(callback: () => void): () => void;
+    searchFiles(query: string, limit?: number): Promise<FileTreeNode[]>;
   };
   system: {
     openPrivacySettings(): Promise<void>;

--- a/tests/unit/file-icon.test.ts
+++ b/tests/unit/file-icon.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect } from 'vitest';
+import { getFileIcon, getFolderIcon } from '../../src/renderer/utils/file-icon';
+
+describe('getFileIcon', () => {
+  describe('TypeScript / JavaScript', () => {
+    it('returns ts icon for .ts files', () => {
+      const icon = getFileIcon('index.ts');
+      expect(icon.iconName).toBe('typescript');
+      expect(icon.color).toBe('#3178C6');
+    });
+
+    it('returns tsx icon for .tsx files', () => {
+      const icon = getFileIcon('App.tsx');
+      expect(icon.iconName).toBe('react_ts');
+      expect(icon.color).toBe('#61DAFB');
+    });
+
+    it('returns js icon for .js files', () => {
+      const icon = getFileIcon('main.js');
+      expect(icon.iconName).toBe('javascript');
+      expect(icon.color).toBe('#F7DF1E');
+    });
+
+    it('returns jsx icon for .jsx files', () => {
+      const icon = getFileIcon('App.jsx');
+      expect(icon.iconName).toBe('react');
+      expect(icon.color).toBe('#61DAFB');
+    });
+
+    it('returns mts icon for .mts files', () => {
+      const icon = getFileIcon('config.mts');
+      expect(icon.iconName).toBe('typescript');
+      expect(icon.color).toBe('#3178C6');
+    });
+
+    it('returns cts icon for .cts files', () => {
+      const icon = getFileIcon('module.cts');
+      expect(icon.iconName).toBe('typescript');
+      expect(icon.color).toBe('#3178C6');
+    });
+  });
+
+  describe('Markup / Style', () => {
+    it('returns html icon for .html files', () => {
+      const icon = getFileIcon('index.html');
+      expect(icon.iconName).toBe('html');
+      expect(icon.color).toBe('#E44D26');
+    });
+
+    it('returns css icon for .css files', () => {
+      const icon = getFileIcon('styles.css');
+      expect(icon.iconName).toBe('css');
+      expect(icon.color).toBe('#264de4');
+    });
+
+    it('returns scss icon for .scss files', () => {
+      const icon = getFileIcon('main.scss');
+      expect(icon.iconName).toBe('sass');
+      expect(icon.color).toBe('#CC6699');
+    });
+  });
+
+  describe('Data / Config', () => {
+    it('returns json icon for .json files', () => {
+      const icon = getFileIcon('package.json');
+      expect(icon.iconName).toBe('json');
+      expect(icon.color).toBe('#F5A623');
+    });
+
+    it('returns yaml icon for .yaml files', () => {
+      const icon = getFileIcon('config.yaml');
+      expect(icon.iconName).toBe('yaml');
+      expect(icon.color).toBe('#CB171E');
+    });
+
+    it('returns yaml icon for .yml files', () => {
+      const icon = getFileIcon('.github/workflows/ci.yml');
+      expect(icon.iconName).toBe('yaml');
+      expect(icon.color).toBe('#CB171E');
+    });
+
+    it('returns toml icon for .toml files', () => {
+      const icon = getFileIcon('Cargo.toml');
+      expect(icon.iconName).toBe('toml');
+      expect(icon.color).toBe('#9C4121');
+    });
+
+    it('returns env icon for .env files', () => {
+      const icon = getFileIcon('.env');
+      expect(icon.iconName).toBe('dotenv');
+      expect(icon.color).toBe('#ECD53F');
+    });
+
+    it('returns env icon for .env.local files', () => {
+      const icon = getFileIcon('.env.local');
+      expect(icon.iconName).toBe('dotenv');
+      expect(icon.color).toBe('#ECD53F');
+    });
+  });
+
+  describe('Documentation', () => {
+    it('returns markdown icon for .md files', () => {
+      const icon = getFileIcon('README.md');
+      expect(icon.iconName).toBe('markdown');
+      expect(icon.color).toBe('#4A9EBF');
+    });
+
+    it('returns markdown icon for .mdx files', () => {
+      const icon = getFileIcon('page.mdx');
+      expect(icon.iconName).toBe('markdown');
+      expect(icon.color).toBe('#4A9EBF');
+    });
+  });
+
+  describe('Images', () => {
+    it('returns image icon for .png files', () => {
+      const icon = getFileIcon('logo.png');
+      expect(icon.iconName).toBe('image');
+      expect(icon.color).toBe('#A074C4');
+    });
+
+    it('returns image icon for .svg files', () => {
+      const icon = getFileIcon('icon.svg');
+      expect(icon.iconName).toBe('svg');
+      expect(icon.color).toBe('#FFB13B');
+    });
+
+    it('returns image icon for .jpg files', () => {
+      const icon = getFileIcon('photo.jpg');
+      expect(icon.iconName).toBe('image');
+      expect(icon.color).toBe('#A074C4');
+    });
+  });
+
+  describe('System languages', () => {
+    it('returns rust icon for .rs files', () => {
+      const icon = getFileIcon('main.rs');
+      expect(icon.iconName).toBe('rust');
+      expect(icon.color).toBe('#DEA584');
+    });
+
+    it('returns python icon for .py files', () => {
+      const icon = getFileIcon('app.py');
+      expect(icon.iconName).toBe('python');
+      expect(icon.color).toBe('#3572A5');
+    });
+
+    it('returns go icon for .go files', () => {
+      const icon = getFileIcon('main.go');
+      expect(icon.iconName).toBe('go');
+      expect(icon.color).toBe('#00ADD8');
+    });
+
+    it('returns java icon for .java files', () => {
+      const icon = getFileIcon('Main.java');
+      expect(icon.iconName).toBe('java');
+      expect(icon.color).toBe('#B07219');
+    });
+
+    it('returns c icon for .c files', () => {
+      const icon = getFileIcon('main.c');
+      expect(icon.iconName).toBe('c');
+      expect(icon.color).toBe('#555555');
+    });
+
+    it('returns cpp icon for .cpp files', () => {
+      const icon = getFileIcon('main.cpp');
+      expect(icon.iconName).toBe('cpp');
+      expect(icon.color).toBe('#F34B7D');
+    });
+  });
+
+  describe('Special filenames', () => {
+    it('returns git icon for .gitignore', () => {
+      const icon = getFileIcon('.gitignore');
+      expect(icon.iconName).toBe('git');
+      expect(icon.color).toBe('#F05133');
+    });
+
+    it('returns docker icon for Dockerfile', () => {
+      const icon = getFileIcon('Dockerfile');
+      expect(icon.iconName).toBe('docker');
+      expect(icon.color).toBe('#2496ED');
+    });
+
+    it('returns docker icon for docker-compose.yml', () => {
+      const icon = getFileIcon('docker-compose.yml');
+      expect(icon.iconName).toBe('docker');
+      expect(icon.color).toBe('#2496ED');
+    });
+
+    it('returns license icon for LICENSE file', () => {
+      const icon = getFileIcon('LICENSE');
+      expect(icon.iconName).toBe('license');
+      expect(icon.color).toBe('#D0A85C');
+    });
+
+    it('returns shell icon for .sh files', () => {
+      const icon = getFileIcon('build.sh');
+      expect(icon.iconName).toBe('shell');
+      expect(icon.color).toBe('#89E051');
+    });
+  });
+
+  describe('Fallback', () => {
+    it('returns default icon for unknown extensions', () => {
+      const icon = getFileIcon('mystery.xyz123');
+      expect(icon.iconName).toBe('file');
+      expect(icon.color).toBe('#6D8086');
+    });
+
+    it('returns makefile icon for Makefile (special-cased filename)', () => {
+      const icon = getFileIcon('Makefile');
+      expect(icon.iconName).toBe('makefile');
+    });
+
+    it('handles deeply nested path correctly', () => {
+      const icon = getFileIcon('src/renderer/components/App.tsx');
+      expect(icon.iconName).toBe('react_ts');
+    });
+  });
+});
+
+describe('getFolderIcon', () => {
+  it('returns open folder icon when expanded=true', () => {
+    const icon = getFolderIcon(true);
+    expect(icon.iconName).toBe('folder_open');
+    expect(icon.color).toBeDefined();
+  });
+
+  it('returns closed folder icon when expanded=false', () => {
+    const icon = getFolderIcon(false);
+    expect(icon.iconName).toBe('folder');
+    expect(icon.color).toBeDefined();
+  });
+
+  it('open and closed icons have the same color', () => {
+    const open = getFolderIcon(true);
+    const closed = getFolderIcon(false);
+    expect(open.color).toBe(closed.color);
+  });
+
+  it('named src folder returns src-specific icon', () => {
+    const icon = getFolderIcon(false, 'src');
+    expect(icon.iconName).toBe('folder_src');
+  });
+
+  it('named node_modules folder returns node_modules icon', () => {
+    const icon = getFolderIcon(false, 'node_modules');
+    expect(icon.iconName).toBe('folder_node_modules');
+  });
+
+  it('named .git folder returns git icon', () => {
+    const icon = getFolderIcon(true, '.git');
+    expect(icon.iconName).toBe('folder_git');
+  });
+
+  it('unknown folder name returns generic folder icon', () => {
+    const icon = getFolderIcon(false, 'someRandomFolder');
+    expect(icon.iconName).toBe('folder');
+  });
+});

--- a/tests/unit/file-index.test.ts
+++ b/tests/unit/file-index.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { FileIndex } from '../../src/main/ipc/file-index';
+
+let tmpRoot: string;
+
+function writeFile(rel: string, content = ''): string {
+  const full = path.join(tmpRoot, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+  return full;
+}
+
+function mkDir(rel: string): string {
+  const full = path.join(tmpRoot, rel);
+  fs.mkdirSync(full, { recursive: true });
+  return full;
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'aide-file-index-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('FileIndex.initialize', () => {
+  it('walks the workspace recursively and indexes files + directories', async () => {
+    writeFile('src/utils/logger.ts');
+    writeFile('src/utils/file-search.ts');
+    writeFile('src/index.ts');
+    writeFile('README.md');
+
+    const index = new FileIndex();
+    await index.initialize(tmpRoot);
+
+    // 3 dirs (src, src/utils, implicit none) + 4 files = 3 + 4 = 7? Actually:
+    // root-level entries: src (dir), README.md (file)
+    // src: utils (dir), index.ts (file)
+    // utils: logger.ts, file-search.ts
+    // Total indexed: src, src/utils, src/utils/logger.ts, src/utils/file-search.ts, src/index.ts, README.md
+    expect(index.size()).toBe(6);
+  });
+
+  it('honours watcher-exclusions (skips node_modules, .git, dist)', async () => {
+    writeFile('node_modules/left/index.js');
+    writeFile('.git/config');
+    writeFile('dist/bundle.js');
+    writeFile('src/kept.ts');
+
+    const index = new FileIndex();
+    await index.initialize(tmpRoot);
+
+    const tree = index.search('kept');
+    expect(tree).toHaveLength(1);
+    expect(tree[0].name).toBe('src');
+    expect(tree[0].children?.[0].name).toBe('kept.ts');
+
+    expect(index.search('index.js')).toEqual([]);
+    expect(index.search('config')).toEqual([]);
+    expect(index.search('bundle')).toEqual([]);
+  });
+});
+
+describe('FileIndex.search', () => {
+  it('returns an empty tree for an empty query', async () => {
+    writeFile('a.ts');
+    const index = new FileIndex();
+    await index.initialize(tmpRoot);
+    expect(index.search('')).toEqual([]);
+    expect(index.search('   ')).toEqual([]);
+  });
+
+  it('matches files across the full workspace, not just top level', async () => {
+    writeFile('a/b/c/deeply-nested.ts');
+    writeFile('top.ts');
+
+    const index = new FileIndex();
+    await index.initialize(tmpRoot);
+
+    const tree = index.search('deeply');
+    expect(tree).toHaveLength(1);
+    expect(tree[0].name).toBe('a');
+    expect(tree[0].children?.[0].name).toBe('b');
+    expect(tree[0].children?.[0].children?.[0].name).toBe('c');
+    expect(tree[0].children?.[0].children?.[0].children?.[0].name).toBe('deeply-nested.ts');
+  });
+
+  it('is case insensitive', async () => {
+    writeFile('README.md');
+    const index = new FileIndex();
+    await index.initialize(tmpRoot);
+    expect(index.search('readme')[0].name).toBe('README.md');
+    expect(index.search('README')[0].name).toBe('README.md');
+  });
+
+  it('pulls the whole subtree when a directory name matches the query', async () => {
+    writeFile('components/SearchBar/index.tsx');
+    writeFile('components/SearchBar/styles.css');
+    writeFile('components/Other.tsx');
+
+    const index = new FileIndex();
+    await index.initialize(tmpRoot);
+
+    const tree = index.search('SearchBar');
+    // components → SearchBar → [index.tsx, styles.css]
+    expect(tree).toHaveLength(1);
+    expect(tree[0].name).toBe('components');
+    const searchBarDir = tree[0].children?.find((c) => c.name === 'SearchBar');
+    expect(searchBarDir).toBeDefined();
+    expect(searchBarDir?.children?.map((c) => c.name).sort()).toEqual(['index.tsx', 'styles.css']);
+    // Sibling that does not match is pruned
+    expect(tree[0].children?.find((c) => c.name === 'Other.tsx')).toBeUndefined();
+  });
+
+  it('sorts directories before files and alphabetically within each group', async () => {
+    writeFile('match-zebra.ts');
+    writeFile('match-alpha.ts');
+    mkDir('match-dir');
+    writeFile('match-dir/readme.md');
+
+    const index = new FileIndex();
+    await index.initialize(tmpRoot);
+
+    const tree = index.search('match');
+    const names = tree.map((n) => n.name);
+    expect(names).toEqual(['match-dir', 'match-alpha.ts', 'match-zebra.ts']);
+  });
+
+  it('respects the limit', async () => {
+    for (let i = 0; i < 50; i++) writeFile(`match-${i}.ts`);
+
+    const index = new FileIndex();
+    await index.initialize(tmpRoot);
+
+    const tree = index.search('match', 10);
+    expect(tree.length).toBeLessThanOrEqual(10);
+  });
+});
+
+describe('FileIndex incremental updates', () => {
+  it('addPath makes a new file discoverable immediately', async () => {
+    const index = new FileIndex();
+    await index.initialize(tmpRoot);
+    expect(index.search('newfile')).toEqual([]);
+
+    const full = writeFile('sub/newfile.ts');
+    index.addPath(full, 'file');
+    // Parent dir wasn't auto-added; add it too for a realistic chokidar sequence.
+    index.addPath(path.join(tmpRoot, 'sub'), 'directory');
+
+    const tree = index.search('newfile');
+    expect(tree).toHaveLength(1);
+    expect(tree[0].name).toBe('sub');
+  });
+
+  it('removePath drops the entry', async () => {
+    const full = writeFile('gone.ts');
+    const index = new FileIndex();
+    await index.initialize(tmpRoot);
+    expect(index.search('gone')).toHaveLength(1);
+
+    index.removePath(full);
+    expect(index.search('gone')).toEqual([]);
+  });
+
+  it('removeDir drops the directory and all descendants', async () => {
+    writeFile('wiped/inner/file.ts');
+    writeFile('kept/file.ts');
+    const index = new FileIndex();
+    await index.initialize(tmpRoot);
+
+    index.removeDir(path.join(tmpRoot, 'wiped'));
+    expect(index.search('file.ts').map((n) => n.name)).toEqual(['kept']);
+  });
+
+  it('clear wipes the index', async () => {
+    writeFile('a.ts');
+    const index = new FileIndex();
+    await index.initialize(tmpRoot);
+    expect(index.size()).toBeGreaterThan(0);
+
+    index.clear();
+    expect(index.size()).toBe(0);
+    // After clear there is no root path, so searches are empty.
+    expect(index.search('a')).toEqual([]);
+  });
+});

--- a/tests/unit/file-search.test.ts
+++ b/tests/unit/file-search.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import type { FileTreeNode } from '../../src/types/ipc';
+import { matchNode, filterTree } from '../../src/renderer/utils/file-search';
+
+function file(name: string, path = `/${name}`): FileTreeNode {
+  return { name, path, type: 'file' };
+}
+function dir(name: string, children: FileTreeNode[] = [], path = `/${name}`): FileTreeNode {
+  return { name, path, type: 'directory', children };
+}
+
+describe('matchNode', () => {
+  it('returns true for an empty query', () => {
+    expect(matchNode('foo.ts', '')).toBe(true);
+  });
+  it('is case insensitive', () => {
+    expect(matchNode('README.md', 'readme')).toBe(true);
+    expect(matchNode('index.ts', 'IDX')).toBe(false);
+  });
+  it('matches a substring anywhere in the name', () => {
+    expect(matchNode('file-search.ts', 'search')).toBe(true);
+    expect(matchNode('file-search.ts', 'xyz')).toBe(false);
+  });
+});
+
+describe('filterTree', () => {
+  it('returns the input unchanged when the query is empty', () => {
+    const tree = [file('a.ts'), dir('src', [file('b.ts')])];
+    expect(filterTree(tree, '')).toBe(tree);
+  });
+
+  it('keeps files whose name matches and drops the rest', () => {
+    const tree = [file('foo.ts'), file('bar.md')];
+    expect(filterTree(tree, 'foo')).toEqual([file('foo.ts')]);
+  });
+
+  it('keeps ancestor directories when a descendant matches, pruning non-matching siblings', () => {
+    const tree = [
+      dir('src', [
+        dir('utils', [file('file-search.ts'), file('logger.ts')]),
+        file('index.ts'),
+      ]),
+      dir('tests', [file('unrelated.test.ts')]),
+    ];
+    const result = filterTree(tree, 'search');
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('src');
+    expect(result[0].children).toHaveLength(1);
+    expect(result[0].children?.[0].name).toBe('utils');
+    expect(result[0].children?.[0].children?.map((c) => c.name)).toEqual(['file-search.ts']);
+  });
+
+  it('keeps all children when the directory name itself matches', () => {
+    const original = dir('search', [file('a.ts'), file('b.ts')]);
+    const result = filterTree([original], 'search');
+    expect(result[0]).toBe(original);
+    expect(result[0].children?.map((c) => c.name)).toEqual(['a.ts', 'b.ts']);
+  });
+
+  it('drops directories whose descendants do not match', () => {
+    const tree = [dir('src', [file('x.ts')]), dir('docs', [file('y.md')])];
+    expect(filterTree(tree, 'unknown')).toEqual([]);
+  });
+
+  it('is case insensitive', () => {
+    const tree = [file('README.md'), file('index.ts')];
+    expect(filterTree(tree, 'readme')).toEqual([file('README.md')]);
+  });
+
+  it('does not mutate the input tree', () => {
+    const utils = dir('utils', [file('file-search.ts'), file('logger.ts')]);
+    const src = dir('src', [utils]);
+    const tree = [src];
+    filterTree(tree, 'search');
+    expect(src.children).toHaveLength(1);
+    expect(utils.children).toHaveLength(2);
+  });
+});

--- a/tests/unit/plugin-deactivate.test.ts
+++ b/tests/unit/plugin-deactivate.test.ts
@@ -11,6 +11,7 @@ import { usePluginStore } from '../../src/renderer/stores/plugin-store';
 import { useLayoutStore, createPane } from '../../src/renderer/stores/layout-store';
 import { useTerminalStore } from '../../src/renderer/stores/terminal-store';
 import { useWorkspaceStore } from '../../src/renderer/stores/workspace-store';
+import { deactivatingPluginIds } from '../../src/renderer/stores/plugin-deactivate-guard';
 import type { TerminalTab, PluginInfo } from '../../src/types/ipc';
 
 // ── helpers ────────────────────────────────────────────────────────────────
@@ -54,6 +55,7 @@ describe('plugin deactivate – tab removal', () => {
     useTerminalStore.setState({ tabs: [], activeTabId: null, dropdownOpen: false, workspaceTabs: {} });
     usePluginStore.setState({ plugins: [], loading: false, error: null, generating: false, generateError: null });
     useWorkspaceStore.setState({ workspaces: [], activeWorkspaceId: 'ws-1', recentProjects: [], navExpanded: true });
+    deactivatingPluginIds.clear();
   });
 
   afterEach(() => {
@@ -192,5 +194,126 @@ describe('plugin deactivate – tab removal', () => {
       (t) => (t as Record<string, unknown>).pluginId === 'plugin-off',
     );
     expect(inactiveSavedTabs).toHaveLength(0);
+  });
+
+  // ── case (e) Fix A: closing a plugin tab directly auto-deactivates ────────
+
+  it('(e) removeTabFromPane on a plugin tab triggers window.aide.plugin.deactivate', async () => {
+    const plugin = makePlugin('plugin-close', true);
+    const tab = makePluginTab('plugin-close');
+
+    usePluginStore.setState({ plugins: [plugin], loading: false, error: null, generating: false, generateError: null });
+    const paneId = useLayoutStore.getState().getAllPanes()[0].id;
+    useLayoutStore.getState().addTabToPane(paneId, tab);
+    useTerminalStore.getState().addTab(tab);
+
+    (window.aide.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makePlugin('plugin-close', false),
+    ]);
+
+    // Simulate a × click on the plugin tab: layout-store removes the tab.
+    // The auto-deactivate side effect is fire-and-forget, so await a tick.
+    useLayoutStore.getState().removeTabFromPane(paneId, tab.id);
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(window.aide.plugin.deactivate).toHaveBeenCalledWith('plugin-close');
+  });
+
+  // ── case (f) Fix A idempotent: deactivate() does not recurse ──────────────
+
+  it('(f) plugin-store.deactivate does not cause recursive deactivate via removeTabFromPane', async () => {
+    const plugin = makePlugin('plugin-recur', true);
+    const tab = makePluginTab('plugin-recur');
+
+    usePluginStore.setState({ plugins: [plugin], loading: false, error: null, generating: false, generateError: null });
+    const paneId = useLayoutStore.getState().getAllPanes()[0].id;
+    useLayoutStore.getState().addTabToPane(paneId, tab);
+    useTerminalStore.getState().addTab(tab);
+
+    (window.aide.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makePlugin('plugin-recur', false),
+    ]);
+
+    await usePluginStore.getState().deactivate('plugin-recur');
+    // Give any fire-and-forget side effects a chance to run
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    // window.aide.plugin.deactivate is called exactly once by plugin-store
+    // itself — the layout-store hook must NOT call it a second time.
+    expect(window.aide.plugin.deactivate).toHaveBeenCalledTimes(1);
+  });
+
+  // ── case (g) Fix B: restoreSession skips plugin tabs not in activePlugins ─
+
+  it('(g) restoreSession skips plugin tabs missing from session.activePlugins', async () => {
+    // Tampered saved session: layout has a plugin tab for plugin-gone, but
+    // activePlugins does not list it. A shell tab is present too.
+    const tamperedSession = {
+      version: 1,
+      workspaceId: 'ws-1',
+      savedAt: Date.now(),
+      layout: {
+        id: 'pane-1',
+        tabs: [
+          { id: 'ghost-plugin', type: 'plugin', title: 'Gone', pluginId: 'plugin-gone', isActive: false },
+          { id: 'shell-1', type: 'shell', title: '$ shell', isActive: true },
+        ],
+        activeTabId: 'shell-1',
+      },
+      focusedPaneId: 'pane-1',
+      activePlugins: [],
+      sidePanelTab: 'files' as const,
+    };
+
+    (window.aide.session.load as ReturnType<typeof vi.fn>).mockResolvedValue(tamperedSession);
+    (window.aide.terminal.spawn as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true, sessionId: 'new-sess' });
+
+    useWorkspaceStore.setState({
+      workspaces: [{ id: 'ws-1', name: 'ws', path: '/tmp/ws' }],
+      activeWorkspaceId: 'ws-1',
+      recentProjects: [],
+      navExpanded: true,
+      sidePanelTab: 'files',
+    } as Parameters<typeof useWorkspaceStore.setState>[0]);
+
+    await useLayoutStore.getState().restoreSession('ws-1');
+
+    const restoredPluginTabs = useLayoutStore
+      .getState()
+      .getAllPanes()
+      .flatMap((p) => p.tabs.filter((t) => t.type === 'plugin'));
+    expect(restoredPluginTabs).toHaveLength(0);
+
+    const restoredShellTabs = useLayoutStore
+      .getState()
+      .getAllPanes()
+      .flatMap((p) => p.tabs.filter((t) => t.type === 'shell'));
+    expect(restoredShellTabs).toHaveLength(1);
+  });
+
+  // ── case (h) Fix A guard isolation: guard presence suppresses the hook ────
+
+  it('(h) removeTabFromPane skips auto-deactivate when pluginId is in the guard set', async () => {
+    const plugin = makePlugin('plugin-guarded', true);
+    const tab = makePluginTab('plugin-guarded');
+
+    usePluginStore.setState({ plugins: [plugin], loading: false, error: null, generating: false, generateError: null });
+    const paneId = useLayoutStore.getState().getAllPanes()[0].id;
+    useLayoutStore.getState().addTabToPane(paneId, tab);
+    useTerminalStore.getState().addTab(tab);
+
+    // Pre-populate the guard — simulates plugin-store.deactivate() being the
+    // caller, so the layout-store hook must NOT call deactivate again.
+    deactivatingPluginIds.add('plugin-guarded');
+    try {
+      useLayoutStore.getState().removeTabFromPane(paneId, tab.id);
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+      expect(window.aide.plugin.deactivate).not.toHaveBeenCalled();
+    } finally {
+      deactivatingPluginIds.delete('plugin-guarded');
+    }
   });
 });

--- a/tests/unit/plugin-deactivate.test.ts
+++ b/tests/unit/plugin-deactivate.test.ts
@@ -1,0 +1,196 @@
+/**
+ * TDD tests for plugin deactivate tab-removal bug.
+ *
+ * Bug: toggling a plugin off leaves its tab visible in the UI because
+ * deactivate() does not reliably remove plugin tabs from all panes, and
+ * buildSavedSession() serialises the layout as-is (including plugin tabs)
+ * without stripping tabs for inactive plugins.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { usePluginStore } from '../../src/renderer/stores/plugin-store';
+import { useLayoutStore, createPane } from '../../src/renderer/stores/layout-store';
+import { useTerminalStore } from '../../src/renderer/stores/terminal-store';
+import { useWorkspaceStore } from '../../src/renderer/stores/workspace-store';
+import type { TerminalTab, PluginInfo } from '../../src/types/ipc';
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function makePlugin(id: string, active = true): PluginInfo {
+  return { id, name: `Plugin ${id}`, description: '', active, version: '0.1.0', toolCount: 0 };
+}
+
+function makePluginTab(pluginId: string, tabId = `tab-${pluginId}`): TerminalTab {
+  return { id: tabId, type: 'plugin', pluginId, title: `Plugin ${pluginId}` };
+}
+
+function setupWindow(overrides: Record<string, unknown> = {}) {
+  vi.stubGlobal('window', {
+    aide: {
+      plugin: {
+        list: vi.fn().mockResolvedValue([]),
+        activate: vi.fn().mockResolvedValue(undefined),
+        deactivate: vi.fn().mockResolvedValue(undefined),
+      },
+      session: {
+        save: vi.fn().mockResolvedValue(undefined),
+        load: vi.fn().mockResolvedValue(null),
+      },
+      terminal: { spawn: vi.fn().mockResolvedValue({ ok: true, sessionId: 'sess-1' }) },
+      workspace: { open: vi.fn().mockResolvedValue(undefined) },
+      ...overrides,
+    },
+  });
+}
+
+// ── suite ──────────────────────────────────────────────────────────────────
+
+describe('plugin deactivate – tab removal', () => {
+  beforeEach(() => {
+    setupWindow();
+
+    // Reset stores to clean state
+    const initialPane = createPane();
+    useLayoutStore.setState({ layout: initialPane, focusedPaneId: initialPane.id });
+    useTerminalStore.setState({ tabs: [], activeTabId: null, dropdownOpen: false, workspaceTabs: {} });
+    usePluginStore.setState({ plugins: [], loading: false, error: null, generating: false, generateError: null });
+    useWorkspaceStore.setState({ workspaces: [], activeWorkspaceId: 'ws-1', recentProjects: [], navExpanded: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // ── case (a): deactivate removes the plugin tab from the single pane ──────
+
+  it('(a) deactivate() removes the plugin tab from the layout', async () => {
+    const plugin = makePlugin('plugin-1');
+    const tab = makePluginTab('plugin-1');
+
+    // Pre-condition: plugin is active and its tab is in the pane
+    usePluginStore.setState({ plugins: [plugin], loading: false, error: null, generating: false, generateError: null });
+    const paneId = useLayoutStore.getState().getAllPanes()[0].id;
+    useLayoutStore.getState().addTabToPane(paneId, tab);
+    useTerminalStore.getState().addTab(tab);
+
+    // After deactivate, the IPC call returns empty list (plugin now inactive)
+    (window.aide.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makePlugin('plugin-1', false),
+    ]);
+
+    await usePluginStore.getState().deactivate('plugin-1');
+
+    // Tab must be gone from every pane
+    const allPanes = useLayoutStore.getState().getAllPanes();
+    const remainingPluginTabs = allPanes.flatMap((p) =>
+      p.tabs.filter((t) => t.type === 'plugin' && t.pluginId === 'plugin-1'),
+    );
+    expect(remainingPluginTabs).toHaveLength(0);
+  });
+
+  // ── case (b): deactivate removes the tab from terminal store ─────────────
+
+  it('(b) deactivate() removes the plugin tab from the terminal store', async () => {
+    const plugin = makePlugin('plugin-1');
+    const tab = makePluginTab('plugin-1');
+
+    usePluginStore.setState({ plugins: [plugin], loading: false, error: null, generating: false, generateError: null });
+    const paneId = useLayoutStore.getState().getAllPanes()[0].id;
+    useLayoutStore.getState().addTabToPane(paneId, tab);
+    useTerminalStore.getState().addTab(tab);
+
+    (window.aide.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makePlugin('plugin-1', false),
+    ]);
+
+    await usePluginStore.getState().deactivate('plugin-1');
+
+    const terminalTabs = useTerminalStore.getState().tabs;
+    expect(terminalTabs.some((t) => t.pluginId === 'plugin-1')).toBe(false);
+  });
+
+  // ── case (c): deactivate removes plugin tabs from ALL panes ───────────────
+
+  it('(c) deactivate() removes plugin tabs from multiple panes', async () => {
+    const plugin = makePlugin('plugin-1');
+    const tab1 = makePluginTab('plugin-1', 'tab-p1-pane1');
+    const tab2 = makePluginTab('plugin-1', 'tab-p1-pane2');
+
+    usePluginStore.setState({ plugins: [plugin], loading: false, error: null, generating: false, generateError: null });
+
+    // Set up two panes: first pane already exists, split to create second
+    const pane1Id = useLayoutStore.getState().getAllPanes()[0].id;
+    useLayoutStore.getState().addTabToPane(pane1Id, tab1);
+    useTerminalStore.getState().addTab(tab1);
+
+    // Add a shell tab so split is possible, then split
+    const shellTab: TerminalTab = { id: 'shell-1', type: 'shell', sessionId: 's1', title: '$ shell' };
+    useLayoutStore.getState().addTabToPane(pane1Id, shellTab);
+    useLayoutStore.getState().splitPane(pane1Id, 'horizontal');
+
+    // Get second pane and add the same plugin tab there too
+    const allPanes = useLayoutStore.getState().getAllPanes();
+    const pane2 = allPanes.find((p) => p.id !== pane1Id);
+    expect(pane2).toBeDefined();
+    useLayoutStore.getState().addTabToPane(pane2!.id, tab2);
+    useTerminalStore.getState().addTab(tab2);
+
+    (window.aide.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makePlugin('plugin-1', false),
+    ]);
+
+    await usePluginStore.getState().deactivate('plugin-1');
+
+    const remainingPluginTabs = useLayoutStore
+      .getState()
+      .getAllPanes()
+      .flatMap((p) => p.tabs.filter((t) => t.type === 'plugin' && t.pluginId === 'plugin-1'));
+
+    expect(remainingPluginTabs).toHaveLength(0);
+  });
+
+  // ── case (d): buildSavedSession excludes tabs of inactive plugins ─────────
+
+  it('(d) buildSavedSession() does not include tabs for inactive plugins', () => {
+    const inactivePlugin = makePlugin('plugin-off', false);
+    const activePlugin = makePlugin('plugin-on', true);
+
+    usePluginStore.setState({
+      plugins: [inactivePlugin, activePlugin],
+      loading: false,
+      error: null,
+      generating: false,
+      generateError: null,
+    });
+
+    // Manually put a stale plugin tab for the *inactive* plugin into the layout
+    // (simulates a case where deactivate failed to remove it)
+    const paneId = useLayoutStore.getState().getAllPanes()[0].id;
+    const staleTab = makePluginTab('plugin-off', 'stale-tab');
+    const activeTab = makePluginTab('plugin-on', 'active-tab');
+    useLayoutStore.getState().addTabToPane(paneId, staleTab);
+    useLayoutStore.getState().addTabToPane(paneId, activeTab);
+
+    useWorkspaceStore.setState({
+      workspaces: [],
+      activeWorkspaceId: 'ws-1',
+      recentProjects: [],
+      navExpanded: true,
+      sidePanelTab: 'files',
+    } as Parameters<typeof useWorkspaceStore.setState>[0]);
+
+    const saved = useLayoutStore.getState().buildSavedSession('ws-1');
+
+    // The saved session should not contain a tab for the inactive plugin
+    function collectSavedTabs(node: unknown): unknown[] {
+      const n = node as Record<string, unknown>;
+      if ('tabs' in n) return (n.tabs as unknown[]);
+      if ('children' in n) return (n.children as unknown[]).flatMap(collectSavedTabs);
+      return [];
+    }
+    const savedTabs = collectSavedTabs(saved.layout);
+    const inactiveSavedTabs = savedTabs.filter(
+      (t) => (t as Record<string, unknown>).pluginId === 'plugin-off',
+    );
+    expect(inactiveSavedTabs).toHaveLength(0);
+  });
+});

--- a/tests/unit/unregister-aide-claude-global.test.ts
+++ b/tests/unit/unregister-aide-claude-global.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { unregisterAideFromJsonConfig } from '../../src/main/mcp/config-writer';
+
+describe('unregisterAideFromJsonConfig', () => {
+  let tmpDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aide-unreg-test-'));
+    configPath = path.join(tmpDir, '.claude.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('does nothing when the config file does not exist', () => {
+    expect(() => unregisterAideFromJsonConfig(configPath)).not.toThrow();
+    expect(fs.existsSync(configPath)).toBe(false);
+  });
+
+  it('removes the aide entry when it is the only mcpServer', () => {
+    const config = {
+      mcpServers: {
+        aide: { command: 'node', args: ['/path/to/server.js'] },
+      },
+    };
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+    unregisterAideFromJsonConfig(configPath);
+
+    const result = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(result.mcpServers).toBeUndefined();
+  });
+
+  it('removes only the aide entry, preserving other mcpServers', () => {
+    const config = {
+      mcpServers: {
+        aide: { command: 'node', args: ['server.js'] },
+        userCustom: { command: 'python', args: ['custom.py'] },
+      },
+    };
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+    unregisterAideFromJsonConfig(configPath);
+
+    const result = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(result.mcpServers.aide).toBeUndefined();
+    expect(result.mcpServers.userCustom).toEqual({ command: 'python', args: ['custom.py'] });
+  });
+
+  it('preserves other top-level keys', () => {
+    const config = {
+      mcpServers: { aide: { command: 'node', args: ['server.js'] } },
+      model: 'claude-opus-4-7',
+      permissions: { allow: ['Bash'] },
+    };
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+    unregisterAideFromJsonConfig(configPath);
+
+    const result = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(result.mcpServers).toBeUndefined();
+    expect(result.model).toBe('claude-opus-4-7');
+    expect(result.permissions).toEqual({ allow: ['Bash'] });
+  });
+
+  it('is a no-op when mcpServers has no aide key', () => {
+    const config = {
+      mcpServers: { other: { command: 'node', args: ['other.js'] } },
+    };
+    const raw = JSON.stringify(config, null, 2);
+    fs.writeFileSync(configPath, raw);
+
+    unregisterAideFromJsonConfig(configPath);
+
+    expect(fs.readFileSync(configPath, 'utf-8')).toBe(raw);
+  });
+
+  it('is a no-op when mcpServers key is absent', () => {
+    const config = { model: 'claude-opus-4-7' };
+    const raw = JSON.stringify(config, null, 2);
+    fs.writeFileSync(configPath, raw);
+
+    unregisterAideFromJsonConfig(configPath);
+
+    expect(fs.readFileSync(configPath, 'utf-8')).toBe(raw);
+  });
+
+  it('leaves a corrupt config file untouched', () => {
+    const raw = '{invalid json!!!';
+    fs.writeFileSync(configPath, raw);
+
+    expect(() => unregisterAideFromJsonConfig(configPath)).not.toThrow();
+    expect(fs.readFileSync(configPath, 'utf-8')).toBe(raw);
+  });
+
+  it('is idempotent when called twice', () => {
+    const config = {
+      mcpServers: {
+        aide: { command: 'node', args: ['server.js'] },
+        other: { command: 'python', args: ['other.py'] },
+      },
+    };
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+    unregisterAideFromJsonConfig(configPath);
+    unregisterAideFromJsonConfig(configPath);
+
+    const result = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(result.mcpServers.aide).toBeUndefined();
+    expect(result.mcpServers.other).toBeDefined();
+  });
+});

--- a/tests/unit/workspace-activate-ordering.test.ts
+++ b/tests/unit/workspace-activate-ordering.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Regression tests for workspace-store.setActive() call ordering.
+ *
+ * Bug: restoreSession() calls window.aide.plugin.activate(id) for each entry
+ * in session.activePlugins. If this runs before window.aide.workspace.open()
+ * and usePluginStore.loadPlugins(), the main-side plugin registry is empty
+ * and activate silently fails — the tab is restored but plugin.active stays
+ * false.
+ *
+ * Fix: setActive must open the workspace and load plugins into the registry
+ * BEFORE calling restoreSession, then reload after so the renderer reflects
+ * the main-side activation results.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useWorkspaceStore } from '../../src/renderer/stores/workspace-store';
+import { useLayoutStore, createPane } from '../../src/renderer/stores/layout-store';
+import { useTerminalStore } from '../../src/renderer/stores/terminal-store';
+import { usePluginStore } from '../../src/renderer/stores/plugin-store';
+
+describe('workspace-store.setActive — activation ordering', () => {
+  const calls: string[] = [];
+
+  beforeEach(() => {
+    calls.length = 0;
+
+    vi.stubGlobal('window', {
+      aide: {
+        workspace: {
+          open: vi.fn(async () => {
+            calls.push('workspace.open');
+          }),
+          list: vi.fn().mockResolvedValue([]),
+          recent: vi.fn().mockResolvedValue([]),
+        },
+        plugin: {
+          list: vi.fn(async () => {
+            calls.push('plugin.list');
+            return [];
+          }),
+          activate: vi.fn(async () => {
+            calls.push('plugin.activate');
+          }),
+          deactivate: vi.fn().mockResolvedValue(undefined),
+          onChanged: vi.fn(() => () => { /* unsub */ }),
+        },
+        session: {
+          load: vi.fn(async () => {
+            calls.push('session.load');
+            return {
+              version: 1,
+              workspaceId: 'ws-1',
+              savedAt: Date.now(),
+              layout: {
+                id: 'pane-1',
+                tabs: [
+                  {
+                    id: 'tab-plugin-1',
+                    type: 'plugin',
+                    title: 'agent-todo-board',
+                    isActive: true,
+                    pluginId: 'plugin-abc',
+                  },
+                ],
+                activeTabId: 'tab-plugin-1',
+              },
+              focusedPaneId: 'pane-1',
+              activePlugins: ['plugin-abc'],
+              sidePanelTab: 'files',
+            };
+          }),
+          save: vi.fn().mockResolvedValue(undefined),
+        },
+        terminal: { spawn: vi.fn().mockResolvedValue({ ok: true, sessionId: 'sess-1' }) },
+      },
+    });
+
+    const initialPane = createPane();
+    useLayoutStore.setState({ layout: initialPane, focusedPaneId: initialPane.id });
+    useTerminalStore.setState({ tabs: [], activeTabId: null, dropdownOpen: false, workspaceTabs: {} });
+    usePluginStore.setState({ plugins: [], loading: false, error: null, generating: false, generateError: null });
+    useWorkspaceStore.setState({
+      workspaces: [{ id: 'ws-1', name: 'ws', path: '/tmp/ws' }],
+      activeWorkspaceId: null,
+      recentProjects: [],
+      navExpanded: true,
+      sidePanelTab: 'files',
+    } as Parameters<typeof useWorkspaceStore.setState>[0]);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('opens the workspace and loads plugins BEFORE restoreSession activates them', async () => {
+    await useWorkspaceStore.getState().setActive('ws-1');
+
+    // Required: workspace.open and at least one plugin.list happen before the
+    // first plugin.activate, so the main-side registry is populated.
+    const firstOpen = calls.indexOf('workspace.open');
+    const firstList = calls.indexOf('plugin.list');
+    const firstActivate = calls.indexOf('plugin.activate');
+
+    expect(firstOpen, 'workspace.open should fire').toBeGreaterThanOrEqual(0);
+    expect(firstList, 'plugin.list should fire').toBeGreaterThanOrEqual(0);
+    expect(firstActivate, 'plugin.activate should fire for the saved activePlugin').toBeGreaterThanOrEqual(0);
+
+    expect(firstOpen).toBeLessThan(firstActivate);
+    expect(firstList).toBeLessThan(firstActivate);
+  });
+
+  it('reloads plugin list AFTER restoreSession so renderer reflects activate results', async () => {
+    await useWorkspaceStore.getState().setActive('ws-1');
+
+    // There should be at least TWO plugin.list calls: one before restoreSession
+    // (to populate registry) and one after (to refresh renderer with activate results).
+    const listCount = calls.filter((c) => c === 'plugin.list').length;
+    expect(listCount).toBeGreaterThanOrEqual(2);
+
+    const lastActivate = calls.lastIndexOf('plugin.activate');
+    const lastList = calls.lastIndexOf('plugin.list');
+    expect(lastActivate, 'plugin.activate should be invoked').toBeGreaterThanOrEqual(0);
+    expect(lastList).toBeGreaterThan(lastActivate);
+  });
+
+  it('switching into a workspace with no saved activePlugins still calls workspace.open and loadPlugins', async () => {
+    (window.aide.session.load as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      version: 1,
+      workspaceId: 'ws-1',
+      savedAt: Date.now(),
+      layout: { id: 'pane-1', tabs: [], activeTabId: null },
+      focusedPaneId: 'pane-1',
+      activePlugins: [],
+      sidePanelTab: 'files',
+    });
+
+    await useWorkspaceStore.getState().setActive('ws-1');
+
+    expect(calls).toContain('workspace.open');
+    expect(calls.filter((c) => c === 'plugin.list').length).toBeGreaterThanOrEqual(1);
+    expect(calls.filter((c) => c === 'plugin.activate').length).toBe(0);
+  });
+
+  it('cache-hit path still calls plugin.list so the renderer store reflects current main-side plugin state', async () => {
+    // Pre-seed the layout cache so loadLayoutFromCache returns true.
+    useLayoutStore.setState({
+      layout: createPane(),
+      focusedPaneId: null,
+      layoutCache: {
+        'ws-1': {
+          layout: createPane(),
+          focusedPaneId: null,
+          sidePanelTab: 'files',
+        },
+      } as unknown as Parameters<typeof useLayoutStore.setState>[0] extends infer S ? S : never,
+    } as Parameters<typeof useLayoutStore.setState>[0]);
+
+    await useWorkspaceStore.getState().setActive('ws-1');
+
+    // Even on a cache hit, plugin.list must fire at least once so the
+    // renderer picks up any main-side plugin changes (file watcher events,
+    // etc.) since the previous visit.
+    expect(calls.filter((c) => c === 'plugin.list').length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tests/unit/workspace-activate-ordering.test.ts
+++ b/tests/unit/workspace-activate-ordering.test.ts
@@ -141,24 +141,21 @@ describe('workspace-store.setActive — activation ordering', () => {
   });
 
   it('cache-hit path still calls plugin.list so the renderer store reflects current main-side plugin state', async () => {
-    // Pre-seed the layout cache so loadLayoutFromCache returns true.
-    useLayoutStore.setState({
-      layout: createPane(),
-      focusedPaneId: null,
-      layoutCache: {
-        'ws-1': {
-          layout: createPane(),
-          focusedPaneId: null,
-          sidePanelTab: 'files',
-        },
-      } as unknown as Parameters<typeof useLayoutStore.setState>[0] extends infer S ? S : never,
-    } as Parameters<typeof useLayoutStore.setState>[0]);
+    // Seed the module-level layout cache via the public API, then clear the
+    // recorded calls so we only observe the second setActive.
+    useWorkspaceStore.setState({
+      workspaces: [
+        { id: 'ws-1', name: 'ws', path: '/tmp/ws' },
+        { id: 'ws-2', name: 'ws2', path: '/tmp/ws2' },
+      ],
+    } as Parameters<typeof useWorkspaceStore.setState>[0]);
+    await useWorkspaceStore.getState().setActive('ws-1');
+    await useWorkspaceStore.getState().setActive('ws-2');
+    calls.length = 0;
 
     await useWorkspaceStore.getState().setActive('ws-1');
 
-    // Even on a cache hit, plugin.list must fire at least once so the
-    // renderer picks up any main-side plugin changes (file watcher events,
-    // etc.) since the previous visit.
+    expect(useLayoutStore.getState().loadLayoutFromCache).toBeTypeOf('function');
     expect(calls.filter((c) => c === 'plugin.list').length).toBeGreaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
## Summary
Release v0.0.12 from develop. Bundles four post-v0.0.11 fixes plus a new file tree search feature.

## Highlights

- **File tree search** (#84, #87) — new search box in the files panel. Indexes the entire workspace and supports deep paths so long names / nested directories are reachable without scrolling.
- **Plugin toggle ↔ tab state stays in sync** (#85) — closing a plugin tab with ×, or having the saved session drift from activePlugins, no longer leaves a "tab visible / plugin OFF" ghost. Three layers: auto-deactivate on tab close, inactive tabs stripped at save time, unknown plugin tabs skipped on restore.
- **Plugin re-activation on workspace open works** (#86) — on app start or workspace switch, saved active plugins are now reliably re-activated. The previous code called `plugin.activate` before the main-side registry was seeded, so the activate calls silently no-op and plugin tabs came back visible but with plugin.active=false.

## Version bump
- `package.json`: `0.0.11 → 0.0.12`

## Release artifacts
DMG + app.zip will be built locally (`sh build.sh`) and uploaded to the GitHub release manually — the CI workflow was removed in #78.

## Test plan
- [x] `pnpm test` (247/247 passing on develop, verified on release/0.0.12)
- [x] `pnpm lint` no new warnings
- [ ] Manual smoke test after build:
  - [ ] File tree search returns results for nested paths
  - [ ] Plugin toggle ON/OFF keeps the plugin tab and active state in lockstep
  - [ ] App restart restores plugin tabs with plugin.active = true
  - [ ] `ps aux | grep aide-mcp` shows no zombie MCP processes after close/restart cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)