### PR TITLE
docs(readme): add macOS xattr step for unsigned DMG

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,16 @@ sh build.sh   # macOS — produces out/AIDE.dmg
 
 The build script handles dependency install, lint, package, and DMG creation with a drag-and-drop installer layout.
 
+### macOS Gatekeeper (unsigned build)
+
+The distributed DMG is not code-signed, so macOS quarantines it on first launch ("AIDE is damaged and can't be opened"). After dragging AIDE into `/Applications`, strip the quarantine attribute:
+
+```bash
+xattr -cr /Applications/AIDE.app
+```
+
+Then launch AIDE normally.
+
 ---
 
 ## Architecture

--- a/README_kor.md
+++ b/README_kor.md
@@ -138,6 +138,16 @@ sh build.sh   # macOS — out/AIDE.dmg 생성
 
 빌드 스크립트는 의존성 설치, lint, 패키징, 드래그-드롭 인스톨러 레이아웃 DMG 생성을 모두 처리합니다.
 
+### macOS Gatekeeper (서명되지 않은 빌드)
+
+배포용 DMG는 코드 서명이 되어 있지 않기 때문에, macOS가 첫 실행 시 격리(quarantine)시켜 "AIDE가 손상되어 열 수 없습니다"라는 메시지가 표시될 수 있습니다. `/Applications`로 드래그해 설치한 뒤, 아래 명령어로 격리 속성을 제거해주세요:
+
+```bash
+xattr -cr /Applications/AIDE.app
+```
+
+이후 정상적으로 AIDE를 실행할 수 있습니다.
+
 ---
 
 ## 아키텍처


### PR DESCRIPTION
## Summary
- Document the `xattr -cr /Applications/AIDE.app` workaround users need when running the unsigned macOS DMG for the first time
- Added to both `README.md` and `README_kor.md` under the Installation section

## Test plan
- [ ] Render both READMEs on GitHub and confirm the new "macOS Gatekeeper (unsigned build)" subsection appears right after the build step

🤖 Generated with [Claude Code](https://claude.com/claude-code)