### PR TITLE
chore(rust): Scenario C ④ — hygiene round (CI pins, napi pins, string_enum, observability)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,11 @@ jobs:
           cache: pnpm
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # Pinned to stable branch SHA as of 2026-04-23.
+        # dtolnay/rust-toolchain has no version tags beyond v1 — SHA is the
+        # standard supply-chain pinning approach for this action.
+        # To update: fetch HEAD of https://github.com/dtolnay/rust-toolchain/tree/stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: stable
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,13 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Capture rustc version for cache key
+        id: rustc-version
+        run: echo "version=$(rustc --version | tr ' ' '-')" >> "$GITHUB_OUTPUT"
+        shell: bash
 
       - name: Cache Rust build artifacts
         uses: actions/cache@v4
@@ -38,7 +45,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.rustc-version.outputs.version }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ name = "aide-core"
 version = "0.1.0"
 dependencies = [
  "notify",
+ "portable-pty",
  "tempfile",
 ]
 
@@ -28,6 +29,12 @@ dependencies = [
  "napi-build",
  "napi-derive",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "autocfg"
@@ -88,6 +95,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +117,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror",
+ "winapi",
 ]
 
 [[package]]
@@ -173,6 +197,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ioctl-rs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +224,12 @@ dependencies = [
  "bitflags 1.3.2",
  "libc",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -237,6 +276,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mio"
@@ -308,6 +356,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+]
+
+[[package]]
 name = "notify"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,10 +395,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "portable-pty"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806ee80c2a03dbe1a9fb9534f8d19e4c0546b790cde8fd1fea9d6390644cb0be"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -433,6 +522,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "serial"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+dependencies = [
+ "serial-core",
+ "serial-unix",
+ "serial-windows",
+]
+
+[[package]]
+name = "serial-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "serial-unix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
+dependencies = [
+ "ioctl-rs",
+ "libc",
+ "serial-core",
+ "termios",
+]
+
+[[package]]
+name = "serial-windows"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
+dependencies = [
+ "libc",
+ "serial-core",
+]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +602,35 @@ dependencies = [
  "redox_syscall 0.3.5",
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "termios"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -486,6 +662,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +685,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -574,3 +772,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]

--- a/crates/aide-core/src/lib.rs
+++ b/crates/aide-core/src/lib.rs
@@ -79,6 +79,9 @@ pub struct ReadTreeError {
 pub struct ReadTreeResult {
     pub nodes: Vec<FileNode>,
     pub error: Option<ReadTreeError>,
+    /// Number of directory entries skipped because their names were not valid UTF-8.
+    /// Renderer can surface this count; previously only an eprintln was emitted.
+    pub skipped_count: u32,
 }
 
 /// Read the immediate children of `dir_path`, returning structured error info on failure.
@@ -93,14 +96,15 @@ pub fn read_tree_with_error(dir_path: &str) -> ReadTreeResult {
     match fs::read_dir(dir_path) {
         Ok(entries) => {
             let mut nodes = Vec::new();
+            let mut skipped_count: u32 = 0;
             for entry in entries.flatten() {
                 let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
-                    eprintln!("[aide-core] skipping non-UTF-8 filename in {dir_path}");
+                    skipped_count += 1;
                     continue;
                 };
                 let full_path = Path::new(dir_path).join(&name);
                 let Some(path_str) = full_path.to_str().map(str::to_owned) else {
-                    eprintln!("[aide-core] skipping non-UTF-8 path in {dir_path}");
+                    skipped_count += 1;
                     continue;
                 };
                 let node_type = match entry.file_type() {
@@ -110,7 +114,7 @@ pub fn read_tree_with_error(dir_path: &str) -> ReadTreeResult {
                 };
                 nodes.push(FileNode { name, path: path_str, node_type });
             }
-            ReadTreeResult { nodes, error: None }
+            ReadTreeResult { nodes, error: None, skipped_count }
         }
         Err(e) => {
             use std::io::ErrorKind;
@@ -134,6 +138,7 @@ pub fn read_tree_with_error(dir_path: &str) -> ReadTreeResult {
                     path: dir_path.to_owned(),
                     message: e.to_string(),
                 }),
+                skipped_count: 0,
             }
         }
     }

--- a/crates/aide-napi/Cargo.toml
+++ b/crates/aide-napi/Cargo.toml
@@ -8,8 +8,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 aide-core = { path = "../aide-core" }
-napi = { version = "2", default-features = false, features = ["napi8"] }
-napi-derive = "2"
+# Pinned to exact versions matching Cargo.lock — same policy as napi-build below.
+# To update: bump version here, run `cargo update -p napi -p napi-derive`, verify tests pass.
+napi = { version = "=2.16.17", default-features = false, features = ["napi8"] }
+napi-derive = "=2.16.13"
 
 [build-dependencies]
 # Pinned to 2.1.4 — napi-build 2.3.x bumps MSRV to rustc ≥1.88, but our

--- a/crates/aide-napi/src/lib.rs
+++ b/crates/aide-napi/src/lib.rs
@@ -49,11 +49,14 @@ pub struct ExportedReadTreeError {
     pub message: String,
 }
 
-/// Return value of read_tree_with_error — mirrors { nodes, error? } in TS.
+/// Return value of read_tree_with_error — mirrors { nodes, error?, skippedCount } in TS.
 #[napi(object)]
 pub struct ExportedReadTreeResult {
     pub nodes: Vec<ExportedFileNode>,
     pub error: Option<ExportedReadTreeError>,
+    /// Number of entries skipped because their names were not valid UTF-8.
+    /// Zero on most systems; non-zero only on Linux ext4/tmpfs with non-UTF8 filenames.
+    pub skipped_count: u32,
 }
 
 /// Converts an `io::Error` to a `napi::Error` with a Node.js-compatible error code
@@ -102,6 +105,7 @@ pub fn read_tree_with_error(dir_path: String) -> ExportedReadTreeResult {
             path: e.path,
             message: e.message,
         }),
+        skipped_count: result.skipped_count,
     }
 }
 

--- a/crates/aide-napi/src/lib.rs
+++ b/crates/aide-napi/src/lib.rs
@@ -40,11 +40,21 @@ fn file_node_to_exported(n: aide_core::FileNode) -> ExportedFileNode {
     }
 }
 
+/// String enum for `ExportedReadTreeError.code`.
+/// napi-rs marshals this to/from `'EPERM' | 'ENOENT' | 'ENOTDIR' | 'UNKNOWN'` on the TS side,
+/// which is stronger than a plain `string`.
+#[napi(string_enum)]
+pub enum ExportedReadTreeErrorCode {
+    EPERM,
+    ENOENT,
+    ENOTDIR,
+    UNKNOWN,
+}
+
 /// Mirrors FsReadTreeError in TypeScript ipc.ts.
 #[napi(object)]
 pub struct ExportedReadTreeError {
-    /// "EPERM" | "ENOENT" | "ENOTDIR" | "UNKNOWN"
-    pub code: String,
+    pub code: ExportedReadTreeErrorCode,
     pub path: String,
     pub message: String,
 }
@@ -97,10 +107,10 @@ pub fn read_tree_with_error(dir_path: String) -> ExportedReadTreeResult {
         nodes: result.nodes.into_iter().map(file_node_to_exported).collect(),
         error: result.error.map(|e| ExportedReadTreeError {
             code: match e.code {
-                aide_core::ReadTreeErrorCode::EPERM => "EPERM".to_string(),
-                aide_core::ReadTreeErrorCode::ENOENT => "ENOENT".to_string(),
-                aide_core::ReadTreeErrorCode::ENOTDIR => "ENOTDIR".to_string(),
-                aide_core::ReadTreeErrorCode::UNKNOWN => "UNKNOWN".to_string(),
+                aide_core::ReadTreeErrorCode::EPERM => ExportedReadTreeErrorCode::EPERM,
+                aide_core::ReadTreeErrorCode::ENOENT => ExportedReadTreeErrorCode::ENOENT,
+                aide_core::ReadTreeErrorCode::ENOTDIR => ExportedReadTreeErrorCode::ENOTDIR,
+                aide_core::ReadTreeErrorCode::UNKNOWN => ExportedReadTreeErrorCode::UNKNOWN,
             },
             path: e.path,
             message: e.message,

--- a/src/main/ipc/fs-handlers.ts
+++ b/src/main/ipc/fs-handlers.ts
@@ -49,7 +49,7 @@ export interface PtyHandle {
 
 interface NativeMod {
   readTree: (dir: string) => FileTreeNode[];
-  readTreeWithError: (dir: string) => { nodes: FileTreeNode[]; error?: FsReadTreeError };
+  readTreeWithError: (dir: string) => { nodes: FileTreeNode[]; error?: FsReadTreeError; skippedCount: number };
   readFile: (path: string) => string;
   writeFile: (path: string, content: string) => void;
   deletePath: (path: string) => void;

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -215,7 +215,7 @@ export interface UpdateInfo {
 export interface AideAPI {
   fs: {
     readTree(dirPath: string): Promise<FileTreeNode[]>;
-    readTreeWithError(dirPath: string): Promise<{ nodes: FileTreeNode[]; error?: FsReadTreeError }>;
+    readTreeWithError(dirPath: string): Promise<{ nodes: FileTreeNode[]; error?: FsReadTreeError; skippedCount: number }>;
     readFile(filePath: string): Promise<string>;
     writeFile(filePath: string, content: string): Promise<void>;
     delete(filePath: string): Promise<void>;

--- a/tests/unit/native-read-tree.test.ts
+++ b/tests/unit/native-read-tree.test.ts
@@ -75,7 +75,7 @@ const hasReadTreeWithError: boolean = nativeModPath !== null &&
 describe.skipIf(nativeModPath === null)('native read_tree (napi-rs)', () => {
   let nativeMod: {
     readTree: (dir: string) => Array<{ name: string; path: string; type: string }>;
-    readTreeWithError: (dir: string) => { nodes: Array<{ name: string; path: string; type: string }>; error: { code: string; path: string; message: string } | null | undefined };
+    readTreeWithError: (dir: string) => { nodes: Array<{ name: string; path: string; type: string }>; error: { code: string; path: string; message: string } | null | undefined; skippedCount: number };
   };
   let testDir: string;
 
@@ -192,6 +192,9 @@ describe.skipIf(nativeModPath === null)('native read_tree (napi-rs)', () => {
         // If this assertion fails after a napi-rs upgrade, the serialization
         // contract changed and callers must be audited.
         expect(result.error).toBeUndefined();
+        // skippedCount must be present and zero for a normal UTF-8 directory.
+        expect(result).toHaveProperty('skippedCount');
+        expect(result.skippedCount).toBe(0);
       });
 
       it('error field has {code, path, message} shape when path does not exist', () => {


### PR DESCRIPTION
## Summary

Final Scenario C deliverable — 7 Medium-impact hygiene items bundled into one PR. Closes the Rust migration cleanup backlog.

## 7 items addressed (5 commits)

| # | Item | Commit | Status |
|---|---|---|---|
| 1 | CI cache key includes rustc version — toolchain drift invalidates cache | `0ed4929` | ✅ |
| 2 | Non-UTF8 skip observable via `skippedCount` in ReadTreeResult — renderer can detect under-enumeration | `0269dc9` | ✅ |
| 3 | `dtolnay/rust-toolchain` pinned to SHA (supply chain) | `cabe4a1` | ✅ |
| 4 | `napi` + `napi-derive` pinned to exact versions matching Cargo.lock (reproducibility) | `ff99aa4` | ✅ |
| 5 | `ExportedReadTreeError.code` → `string_enum` for TS type narrowing | `d2a95c7` | ✅ |
| 6 | Renderer contract audit for `err.code` consumers | (no commit — audit only) | ✅ clean |
| 7 | `/dev/fd/N` fsevents EBADF regression test | (no commit — already present as `test_is_excluded_dev_fd`) | ✅ preexisting |

## Item details

### 1 — CI rustc in cache key (`0ed4929`)
When `dtolnay/rust-toolchain@stable` moves forward, `target/` artifacts built with old rustc would be silently restored and linked with new toolchain — past cause of miscompiles elsewhere. Now the cache key includes `rustc --version` so toolchain change invalidates the cache cleanly.

### 2 — skippedCount observability (`0269dc9`)
Previously, Rust `read_tree` silently dropped entries with non-UTF-8 filenames and logged via `eprintln!` (not reachable in packaged Electron). Now `ReadTreeResult` returns a `skippedCount: number` so the renderer can surface a warning if needed. Test locks the new field shape.

### 3 — dtolnay action SHA pin (`cabe4a1`)
`@stable` is a moving tag. Replaced with full SHA `29eef336d9b2848a0b548edc03f92a220660cdb8` (stable branch HEAD as of 2026-04-23). Comment explains the update procedure. Supply-chain safety.

### 4 — napi version pin (`ff99aa4`)
`napi = "2"` and `napi-derive = "2"` floated to latest 2.x on every lock regen. Pinned to `=2.16.17` and `=2.16.13` (current Cargo.lock state). Matches existing `napi-build = "=2.1.4"` policy.

### 5 — string_enum on error code (`d2a95c7`)
`ExportedReadTreeError.code: String` → `ExportedReadTreeErrorCode` enum via `#[napi(string_enum)]`. TS side narrows from `string` to `'EPERM' | 'ENOENT' | 'ENOTDIR' | 'UNKNOWN'` automatically. napi-derive 2.16.13 supports this. Manual match arm block simplified to direct variant assignment.

### 6 — Renderer audit (no commit)
`grep -rn "\.code ===\|err\.code\|error\.code" src/renderer src/main` — only hits:
- `FileExplorer.tsx:273,333` — reads `err.code === 'EPERM'` on the **structured `ExportedReadTreeError.code`** (now enum-narrowed). Intended contract, not Node Error.code.
- `terminal-handlers.ts:238` — Node `ErrnoException.code` on JS spawn errors. Unchanged.

**No napi `Error.code` consumers exist** — the string-prefix approach from PR #93 is validated. Item documented here instead of as a commit.

### 7 — /dev/fd/ pitfall regression (no commit)
Intended target: unit test locking down the macOS `/dev/fd/N` fsevents EBADF guard (CLAUDE.md pitfall). Discovered `crates/aide-core/src/watcher.rs` already has `test_is_excluded_dev_fd`. No action needed.

## Test delta

| | Before | After |
|---|---|---|
| `cargo test -p aide-core` | 34 | 34 (no new tests in this round) |
| `pnpm test` | 299 + 3 skipped | 299 + 3 skipped |
| `pnpm lint` | 0 new errors | 0 new errors |

## Scenario C completion

| | | |
|---|---|---|
| ① committed .node 제거 | PR #101 | ✅ |
| ② Universal binary (darwin) | PR #102 | ✅ |
| ③ ConPTY reader shutdown | PR #104 | ✅ |
| **④ Medium 7개 묶음** | **this PR** | 🟠 |

After merge: Scenario C complete. Remaining backlog items (fix-env, Phase 4/5/6 full migrations, Phase 8 codesign) were explicitly skipped during earlier sessions as low-value or infrastructure-dependent.

## Test plan

- [x] `cargo test -p aide-core` 34 green
- [x] `pnpm test` 299 + 3 skipped
- [x] `pnpm lint` clean in touched files
- [ ] CI 3-OS matrix green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>