### PR TITLE
docs(release): add v0.2.0 release notes

### DIFF
--- a/docs/release/v0.2.0.md
+++ b/docs/release/v0.2.0.md
@@ -1,0 +1,87 @@
+# Smalti v0.2.0
+
+> First **Smalti**-branded release. The product formerly known as AIDE is now Smalti — same product, new identity (named after the Byzantine glass mosaic tiles).
+
+## Why the rename
+
+A naming conflict with Android IDE forced a rebrand. We took the opportunity to pick a name that reflects what we actually build: a terminal-centric IDE where small, composable plugins are assembled into something larger — the same way Byzantine mosaicists fit colored *smalti* tiles into a single image. The Matterhorn mosaic in our new app icon is a literal nod to that craft.
+
+## Highlights
+
+### Brand
+- **Smalti** identity end-to-end — display strings, log prefixes, IPC schemes, build artifacts, native crates
+- **Matterhorn mosaic app icon** — `.icns` (10 sizes), `.ico` (4 sizes), Linux PNG set
+- **Palette C theme** — Hacker-Byzantine hybrid (deep terminal greens + Byzantine gold accents) wired through `aide-*` CSS variable aliases plus new opacity-safe `smalti-*` tokens
+- **Sky Blue active highlight** in the workspace sidebar (replaces the old cyan-bar/gold-ring combo)
+
+### Migration
+- **`~/.aide` → `~/.smalti`** via atomic `fsp.rename` with EXDEV fallback to recursive merge. Marker file (`~/.smalti/.migrated-from-aide`) makes the migration idempotent. Visible warnings on failure (no more silent partial migrations).
+- **Bundle ID stabilized** to `com.smaltihq.smalti`, decoupled from `packagerConfig.name` so macOS TCC permissions persist across any future renames.
+- **Auto-update** uses name-agnostic `.app` bundle discovery so existing v0.1.x AIDE installs upgrade cleanly to v0.2.0 Smalti.
+
+### Workspace UX
+- Unified avatar size (collapsed = expanded)
+- White avatar font in both light and dark modes
+- Real Tooltip on collapsed sidebar buttons (workspaces + new-workspace)
+- Empty pane now shows a hero (no auto-shell-spawn)
+- The last workspace is deletable (welcome screen catches the empty state)
+
+### Native crates
+- `aide-napi` → `smalti-napi`
+- `aide-core` → `smalti-core`
+- CI `cargo test` target updated accordingly
+
+### IPC protocols
+- Primary: `smalti://`, `smalti-plugin://`, `smalti-cdn://`
+- Legacy `aide-*` aliases retained for 1–2 releases
+
+## Upgrade notes
+
+### v0.1.x users — one-time manual install required
+
+Your installed v0.1.x app bundle is named `AIDE.app` and its installer hard-codes that name, so it cannot self-update across the rename. Please:
+
+1. Download `Smalti.dmg` from this release
+2. Open the DMG and drag `Smalti.app` into `/Applications`
+3. (Optional) Drag old `AIDE.app` to the Trash
+
+From this version onward, auto-update handles future renames automatically (name-agnostic `.app` discovery).
+
+### macOS — strip the quarantine attribute (unsigned build)
+
+This release is **not code-signed**, so on first launch macOS Gatekeeper will refuse to open it ("Smalti is damaged and can't be opened" or "cannot be opened because the developer cannot be verified"). Strip the quarantine attribute once after copying to `/Applications`:
+
+```bash
+xattr -c /Applications/Smalti.app
+```
+
+Then double-click the app normally. You only need to do this once per install. (We're working toward a signed build for a future release.)
+
+### Data migration is automatic
+
+On first launch, Smalti renames `~/.aide` → `~/.smalti`. Your settings, plugins, and session history come with you. If the rename can't be done atomically (e.g. cross-filesystem), Smalti falls back to a recursive merge and surfaces a warning if anything fails.
+
+### macOS permissions
+
+Because the bundle ID changed from the previous default, macOS may re-prompt for Files & Folders / Accessibility permissions on first launch. Subsequent renames will *not* re-prompt — the new bundle ID is stable.
+
+## Quality gates
+
+- 464 unit tests passing (3 skipped, 1 ignored — see commit `334ff86` for the timing-sensitive PTY coalesce smoke test)
+- 35 Rust core tests passing on macOS / Linux / Windows CI
+- ESLint clean (zero warnings)
+- TypeScript strict — zero errors
+
+## Known limitations
+
+- `aide-*` IPC protocol aliases will be removed after v0.3.x; plugin authors should migrate to `smalti-*` when convenient
+- `aide-*` Tailwind tokens still resolve (aliased to palette C) and will continue to until a future major
+- The PTY output coalescing test is now opt-in (`cargo test ... -- --ignored`) due to platform-dependent timing — coverage is preserved by `test_pty_batch_flushes_within_window` and `test_pty_batch_respects_size_limit`
+
+## Acknowledgements
+
+Naming, palette, and identity work was driven by an in-house brand harness (`.claude/skills/brand-identity/`). The rebrand spanned 6 PRs (#114–#119) and ~50 commits since v0.1.1.
+
+---
+
+**Full diff**: [`v0.1.1...v0.2.0`](https://github.com/Achelous1/smalti/compare/v0.1.1...v0.2.0)


### PR DESCRIPTION
## Summary

Persists the v0.2.0 release notes (already published on the GitHub release) into the repo at `docs/release/v0.2.0.md`.

Includes the macOS quarantine-strip instructions (`xattr -c /Applications/Smalti.app`) needed for unsigned builds.

## Test plan

- [x] File renders correctly on GitHub
- [x] Matches the published release notes at https://github.com/Achelous1/smalti/releases/tag/v0.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)