### PR TITLE
fix(migrate-aide-data): rename-first strategy + visible warnings

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -94,12 +94,20 @@ const createWindow = (): void => {
 };
 
 app.on('ready', () => {
-  // Migrate ~/.aide → ~/.smalti (copy-only, non-fatal)
+  // Migrate ~/.aide → ~/.smalti (rename-first, non-fatal). Any warnings
+  // surface explicitly so partial failures (e.g. EBUSY on a watcher) are
+  // visible in the console for post-mortem instead of silently leaving
+  // ~/.aide behind.
   migrateAideToSmalti().then((result) => {
     if (result.migrated) {
-      console.log('[smalti] Migrated ~/.aide → ~/.smalti');
+      console.log(`[smalti] Migrated ~/.aide → ~/.smalti (mode=${result.mode}, deletedLegacy=${result.deletedLegacy})`);
     } else if (result.skipped) {
       console.log(`[smalti] Migration skipped: ${result.skipped}`);
+    }
+    if (result.warnings && result.warnings.length > 0) {
+      for (const w of result.warnings) {
+        console.warn(`[smalti] Migration warning: ${w}`);
+      }
     }
   }).catch((err) => {
     console.error('[smalti] Migration failed (non-fatal):', err);

--- a/src/main/migrate-aide-data.ts
+++ b/src/main/migrate-aide-data.ts
@@ -1,19 +1,28 @@
 /**
- * Copy + cleanup migration: ~/.aide → ~/.smalti
+ * Rename-first migration: ~/.aide → ~/.smalti
  *
- * Algorithm:
- *   1. ~/.aide doesn't exist           → no-op (already clean or never used).
- *   2. ~/.smalti doesn't exist          → copy ~/.aide → ~/.smalti, write marker
- *                                         (~/.smalti/.migrated-from-aide), delete ~/.aide.
- *   3. Both ~/.aide and ~/.smalti exist → ensure marker is present, then delete
- *                                         ~/.aide. ~/.smalti is treated as the
- *                                         active directory of record.
+ * Strategy:
+ *   1. ~/.aide doesn't exist           → no-op.
+ *   2. ~/.smalti doesn't exist          → atomic rename (single syscall, no
+ *                                         copy churn, preserves inodes &
+ *                                         permissions).
+ *   3. Both exist                       → directory merge with destination
+ *                                         winning conflicts, then delete
+ *                                         the now-emptied ~/.aide.
  *
- * Marker lives inside ~/.smalti/ (not ~/.aide/) so it survives the legacy delete
- * and remains a stable signal that the migration ran.
+ * Why both branches:
+ *   The renderer/main bootstrap calls writeMcpServerScript() on every launch,
+ *   which lazily creates ~/.smalti/ to drop smalti-mcp-server.js into. So by
+ *   the time migrateAideToSmalti runs, ~/.smalti already exists for users
+ *   who have run any v0.2.x build at least once — the simple-rename branch
+ *   is unreachable for them. Hence the merge fallback.
  *
- * Delete failures are non-fatal — we report deletedLegacy:false but still
- * advance ~/.smalti as the source of truth.
+ * Marker (~/.smalti/.migrated-from-aide) records that migration has run, so
+ * future launches don't redo the merge.
+ *
+ * Failures are surfaced via the returned MigrateResult AND a console.warn so
+ * post-mortem debugging is possible (the previous copy-only version swallowed
+ * delete errors silently and left ~/.aide on disk).
  */
 import * as fs from 'fs';
 import * as fsp from 'fs/promises';
@@ -22,9 +31,56 @@ import { getHome } from './utils/home';
 
 export interface MigrateResult {
   migrated: boolean;
+  /** Which strategy ran: 'renamed' (atomic), 'merged' (both existed), or undefined when skipped. */
+  mode?: 'renamed' | 'merged';
   /** Whether the legacy ~/.aide directory was successfully removed in this run. */
   deletedLegacy?: boolean;
+  /** Why the migration was skipped, when it didn't run. */
   skipped?: string;
+  /** Surface non-fatal errors so callers can log them. */
+  warnings?: string[];
+}
+
+/**
+ * Recursively merge `src` into `dest`. Items that don't exist in `dest` are
+ * moved (rename) — items that already exist in `dest` are kept (dest wins).
+ * Subdirectories are recursed so inner files can be picked up.
+ */
+async function mergeDirectory(src: string, dest: string, warnings: string[]): Promise<void> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fsp.readdir(src, { withFileTypes: true });
+  } catch (err) {
+    warnings.push(`readdir ${src}: ${(err as Error).message}`);
+    return;
+  }
+
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+
+    if (!fs.existsSync(destPath)) {
+      // Move it across — rename when same filesystem, fall back to cp+rm.
+      try {
+        await fsp.rename(srcPath, destPath);
+      } catch {
+        try {
+          await fsp.cp(srcPath, destPath, { recursive: true });
+          await fsp.rm(srcPath, { recursive: true, force: true });
+        } catch (cpErr) {
+          warnings.push(`cp ${srcPath} → ${destPath}: ${(cpErr as Error).message}`);
+        }
+      }
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      // Both have this directory — recurse so inner items can still merge.
+      await mergeDirectory(srcPath, destPath, warnings);
+    }
+    // else: file collision, dest wins — leave srcPath alone, it'll be removed
+    // when we rm the parent below.
+  }
 }
 
 export async function migrateAideToSmalti(): Promise<MigrateResult> {
@@ -32,37 +88,53 @@ export async function migrateAideToSmalti(): Promise<MigrateResult> {
   const oldDir = path.join(home, '.aide');
   const newDir = path.join(home, '.smalti');
   const marker = path.join(newDir, '.migrated-from-aide');
+  const warnings: string[] = [];
 
   if (!fs.existsSync(oldDir)) {
     return { migrated: false, skipped: 'no-aide-dir' };
   }
 
-  if (fs.existsSync(newDir)) {
-    // ~/.smalti already exists — either a previous migration or a manual setup.
-    // Ensure the marker is in place, then drop legacy ~/.aide.
-    if (!fs.existsSync(marker)) {
+  // Branch 1: ~/.smalti doesn't exist — atomic rename.
+  if (!fs.existsSync(newDir)) {
+    try {
+      await fsp.rename(oldDir, newDir);
+    } catch (err) {
+      // Cross-filesystem rename, EXDEV — fall back to cp + rm.
+      warnings.push(`rename ${oldDir} → ${newDir}: ${(err as Error).message}`);
       try {
-        await fsp.writeFile(marker, new Date().toISOString());
-      } catch {
-        // best-effort marker write
+        await fsp.cp(oldDir, newDir, { recursive: true });
+        await fsp.rm(oldDir, { recursive: true, force: true });
+      } catch (cpErr) {
+        warnings.push(`cp fallback: ${(cpErr as Error).message}`);
+        return { migrated: false, skipped: 'rename-and-copy-failed', warnings };
       }
     }
     try {
-      await fsp.rm(oldDir, { recursive: true, force: true });
-      return { migrated: false, skipped: 'already-migrated', deletedLegacy: true };
-    } catch {
-      return { migrated: false, skipped: 'already-migrated', deletedLegacy: false };
+      await fsp.writeFile(marker, new Date().toISOString());
+    } catch (err) {
+      warnings.push(`marker write: ${(err as Error).message}`);
+    }
+    return { migrated: true, mode: 'renamed', deletedLegacy: true, warnings };
+  }
+
+  // Branch 2: both exist — merge, then drop the source.
+  await mergeDirectory(oldDir, newDir, warnings);
+  if (!fs.existsSync(marker)) {
+    try {
+      await fsp.writeFile(marker, new Date().toISOString());
+    } catch (err) {
+      warnings.push(`marker write: ${(err as Error).message}`);
     }
   }
-
-  // First-time migration: copy ~/.aide → ~/.smalti, then delete legacy.
-  await fsp.cp(oldDir, newDir, { recursive: true });
-  await fsp.writeFile(marker, new Date().toISOString());
-
+  let deletedLegacy = false;
   try {
     await fsp.rm(oldDir, { recursive: true, force: true });
-    return { migrated: true, deletedLegacy: true };
-  } catch {
-    return { migrated: true, deletedLegacy: false };
+    deletedLegacy = !fs.existsSync(oldDir);
+    if (!deletedLegacy) {
+      warnings.push(`rm ${oldDir}: directory still present after rm — likely held by another process`);
+    }
+  } catch (err) {
+    warnings.push(`rm ${oldDir}: ${(err as Error).message}`);
   }
+  return { migrated: true, mode: 'merged', deletedLegacy, warnings };
 }

--- a/tests/unit/migrate-aide-data.test.ts
+++ b/tests/unit/migrate-aide-data.test.ts
@@ -1,8 +1,11 @@
 /**
- * Tests for migrate-aide-data (D8): copy + cleanup migration ~/.aide → ~/.smalti.
+ * Tests for migrate-aide-data: rename-first migration ~/.aide → ~/.smalti.
  *
- * The migration is now copy + delete: it keeps ~/.smalti as the source of truth
- * and drops ~/.aide once the marker (~/.smalti/.migrated-from-aide) is in place.
+ *   1. ~/.aide doesn't exist           → no-op.
+ *   2. ~/.smalti doesn't exist          → atomic rename.
+ *   3. Both exist                       → directory merge with destination
+ *                                         winning conflicts, then delete
+ *                                         the now-emptied ~/.aide.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
@@ -45,87 +48,93 @@ describe('migrateAideToSmalti', () => {
     expect(result.deletedLegacy).toBeUndefined();
   });
 
-  it('first-time migration: copies, writes marker, and deletes legacy ~/.aide', async () => {
+  it('rename branch: ~/.smalti absent — atomic rename, marker written, ~/.aide gone', async () => {
     await fsp.mkdir(aideDir);
     await fsp.writeFile(path.join(aideDir, 'settings.json'), '{"test":true}');
 
     const result = await migrateAideToSmalti();
 
     expect(result.migrated).toBe(true);
+    expect(result.mode).toBe('renamed');
     expect(result.deletedLegacy).toBe(true);
-    expect(result.skipped).toBeUndefined();
-    // ~/.smalti now contains the data
     expect(fs.existsSync(smaltiDir)).toBe(true);
     expect(fs.existsSync(path.join(smaltiDir, 'settings.json'))).toBe(true);
-    // marker lives inside ~/.smalti
     expect(fs.existsSync(marker)).toBe(true);
-    // ~/.aide is gone
     expect(fs.existsSync(aideDir)).toBe(false);
   });
 
-  it('preserves file contents during copy', async () => {
-    await fsp.mkdir(aideDir);
+  it('rename branch: preserves nested file content', async () => {
+    await fsp.mkdir(path.join(aideDir, 'plugins'), { recursive: true });
     const content = JSON.stringify({ version: 1, data: 'hello' });
     await fsp.writeFile(path.join(aideDir, 'settings.json'), content);
-    await fsp.mkdir(path.join(aideDir, 'plugins'), { recursive: true });
     await fsp.writeFile(path.join(aideDir, 'plugins', 'plugin.spec.json'), '{"id":"p1"}');
 
     await migrateAideToSmalti();
 
-    const copiedSettings = await fsp.readFile(path.join(smaltiDir, 'settings.json'), 'utf-8');
-    expect(copiedSettings).toBe(content);
-    const copiedPlugin = await fsp.readFile(
-      path.join(smaltiDir, 'plugins', 'plugin.spec.json'),
-      'utf-8',
-    );
-    expect(copiedPlugin).toBe('{"id":"p1"}');
+    expect(await fsp.readFile(path.join(smaltiDir, 'settings.json'), 'utf-8')).toBe(content);
+    expect(
+      await fsp.readFile(path.join(smaltiDir, 'plugins', 'plugin.spec.json'), 'utf-8'),
+    ).toBe('{"id":"p1"}');
   });
 
-  it('cleanup pass: when both dirs exist, writes missing marker and deletes ~/.aide', async () => {
-    // Simulate user state: ~/.smalti was set up (e.g. by an installer) but
-    // ~/.aide wasn't cleaned up yet, and no marker has been written.
-    await fsp.mkdir(aideDir);
+  it('merge branch: both dirs exist — moves missing items, keeps dest winners, deletes source', async () => {
+    // ~/.aide has: leftover.json (unique) + plugins/myplugin.json (unique)
+    await fsp.mkdir(path.join(aideDir, 'plugins'), { recursive: true });
     await fsp.writeFile(path.join(aideDir, 'leftover.json'), 'old');
-    await fsp.mkdir(smaltiDir);
+    await fsp.writeFile(path.join(aideDir, 'plugins', 'myplugin.json'), 'plugin-data');
+    // ~/.smalti has: existing.json (will win conflicts in shared subdir)
+    await fsp.mkdir(path.join(smaltiDir, 'plugins'), { recursive: true });
     await fsp.writeFile(path.join(smaltiDir, 'existing.json'), 'existing');
 
     const result = await migrateAideToSmalti();
 
-    expect(result.migrated).toBe(false);
-    expect(result.skipped).toBe('already-migrated');
+    expect(result.migrated).toBe(true);
+    expect(result.mode).toBe('merged');
     expect(result.deletedLegacy).toBe(true);
-    // ~/.smalti contents untouched
-    const existing = await fsp.readFile(path.join(smaltiDir, 'existing.json'), 'utf-8');
-    expect(existing).toBe('existing');
-    // marker is now in place
+
+    // ~/.smalti now has its own files + the unique items moved over
+    expect(await fsp.readFile(path.join(smaltiDir, 'existing.json'), 'utf-8')).toBe('existing');
+    expect(await fsp.readFile(path.join(smaltiDir, 'leftover.json'), 'utf-8')).toBe('old');
+    expect(
+      await fsp.readFile(path.join(smaltiDir, 'plugins', 'myplugin.json'), 'utf-8'),
+    ).toBe('plugin-data');
+
+    // marker placed, source gone
     expect(fs.existsSync(marker)).toBe(true);
-    // ~/.aide is gone
     expect(fs.existsSync(aideDir)).toBe(false);
   });
 
-  it('cleanup pass: idempotent when marker already exists', async () => {
+  it('merge branch: dest wins conflicts (file with same name in both)', async () => {
+    await fsp.mkdir(aideDir);
+    await fsp.mkdir(smaltiDir);
+    await fsp.writeFile(path.join(aideDir, 'config.json'), 'aide-version');
+    await fsp.writeFile(path.join(smaltiDir, 'config.json'), 'smalti-version');
+
+    await migrateAideToSmalti();
+
+    // Smalti's config.json wins
+    expect(await fsp.readFile(path.join(smaltiDir, 'config.json'), 'utf-8')).toBe('smalti-version');
+    expect(fs.existsSync(aideDir)).toBe(false);
+  });
+
+  it('merge branch: keeps existing marker untouched if already present', async () => {
     await fsp.mkdir(aideDir);
     await fsp.mkdir(smaltiDir);
     await fsp.writeFile(marker, '2026-04-25T00:00:00Z');
 
-    const result = await migrateAideToSmalti();
+    await migrateAideToSmalti();
 
-    expect(result.skipped).toBe('already-migrated');
-    expect(result.deletedLegacy).toBe(true);
-    // marker keeps its original value (not overwritten)
     const markerContent = await fsp.readFile(marker, 'utf-8');
     expect(markerContent).toBe('2026-04-25T00:00:00Z');
     expect(fs.existsSync(aideDir)).toBe(false);
   });
 
-  it('subsequent runs are no-ops once ~/.aide has been removed', async () => {
-    // Run once to set up the migrated state
+  it('subsequent runs are no-ops once ~/.aide is gone', async () => {
     await fsp.mkdir(aideDir);
     await fsp.writeFile(path.join(aideDir, 'x'), '1');
     await migrateAideToSmalti();
     expect(fs.existsSync(aideDir)).toBe(false);
 
-    // Second run finds nothing to do
     const result = await migrateAideToSmalti();
     expect(result.migrated).toBe(false);
     expect(result.skipped).toBe('no-aide-dir');


### PR DESCRIPTION
## Summary

User reported `~/.aide` was still on disk after launching smalti. Tracked down to the previous copy+rm migration silently swallowing `fs.rm` failures and only logging `'Migration skipped: already-migrated'` even when the deletion actually failed.

## Fix

### New algorithm — rename first, merge as fallback

| State | Strategy |
|---|---|
| `~/.aide` absent | no-op |
| `~/.smalti` absent | atomic `fsp.rename` (single syscall, preserves inodes/permissions, no copy) |
| Both exist (the user's case) | recursive directory merge — for each entry in `~/.aide` rename into `~/.smalti` if not already present, recurse into shared subdirs, leave dest-side winners alone — then `fsp.rm` the now-emptied `~/.aide` and verify removal |

The simple-rename branch is what the user asked for. The merge branch is required because `writeMcpServerScript()` lazily creates `~/.smalti/` on every launch to drop `smalti-mcp-server.js`, so by the time the migration runs `~/.smalti` exists for everyone who's run any v0.2.x build at least once.

### Failures are now visible

- `MigrateResult.warnings: string[]` collects every non-fatal failure (EBUSY on a watcher, EACCES, cross-filesystem EXDEV, etc.).
- `src/main/index.ts` logs each warning to `console.warn` so the user sees *why* `~/.aide` didn't get cleaned up.
- `MigrateResult.mode: 'renamed' | 'merged'` is also logged so post-mortem is easier ('Migrated ~/.aide → ~/.smalti (mode=merged, deletedLegacy=true)').

The previous version printed only `Migration skipped: already-migrated` and offered no signal that the underlying `rm` had failed.

### Cross-filesystem safety

`fsp.rename` falls back to `fsp.cp` + `fsp.rm` on EXDEV (different filesystems — possible if `$HOME` is on a separate volume from `$TMPDIR` etc.). Both branches handle this transparently.

## Test plan

- [x] `pnpm test tests/unit/migrate-aide-data.test.ts` — 7/7 pass
  - no-aide-dir
  - rename branch: marker write + content preservation
  - merge branch: moves unique items + dest wins conflicts
  - merge branch: keeps existing marker untouched
  - merge branch: dest wins on filename collisions
  - subsequent run is no-op once `~/.aide` is gone
- [x] `pnpm test` — full suite green
- [ ] Manual smoke: launch smalti on a machine with both directories present, watch for `[smalti] Migrated ~/.aide → ~/.smalti (mode=merged, deletedLegacy=true)` in main process logs, confirm `~/.aide` disappears

## Why this lands as a separate PR

PR #116 already merged. This is a focused follow-up on the one branch of the migration logic that the prior implementation handled poorly. Keeping it separate so the rename-first design choice is reviewable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)