### PR TITLE
feat(brand): code-side polish wave 5 — palette C consistency + lint zero

### DIFF
--- a/src/main/mcp/server.js
+++ b/src/main/mcp/server.js
@@ -1,16 +1,16 @@
 #!/usr/bin/env node
 "use strict";
-const fs = require("fs");
-const path = require("path");
-const vm = require("vm");
-const crypto = require("crypto");
+const fs = require("fs"); // eslint-disable-line @typescript-eslint/no-require-imports
+const path = require("path"); // eslint-disable-line @typescript-eslint/no-require-imports
+const vm = require("vm"); // eslint-disable-line @typescript-eslint/no-require-imports
+const crypto = require("crypto"); // eslint-disable-line @typescript-eslint/no-require-imports
 
 function safeCwd() {
   // process.cwd() throws EPERM in packaged Electron apps when launched from Finder
   // (HOME=/ or unmounted cwd). Fall back to HOME / getpwuid / /tmp.
   try { return process.cwd(); } catch { /* EPERM uv_cwd */ }
   if (process.env.HOME && process.env.HOME !== "/") return process.env.HOME;
-  try { return require("os").userInfo().homedir; } catch { /* ignore */ }
+  try { return require("os").userInfo().homedir; } catch { /* getpwuid fallback unavailable */ } // eslint-disable-line @typescript-eslint/no-require-imports
   return "/tmp";
 }
 const PLUGINS_DIR = path.join(safeCwd(), ".smalti", "plugins");
@@ -31,7 +31,7 @@ function scanPluginsDir(dir) {
     if (!entry.isDirectory()) continue;
     const specPath = path.join(dir, entry.name, "plugin.spec.json");
     if (!fs.existsSync(specPath)) continue;
-    try { specs.push(JSON.parse(fs.readFileSync(specPath, "utf-8"))); } catch {}
+    try { specs.push(JSON.parse(fs.readFileSync(specPath, "utf-8"))); } catch { /* skip malformed spec */ }
   }
   return specs;
 }
@@ -53,7 +53,7 @@ function resolvePluginDir(pluginName) {
           if (fs.existsSync(path.join(localDir, entryPoint))) {
             return { dir: localDir, base: PLUGINS_DIR, entryPoint };
           }
-        } catch {}
+        } catch { /* skip unreadable spec */ }
       }
     }
   }
@@ -64,7 +64,7 @@ function invokePluginTool(pluginName, toolName, args) {
   const resolved = resolvePluginDir(pluginName);
   if (!resolved) throw new Error("Plugin not found: " + pluginName);
   var permissions = [];
-  try { permissions = JSON.parse(fs.readFileSync(path.join(resolved.dir, "plugin.spec.json"), "utf-8")).permissions || []; } catch {}
+  try { permissions = JSON.parse(fs.readFileSync(path.join(resolved.dir, "plugin.spec.json"), "utf-8")).permissions || []; } catch { /* default to empty permissions on parse error */ }
   var hasFsRead = permissions.includes("fs:read");
   var hasFsWrite = permissions.includes("fs:write");
   var hasFsPerm = hasFsRead || hasFsWrite;
@@ -425,7 +425,7 @@ function processBuffer() {
     const line = buffer.slice(0, newline).trim();
     buffer = buffer.slice(newline + 1);
     if (!line) continue;
-    try { const msg = JSON.parse(line); if (msg.method) handleRequest(msg.method, msg.id, msg.params); } catch {}
+    try { const msg = JSON.parse(line); if (msg.method) handleRequest(msg.method, msg.id, msg.params); } catch { /* skip malformed JSON-RPC line */ }
   }
 }
 process.stdin.setEncoding("utf-8");

--- a/src/renderer/components/common/ToastContainer.tsx
+++ b/src/renderer/components/common/ToastContainer.tsx
@@ -16,11 +16,11 @@ function Toast({ toast }: { toast: ToastMessage }) {
   const isError = toast.kind === 'error';
   const isWarning = toast.kind === 'warning';
 
-  const borderColor = isError
-    ? 'var(--status-error, #ef4444)'
+  const accentBarClass = isError
+    ? 'bg-smalti-crimson'
     : isWarning
-      ? 'var(--status-warning, #f59e0b)'
-      : 'var(--accent)';
+      ? 'bg-aide-accent-warning'
+      : 'bg-aide-accent';
 
   return (
     <div
@@ -31,8 +31,7 @@ function Toast({ toast }: { toast: ToastMessage }) {
     >
       {/* Left accent bar */}
       <div
-        className="absolute left-0 top-0 bottom-0 w-1 rounded-l-md"
-        style={{ backgroundColor: borderColor }}
+        className={`absolute left-0 top-0 bottom-0 w-1 rounded-l-md ${accentBarClass}`}
       />
 
       {/* Content */}

--- a/src/renderer/components/layout/EmptyState.tsx
+++ b/src/renderer/components/layout/EmptyState.tsx
@@ -100,10 +100,7 @@ export function EmptyState({ paneId }: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center h-full w-full gap-6 select-none">
       {/* Hero logo */}
-      <div
-        className="font-mono font-bold text-[48px] leading-none"
-        style={{ color: 'var(--accent)' }}
-      >
+      <div className="font-mono font-bold text-[48px] leading-none text-aide-accent">
         {'> smalti_'}
       </div>
 
@@ -113,14 +110,7 @@ export function EmptyState({ paneId }: EmptyStateProps) {
       </p>
 
       {/* Agent buttons */}
-      <div
-        className="flex flex-col gap-2 rounded-xl"
-        style={{
-          width: '440px',
-          padding: '8px',
-          backgroundColor: 'var(--background)',
-        }}
-      >
+      <div className="flex flex-col gap-2 rounded-xl bg-aide-background" style={{ width: '440px', padding: '8px' }}>
         {AGENT_BUTTONS.map((btn, idx) => {
           const installed = isInstalled(btn.id);
           const isFirst = idx === 0;
@@ -129,54 +119,50 @@ export function EmptyState({ paneId }: EmptyStateProps) {
               key={btn.id}
               onClick={() => handleSelect(btn)}
               disabled={!installed}
-              className="flex items-center justify-between rounded-[10px] transition-colors"
-              style={{
-                height: '44px',
-                padding: '0 12px',
-                backgroundColor: isFirst ? 'var(--surface-elevated)' : 'var(--background)',
-                opacity: installed ? 1 : 0.4,
-                cursor: installed ? 'pointer' : 'not-allowed',
-              }}
+              className={[
+                'flex items-center justify-between rounded-[10px] transition-colors',
+                isFirst ? 'bg-aide-surface-elevated' : 'bg-aide-background',
+                installed ? 'cursor-pointer opacity-100' : 'cursor-not-allowed opacity-40',
+              ].join(' ')}
+              style={{ height: '44px', padding: '0 12px' }}
             >
               {/* Left: icon + label */}
-              <div className="flex items-center" style={{ gap: '10px' }}>
+              <div className="flex items-center gap-[10px]">
                 <span
-                  className="font-mono font-bold text-[15px]"
-                  style={{ color: isFirst ? 'var(--text-secondary)' : 'var(--text-tertiary)' }}
+                  className={[
+                    'font-mono font-bold text-[15px]',
+                    isFirst ? 'text-aide-text-secondary' : 'text-aide-text-tertiary',
+                  ].join(' ')}
                 >
                   {btn.icon}
                 </span>
                 <span
-                  className="font-mono font-medium text-[13px]"
-                  style={{ color: isFirst ? 'var(--text-primary)' : 'var(--text-tertiary)' }}
+                  className={[
+                    'font-mono font-medium text-[13px]',
+                    isFirst ? 'text-aide-text-primary' : 'text-aide-text-tertiary',
+                  ].join(' ')}
                 >
                   {btn.label}
                 </span>
               </div>
 
               {/* Right: shortcut chips */}
-              <div className="flex items-center" style={{ gap: '6px' }}>
+              <div className="flex items-center gap-[6px]">
                 <span
-                  className="inline-flex items-center justify-center font-mono font-semibold text-[11px] rounded-full leading-none"
-                  style={{
-                    minWidth: '22px',
-                    height: '22px',
-                    padding: '0 6px',
-                    backgroundColor: isFirst ? 'var(--surface)' : 'var(--surface-elevated)',
-                    color: isFirst ? 'var(--text-secondary)' : 'var(--text-tertiary)',
-                  }}
+                  className={[
+                    'inline-flex items-center justify-center font-mono font-semibold text-[11px] rounded-full leading-none',
+                    isFirst ? 'bg-aide-surface text-aide-text-secondary' : 'bg-aide-surface-elevated text-aide-text-tertiary',
+                  ].join(' ')}
+                  style={{ minWidth: '22px', height: '22px', padding: '0 6px' }}
                 >
                   {'\u2318'}
                 </span>
                 <span
-                  className="inline-flex items-center justify-center font-mono font-semibold text-[11px] rounded-full leading-none"
-                  style={{
-                    minWidth: '22px',
-                    height: '22px',
-                    padding: '0 6px',
-                    backgroundColor: isFirst ? 'var(--surface)' : 'var(--surface-elevated)',
-                    color: isFirst ? 'var(--text-secondary)' : 'var(--text-tertiary)',
-                  }}
+                  className={[
+                    'inline-flex items-center justify-center font-mono font-semibold text-[11px] rounded-full leading-none',
+                    isFirst ? 'bg-aide-surface text-aide-text-secondary' : 'bg-aide-surface-elevated text-aide-text-tertiary',
+                  ].join(' ')}
+                  style={{ minWidth: '22px', height: '22px', padding: '0 6px' }}
                 >
                   {btn.shortcutKey}
                 </span>

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -44,6 +44,11 @@
   --smalti-gold: 201 162 75;
   --smalti-crimson: 241 12 69;
   --smalti-sky-blue: 111 197 219;
+  /* status semantic tokens — dark */
+  --status-success: #4FB3BF;   /* smalti-cyan — 성공/완료 */
+  --status-warning: #C9A24B;   /* smalti-gold — 경고 */
+  --status-error:   #F10C45;   /* smalti-crimson — 에러/critical */
+  --status-info:    #6FC5DB;   /* smalti-sky-blue — 정보 */
 }
 
 .light {
@@ -79,6 +84,11 @@
   --smalti-gold: 168 128 42;
   --smalti-crimson: 200 8 58;
   --smalti-sky-blue: 74 159 184;
+  /* status semantic tokens — light */
+  --status-success: #2B8A94;   /* smalti-cyan light — 성공/완료 */
+  --status-warning: #A8802A;   /* smalti-gold light — 경고 */
+  --status-error:   #C8083A;   /* smalti-crimson light — 에러/critical */
+  --status-info:    #4A9FB8;   /* smalti-sky-blue light — 정보 */
 }
 
 html, body, #root {
@@ -177,20 +187,20 @@ body {
  * Drag interaction visual feedback
  * ============================================================ */
 
-/* Insert position indicator — 2px blue vertical line between tabs */
+/* Insert position indicator — 2px cyan vertical line between tabs */
 .drag-insert-line {
   position: absolute;
   left: 0;
   top: 4px;
   bottom: 4px;
   width: 2px;
-  background-color: #3B82F6;
+  background-color: var(--accent);
   border-radius: 1px;
   pointer-events: none;
   z-index: 20;
 }
 
-/* Cross-pane drop overlay — blue tint + centered label */
+/* Cross-pane drop overlay — cyan tint + centered label */
 .drag-drop-overlay {
   position: absolute;
   inset: 0;
@@ -198,15 +208,15 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: rgba(59, 130, 246, 0.10);
-  border: 1px solid rgba(59, 130, 246, 0.35);
+  background-color: rgb(var(--smalti-cyan) / 0.10);
+  border: 1px solid rgb(var(--smalti-cyan) / 0.35);
   pointer-events: none;
 }
 
 .drag-drop-overlay__text {
   font-family: 'JetBrains Mono', 'IBM Plex Mono', monospace;
   font-size: 12px;
-  color: #3B82F6;
+  color: var(--accent);
   opacity: 0.9;
 }
 
@@ -225,7 +235,7 @@ button:focus-visible .drag-handle-icon {
   opacity: 1;
 }
 
-/* Resize divider — 4px blue highlight on hover and active drag */
+/* Resize divider — 4px cyan highlight on hover and active drag */
 .resize-divider {
   background-color: var(--border);
   transition: background-color 150ms ease-out;
@@ -233,7 +243,7 @@ button:focus-visible .drag-handle-icon {
 
 .resize-divider:hover,
 .resize-divider--active {
-  background-color: #3B82F6;
+  background-color: var(--accent);
 }
 
 /* Expand visual width/height to 4px via ::before pseudo-element */
@@ -260,7 +270,7 @@ button:focus-visible .drag-handle-icon {
 
 .resize-divider:hover::before,
 .resize-divider--active::before {
-  background-color: #3B82F6;
+  background-color: var(--accent);
 }
 
 /* Direction icon on resize divider */
@@ -268,7 +278,7 @@ button:focus-visible .drag-handle-icon {
   position: absolute;
   z-index: 15;
   font-size: 10px;
-  color: #3B82F6;
+  color: var(--accent);
   opacity: 0;
   transition: opacity 150ms ease-out;
   pointer-events: none;

--- a/tests/unit/brand-component-tokens.test.ts
+++ b/tests/unit/brand-component-tokens.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Guard: inline var() usage in brand-critical components
+// Ensures no undefined CSS variables remain and inline style={} vars are gone.
+// ---------------------------------------------------------------------------
+
+function readComponent(relPath: string): string {
+  return fs.readFileSync(path.resolve(__dirname, '../../', relPath), 'utf-8');
+}
+
+const COMPONENTS = {
+  ToastContainer: 'src/renderer/components/common/ToastContainer.tsx',
+  EmptyState: 'src/renderer/components/layout/EmptyState.tsx',
+  UpdateNotice: 'src/renderer/components/updater/UpdateNotice.tsx',
+} as const;
+
+// CSS vars that are NOT defined in global.css — must not appear in source
+const UNDEFINED_VARS = [
+  '--status-error',
+  '--status-warning',
+];
+
+// CSS vars that were migrated to Tailwind classes and must no longer appear
+// as inline style values in the three target components
+const MIGRATED_VARS = [
+  '--accent',
+  '--background',
+  '--surface-elevated',
+  '--surface',
+  '--text-primary',
+  '--text-secondary',
+  '--text-tertiary',
+];
+
+describe('brand-component-tokens: no undefined CSS vars', () => {
+  it.each(Object.entries(COMPONENTS))(
+    '%s contains no undefined CSS vars (%s)',
+    (_name, relPath) => {
+      const src = readComponent(relPath);
+      for (const v of UNDEFINED_VARS) {
+        expect(src, `Found undefined CSS var "${v}" in ${relPath}`).not.toContain(v);
+      }
+    },
+  );
+});
+
+describe('brand-component-tokens: migrated vars removed from inline styles', () => {
+  it.each(Object.entries(COMPONENTS))(
+    '%s has no inline style={{…var(--*)}} for migrated tokens (%s)',
+    (_name, relPath) => {
+      const src = readComponent(relPath);
+      // Match style={{ ... var(--token) ... }} — inline style attribute usage
+      const inlineStyleVarRegex = /style\s*=\s*\{\s*\{[^}]*var\(--[\w-]+\)[^}]*\}\s*\}/g;
+      const matches = src.match(inlineStyleVarRegex) ?? [];
+
+      for (const match of matches) {
+        for (const v of MIGRATED_VARS) {
+          expect(
+            match,
+            `Migrated var "${v}" still used in inline style in ${relPath}: ${match}`,
+          ).not.toContain(v);
+        }
+      }
+    },
+  );
+});
+
+describe('brand-component-tokens: ToastContainer uses Tailwind tokens for accent bar', () => {
+  const src = readComponent(COMPONENTS.ToastContainer);
+
+  it('uses bg-smalti-crimson for error state', () => {
+    expect(src).toContain('bg-smalti-crimson');
+  });
+
+  it('uses bg-aide-accent-warning for warning state', () => {
+    expect(src).toContain('bg-aide-accent-warning');
+  });
+
+  it('uses bg-aide-accent for default state', () => {
+    expect(src).toContain('bg-aide-accent');
+  });
+});
+
+describe('brand-component-tokens: EmptyState uses Tailwind tokens', () => {
+  const src = readComponent(COMPONENTS.EmptyState);
+
+  it('hero logo uses text-aide-accent', () => {
+    expect(src).toContain('text-aide-accent');
+  });
+
+  it('button container uses bg-aide-background', () => {
+    expect(src).toContain('bg-aide-background');
+  });
+
+  it('first button uses bg-aide-surface-elevated', () => {
+    expect(src).toContain('bg-aide-surface-elevated');
+  });
+});

--- a/tests/unit/global-css-no-blue.test.ts
+++ b/tests/unit/global-css-no-blue.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, it, expect } from 'vitest';
+
+const css = readFileSync(
+  join(__dirname, '../../src/renderer/styles/global.css'),
+  'utf-8',
+);
+
+describe('global.css — smalti palette C cyan guard', () => {
+  it('must not contain hardcoded blue #3B82F6', () => {
+    expect(css).not.toMatch(/#3B82F6/i);
+  });
+
+  it('must not contain rgba blue (59, 130, 246, ...)', () => {
+    expect(css).not.toMatch(/rgba\(\s*59\s*,\s*130\s*,\s*246/);
+  });
+
+  it('drag-insert-line uses var(--accent)', () => {
+    expect(css).toMatch(/\.drag-insert-line[\s\S]*?background-color:\s*var\(--accent\)/);
+  });
+
+  it('drag-drop-overlay uses rgb(var(--smalti-cyan) / 0.10)', () => {
+    expect(css).toMatch(/\.drag-drop-overlay[\s\S]*?background-color:\s*rgb\(var\(--smalti-cyan\)\s*\/\s*0\.10\)/);
+  });
+
+  it('drag-drop-overlay border uses rgb(var(--smalti-cyan) / 0.35)', () => {
+    expect(css).toMatch(/\.drag-drop-overlay[\s\S]*?border:.*rgb\(var\(--smalti-cyan\)\s*\/\s*0\.35\)/);
+  });
+
+  it('drag-drop-overlay__text uses var(--accent)', () => {
+    expect(css).toMatch(/\.drag-drop-overlay__text[\s\S]*?color:\s*var\(--accent\)/);
+  });
+
+  it('resize-divider hover uses var(--accent)', () => {
+    expect(css).toMatch(/\.resize-divider:hover[\s\S]*?background-color:\s*var\(--accent\)/);
+  });
+
+  it('resize-divider::before hover uses var(--accent)', () => {
+    expect(css).toMatch(/\.resize-divider:hover::before[\s\S]*?background-color:\s*var\(--accent\)/);
+  });
+
+  it('resize-divider__icon uses var(--accent)', () => {
+    expect(css).toMatch(/\.resize-divider__icon[\s\S]*?color:\s*var\(--accent\)/);
+  });
+});

--- a/tests/unit/home-resolution.test.ts
+++ b/tests/unit/home-resolution.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 
 /**
  * Tests that home directory resolution rejects HOME=/ (Finder launch)
@@ -81,6 +81,7 @@ describe('fix-env HOME override logic', () => {
 function getHome(): string {
   const env = process.env.HOME;
   if (env && env !== '/') return env;
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   try { return require('os').userInfo().homedir; } catch { /* ignore */ }
   return '/'; // fallback for test — real code uses app.getPath('home')
 }


### PR DESCRIPTION
## Summary

Four parallel tracks finishing the visible-color polish that the design.pen audit surfaced after wave 4. All inline `var(--*)` bypasses, hardcoded brand-foreign blues, undefined CSS variables, and the long-standing 12 lint errors are now gone.

Lands the smalti palette C consistently across the renderer with no more "looks like AIDE" leftovers, and clears the lint baseline so future work can rely on `pnpm lint` exit 0 as a real signal.

## Tracks

### Track A — Toast / EmptyState component tokens

- `ToastContainer.tsx` — replaced inline `var(--status-error, #ef4444)` / `var(--status-warning, #f59e0b)` bypass with a class-driven `accentBarClass` that maps to `bg-smalti-crimson` / `bg-aide-accent-warning` / `bg-aide-accent`. No more reliance on the undefined `--status-*` fallbacks.
- `EmptyState.tsx` — eliminated 9 inline `style={{ color/background/opacity }}` attributes. Hero, container, button states (active/inactive), icon, label, and shortcut chip all migrated to Tailwind `aide-*` tokens.
- Guard test `tests/unit/brand-component-tokens.test.ts` added.

### Track B — drag/drop hardcoded `#3B82F6` → smalti cyan

`src/renderer/styles/global.css` drag/drop and resize-divider styling: 7 hardcoded `#3B82F6` (a blue we never picked) replaced with `var(--accent)` for solid colors and `rgb(var(--smalti-cyan) / 0.10)` / `rgb(… / 0.35)` for alpha overlays. Drag insertion line, drop overlay, resize divider hover, and the resize icon now follow palette C.

Guard test `tests/unit/global-css-no-blue.test.ts` (9 assertions) prevents the blue from sneaking back.

### Track C — `--status-*` CSS variables defined

`global.css` `:root` and `.light` blocks now define `--status-success / -warning / -error / -info` as hex (matching the existing legacy `aide-*` style so consumers keep working without `rgb()` wrapping). Values: cyan / gold / crimson / sky-blue from palette C.

### Track D — pre-existing lint errors zeroed

12 long-standing ESLint errors in `src/main/mcp/server.js` (5 `require()` calls + 4 empty catches) and `tests/unit/home-resolution.test.ts` (2 unused imports + 1 `require()`) all addressed with surgical edits — no logic change. `pnpm lint` now exits 0 across the repo for the first time in a while.

## Test plan

- [x] `pnpm test` — **448 passed, 3 skipped, 47 files**. No regressions.
- [x] `pnpm lint` — **exit 0**. No issues.
- [x] Manual: status bar / drag overlay / toast accent bar render with palette C tones (verified against the locally running dev server).

## Why this is a separate PR

These tracks landed in parallel as independent file scopes (different components / different sections of `global.css` / different lint targets), reviewable on their own. The actual *theme* is already documented in PR #114; this PR is the code-level cleanup that brings the runtime in line with the spec.

## Related

- Follows PR #114 (theme system spec + wiki page)
- Depends on no other open PR
- Closes the runtime side of the wave-3/wave-4 design.pen ↔ code parity work

🤖 Generated with [Claude Code](https://claude.com/claude-code)