### PR TITLE
feat(build): macOS universal binary (arm64 + x64 via lipo) for Intel Mac support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,16 +9,20 @@ AIDE (AI-Driven IDE) - Electron-based terminal-centric IDE that integrates CLI c
 ## Development Commands
 
 ```bash
-pnpm install          # Install dependencies + auto-build Rust native module (postinstall)
-pnpm start            # Dev server with HMR
-pnpm run package      # Package app
-pnpm run make         # Build distributable (dmg/exe)
-pnpm lint             # ESLint
-pnpm test             # Vitest (unit)
-pnpm test:e2e         # Playwright (e2e)
+pnpm install                   # Install dependencies + auto-build Rust native module (postinstall)
+pnpm start                     # Dev server with HMR
+pnpm run package               # Package app
+pnpm run make                  # Build distributable (dmg/exe)
+pnpm lint                      # ESLint
+pnpm test                      # Vitest (unit)
+pnpm test:e2e                  # Playwright (e2e)
+pnpm run build:native          # Rebuild single-arch .node (fast, used by dev/CI postinstall)
+pnpm run build:native:universal  # macOS only: lipo-merged arm64+x64 .node for DMG releases
 ```
 
 **Rust toolchain required**: `pnpm install` runs `postinstall` → `scripts/build-native.mjs` which compiles `crates/aide-napi` into `src/main/native/index.<platform>-<arch>.node`. Requires `rustup` with stable ≥1.82. If only Homebrew rustc (1.74) is installed, build fails — install rustup: `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`. The build script prepends `~/.cargo/bin` to PATH so rustup shim takes precedence over any Homebrew rustc.
+
+**Universal binary (macOS DMG)**: `build.sh` calls `pnpm run build:native:universal` before packaging. This produces `src/main/native/index.darwin-universal.node` (arm64+x64 fat binary via `lipo`). Requires both targets: `rustup target add aarch64-apple-darwin x86_64-apple-darwin`. Do not commit the universal `.node` — it is built locally by `sh build.sh` only. CI uses the fast single-arch postinstall build.
 
 ## Architecture
 

--- a/build.sh
+++ b/build.sh
@@ -27,16 +27,21 @@ DMG_TMP_PATH="out/AIDE-tmp.dmg"
 echo "[1/4] Installing dependencies..."
 pnpm install
 
-# Verify the Rust native module was produced by postinstall.
-# Filename pattern: src/main/native/index.<platform>-<arch>.node
-# macOS darwin-arm64 / darwin-x64; Linux adds -gnu/-musl suffix; Windows adds -msvc.
+# Build darwin-universal native module (arm64 + x64 lipo-merged).
+# This replaces the single-arch .node produced by postinstall with a fat binary
+# that runs on both Apple Silicon and Intel Macs.
+echo "      Building darwin-universal native module..."
+pnpm run build:native:universal
+
+# Verify the universal module was produced.
 NATIVE_DIR="src/main/native"
-NATIVE_NODE=$(ls "$NATIVE_DIR"/*.node 2>/dev/null | head -1)
-if [ -n "$NATIVE_NODE" ]; then
+NATIVE_NODE="$NATIVE_DIR/index.darwin-universal.node"
+if [ -f "$NATIVE_NODE" ]; then
   echo "      Rust native module present: $NATIVE_NODE ($(stat -f%z "$NATIVE_NODE") bytes)"
 else
-  echo "::error::Rust native .node missing in $NATIVE_DIR/ after pnpm install."
-  echo "          Check postinstall log — scripts/build-native.mjs requires rustup stable ≥1.82."
+  echo "::error::darwin-universal .node missing in $NATIVE_DIR/ after build:native:universal."
+  echo "          Requires rustup targets: aarch64-apple-darwin + x86_64-apple-darwin"
+  echo "          Run: rustup target add aarch64-apple-darwin x86_64-apple-darwin"
   exit 1
 fi
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "build:native": "node scripts/build-native.mjs",
+    "build:native:universal": "node scripts/build-native.mjs --universal",
     "postinstall": "pnpm run build:native"
   },
   "keywords": [

--- a/scripts/build-native.mjs
+++ b/scripts/build-native.mjs
@@ -6,10 +6,17 @@
  * over any system-installed rustc (e.g. Homebrew rustc 1.74 on macOS).
  *
  * Exits with a clear error message when cargo / rustc is not found.
+ *
+ * Flags:
+ *   --universal   macOS only. Builds arm64 + x64 separately then lipo-merges
+ *                 them into src/main/native/index.darwin-universal.node.
+ *                 Requires lipo (Xcode CLT) and both rust targets installed:
+ *                   rustup target add aarch64-apple-darwin x86_64-apple-darwin
+ *                 Ignored on non-macOS platforms (prints warning, exits 0).
  */
 
 import { execSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { unlinkSync, existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
@@ -19,6 +26,10 @@ const env = {
   ...process.env,
   PATH: `${cargoBin}${pathSep}${process.env.PATH ?? ''}`,
 };
+
+const universalMode =
+  process.argv.includes('--universal') ||
+  process.env.AIDE_NATIVE_UNIVERSAL === '1';
 
 // Verify cargo is available before attempting build
 function which(cmd) {
@@ -43,6 +54,61 @@ if (!which('cargo')) {
   process.exit(1);
 }
 
+// ── Universal (lipo) mode ────────────────────────────────────────────────────
+if (universalMode) {
+  if (process.platform !== 'darwin') {
+    console.error(
+      '\nError: --universal is only supported on macOS (lipo is required).\n'
+    );
+    process.exit(1);
+  }
+
+  if (!which('lipo')) {
+    console.error(
+      '\nError: lipo not found. Install Xcode Command Line Tools:\n' +
+        '  xcode-select --install\n'
+    );
+    process.exit(1);
+  }
+
+  const outputDir = 'src/main/native';
+  const arm64File = `${outputDir}/index.darwin-arm64.node`;
+  const x64File   = `${outputDir}/index.darwin-x64.node`;
+  const univFile  = `${outputDir}/index.darwin-universal.node`;
+
+  const baseArgs = [
+    '--platform',
+    '--release',
+    '--js', 'false',
+    '--output-dir', outputDir,
+    '--manifest-path', 'crates/aide-napi/Cargo.toml',
+  ];
+
+  // Build arm64
+  const arm64Cmd = ['napi', 'build', '--target', 'aarch64-apple-darwin', ...baseArgs].join(' ');
+  console.log(`[build:native:universal] ${arm64Cmd}`);
+  execSync(arm64Cmd, { env, stdio: 'inherit' });
+
+  // Build x64
+  const x64Cmd = ['napi', 'build', '--target', 'x86_64-apple-darwin', ...baseArgs].join(' ');
+  console.log(`[build:native:universal] ${x64Cmd}`);
+  execSync(x64Cmd, { env, stdio: 'inherit' });
+
+  // lipo-merge
+  const lipoCmd = `lipo -create ${arm64File} ${x64File} -output ${univFile}`;
+  console.log(`[build:native:universal] ${lipoCmd}`);
+  execSync(lipoCmd, { stdio: 'inherit' });
+
+  // Remove intermediates — leave only the universal binary
+  for (const f of [arm64File, x64File]) {
+    if (existsSync(f)) unlinkSync(f);
+  }
+
+  console.log(`[build:native:universal] done → ${univFile}`);
+  process.exit(0);
+}
+
+// ── Single-target (default) mode ─────────────────────────────────────────────
 const napiCmd = [
   'napi build',
   '--platform',

--- a/src/main/ipc/fs-handlers.ts
+++ b/src/main/ipc/fs-handlers.ts
@@ -18,7 +18,8 @@ import type { FileTreeNode, FsReadTreeError } from '../../types/ipc';
 function candidateNativeFilenames(): string[] {
   const base = `index.${process.platform}-${process.arch}`;
   if (process.platform === 'darwin') {
-    return [`${base}.node`];
+    // Prefer universal (lipo-merged arm64+x64) when present; fall back to arch-specific.
+    return [`index.darwin-universal.node`, `${base}.node`];
   }
   if (process.platform === 'linux') {
     return [`${base}-gnu.node`, `${base}-musl.node`, `${base}.node`];

--- a/tests/unit/native-loader-arch.test.ts
+++ b/tests/unit/native-loader-arch.test.ts
@@ -6,6 +6,7 @@
  *   2. The loader returns null when no arch-matching .node exists (no wrong-arch crash).
  *   3. On Linux, libc-suffixed variants (-gnu, -musl) are tried before the bare suffix.
  *   4. On Windows, -msvc suffix is tried before the bare suffix.
+ *   5. On macOS, `index.darwin-universal.node` is preferred over the arch-specific file.
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import * as fs from 'node:fs';
@@ -22,7 +23,8 @@ const EXPECTED_FILENAME = `index.${process.platform}-${process.arch}.node`;
 function candidateNativeFilenames(): string[] {
   const base = `index.${process.platform}-${process.arch}`;
   if (process.platform === 'darwin') {
-    return [`${base}.node`];
+    // Prefer universal (lipo-merged arm64+x64) when present; fall back to arch-specific.
+    return [`index.darwin-universal.node`, `${base}.node`];
   }
   if (process.platform === 'linux') {
     return [`${base}-gnu.node`, `${base}-musl.node`, `${base}.node`];
@@ -105,6 +107,42 @@ describe('arch-aware .node loader', () => {
         expect(path.basename(result!)).toBe(gnuFile);
       } finally {
         fs.rmSync(gnuOnlyDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  // macOS-specific: universal binary is preferred over the arch-specific file.
+  it.skipIf(process.platform !== 'darwin')(
+    'darwin: picks index.darwin-universal.node over index.darwin-<arch>.node when both present',
+    () => {
+      const darwinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aide-darwin-univ-test-'));
+      try {
+        const univFile = 'index.darwin-universal.node';
+        const archFile = `index.darwin-${process.arch}.node`;
+        fs.writeFileSync(path.join(darwinDir, univFile), '');
+        fs.writeFileSync(path.join(darwinDir, archFile), '');
+        const result = resolveNodeFile(darwinDir);
+        expect(result).not.toBeNull();
+        expect(path.basename(result!)).toBe(univFile);
+      } finally {
+        fs.rmSync(darwinDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  // macOS-specific: falls back to arch-specific when universal is absent.
+  it.skipIf(process.platform !== 'darwin')(
+    'darwin: falls back to index.darwin-<arch>.node when universal is absent',
+    () => {
+      const archOnlyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aide-darwin-arch-test-'));
+      try {
+        const archFile = `index.darwin-${process.arch}.node`;
+        fs.writeFileSync(path.join(archOnlyDir, archFile), '');
+        const result = resolveNodeFile(archOnlyDir);
+        expect(result).not.toBeNull();
+        expect(path.basename(result!)).toBe(archFile);
+      } finally {
+        fs.rmSync(archOnlyDir, { recursive: true, force: true });
       }
     },
   );

--- a/tests/unit/native-read-tree.test.ts
+++ b/tests/unit/native-read-tree.test.ts
@@ -32,7 +32,8 @@ function jsReadTree(dirPath: string): Array<{ name: string; path: string; type: 
 function candidateNativeFilenames(): string[] {
   const base = `index.${process.platform}-${process.arch}`;
   if (process.platform === 'darwin') {
-    return [`${base}.node`];
+    // Prefer universal (lipo-merged arm64+x64) when present; fall back to arch-specific.
+    return [`index.darwin-universal.node`, `${base}.node`];
   }
   if (process.platform === 'linux') {
     return [`${base}-gnu.node`, `${base}-musl.node`, `${base}.node`];


### PR DESCRIPTION
## Summary

Packaged DMG now runs on both Apple Silicon and Intel Macs. `scripts/build-native.mjs --universal` builds arm64 + x64 Rust targets and lipo-merges them into a single `index.darwin-universal.node`. `build.sh` invokes this automatically before DMG creation.

Scenario C ② — Phase 7 universal binary deliverable.

## Changes

| File | Change |
|---|---|
| `scripts/build-native.mjs` | `--universal` flag builds both darwin targets, lipo-merges. Non-macOS fails fast with clear error. |
| `package.json` | New `build:native:universal` script. |
| `build.sh` | Calls `build:native:universal` before packaging, verifies `darwin-universal.node` exists. |
| `src/main/ipc/fs-handlers.ts` | `candidateNativeFilenames` returns universal first, arch-specific fallback. |
| `tests/unit/native-read-tree.test.ts` | Mirrors candidate list update. |
| `tests/unit/native-loader-arch.test.ts` | +2 tests: universal preferred when present, fallback when absent. |
| `CLAUDE.md` | Documents `build:native:universal` + "do not commit" policy. |

## Loader priority

```ts
// darwin
['index.darwin-universal.node', 'index.darwin-arm64.node']
// or: ['index.darwin-universal.node', 'index.darwin-x64.node']
```

- Local dev (`pnpm install`) → arch-specific built (~10s)
- Release build (`sh build.sh`) → universal built (~20s, both targets)

Universal .node is NOT committed (PR #101 policy). Build artifact only.

## Local verification

- `pnpm run build:native:universal` → produces `darwin-universal.node`
- `file src/main/native/index.darwin-universal.node` → "Mach-O universal binary with 2 architectures"
- `lipo -info ...` → "Architectures in the fat file: ... x86_64 arm64"
- Delete arch-specific, keep only universal → `pnpm test` all green (universal loads on arm64)
- `pnpm test` → 288 passed, 12 skipped (0 failed)

## What this enables

- Single DMG ships → runs on both Intel and Apple Silicon Macs
- No runtime arch detection needed in JS — Mach-O loader picks the slice
- Dev loop unchanged (postinstall still fast single-target)

## Not in scope

- Windows x64/arm64 split — Windows already single arch
- Linux multi-arch — not needed for current release targets
- Release workflow automation — per user policy, builds stay local

## CI impact

Zero. CI continues single-arch build via postinstall. Universal binary is exclusively a release artifact produced by `sh build.sh` on the developer's machine.

## Rustup target requirement

Contributors releasing DMGs need both darwin targets:
```bash
rustup target add aarch64-apple-darwin x86_64-apple-darwin
```

Documented in CLAUDE.md. Regular dev loop doesn't need x86_64 target.

## Test plan

- [x] Local: universal binary produced, lipo verified
- [x] Local: universal binary loads on arm64 runtime
- [x] `pnpm test` 288 passed + 12 skipped
- [x] `pnpm lint` clean in touched files
- [ ] CI: 3 OS matrix green (single-arch path, unchanged)
- [ ] Release: `sh build.sh` → DMG → verify runs on arm64 + test on Intel Mac if available

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>