### PR TITLE
chore: back-merge v0.2.2 hotfix into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to Smalti are documented here.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning per [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] — 2026-04-27
+
+Hotfix for v0.2.0/v0.2.1 rebrand migration gap — workspace-level `.aide` directory and plugin path alias.
+
+### Fixed
+- **Per-workspace `.aide` → `.smalti` migration** — v0.1.x workspaces stored plugin data and JSON files under `<workspace>/.aide/`. v0.2.0 only renamed the user home directory (`~/.aide → ~/.smalti`); workspace-local directories were untouched. Opening a v0.1.x workspace showed zero plugins and an empty kanban board. New `migrateAideWorkspace()` runs inside the `WORKSPACE_OPEN` IPC handler (before the plugin loader fires), applying the same rename-first / merge-fallback strategy as the home-directory migration. Per-workspace marker (`<ws>/.smalti/.migrated-from-aide`) prevents repeat runs.
+- **Plugin sandbox `.aide/` path alias** — Even after the directory migration, legacy plugins that hardcode `.aide/` as their workspace data prefix (e.g. `const DEFAULT_FILE = '.aide/agent-todos.json'`) would silently recreate `<workspace>/.aide/` and write fresh empty files there, making the kanban board show a blank state. New `resolveWorkspaceRel()` helper in `sandbox.ts` rewrites any leading `.aide/` segment to `.smalti/` before resolving, so legacy plugins transparently read and write the migrated location. Alias removed in v0.3.x.
+- **Stale comment in `cdn-protocol.ts`** — JSDoc referenced `~/.aide/cdn-cache/`; corrected to `~/.smalti/cdn-cache/`.
+
+### Tests
+- 7 new cases for `migrateAideWorkspace` (no-aide-dir / rename / merge / conflict / nested / idempotent / stale-marker re-merge).
+- 7 new cases for `resolveWorkspaceRel` alias logic (`.aide/` → `.smalti/`, directory-only, `./` prefix, already-new path, mid-path non-rewrite, unrelated path, no-dot identifier).
+
+### Upgrade notes
+- v0.1.x users: migration runs automatically on the first workspace open after upgrading. No manual action.
+
 ## [0.2.1] — 2026-04-27
 
 Hotfix for v0.2.0 rebrand migration gap.

--- a/docs/release/v0.2.2.md
+++ b/docs/release/v0.2.2.md
@@ -1,0 +1,102 @@
+# Smalti v0.2.2
+
+> Hotfix for v0.2.0/v0.2.1. Fixes two rebrand migration gaps that caused v0.1.x workspaces to
+> show zero plugins and an empty kanban board after upgrading.
+
+## What changed
+
+### Per-workspace `.aide → .smalti` migration
+
+v0.2.0 renamed the user home directory (`~/.aide → ~/.smalti`) and v0.2.1 handled Electron
+`userData` directories. Both hotfixes missed the **workspace-local** data directory.
+
+v0.1.x workspaces stored plugin data under `<workspace>/.aide/` — JSON files, plugin specs,
+kanban state, and similar. When you opened one of those workspaces in v0.2.x, the plugin loader
+looked in `<workspace>/.smalti/plugins/` and found nothing, so the plugin panel showed zero
+plugins and the kanban board was empty.
+
+**v0.2.2** adds `migrateAideWorkspace()`, which runs inside the `WORKSPACE_OPEN` IPC handler
+before the plugin loader fires:
+
+1. If `<workspace>/.aide/` does not exist — no-op (already migrated or a fresh workspace).
+2. If `<workspace>/.smalti/` does not exist — atomic `fsp.rename` (single syscall, no copy churn).
+3. If both exist — recursive merge with the destination winning file conflicts, then
+   `rm -rf <workspace>/.aide`.
+4. A per-workspace marker (`<workspace>/.smalti/.migrated-from-aide`) is written so subsequent
+   opens skip the check entirely.
+
+The migration is idempotent. If the marker exists but `.aide` has reappeared (e.g. a partial
+failure on an earlier run), a fresh merge is attempted and the existing marker is preserved.
+
+### Plugin sandbox `.aide/` path alias
+
+Even after the workspace directory was migrated, legacy plugins that hardcode `.aide/` as
+their data prefix (for example, the kanban board plugin uses
+`const DEFAULT_FILE = '.aide/agent-todos.agent-todos.json'`) would silently recreate
+`<workspace>/.aide/` and write fresh empty data there. The plugin then read back its own
+empty file rather than the migrated one — the kanban board appeared blank even though the
+data existed under `.smalti/`.
+
+**v0.2.2** introduces `resolveWorkspaceRel()` in `src/main/plugin/sandbox.ts`. Every file
+path a plugin passes to the scoped `fs` API is resolved through this helper, which rewrites
+a leading `.aide/` segment to `.smalti/` before the path hits the filesystem. Only the first
+path segment is rewritten — `.aide/` buried inside a deeper path (e.g. `src/a/.aide/x`) is
+left untouched, preventing false rewrites.
+
+Preserved without change: `aide-plugin://`, `aide-cdn://` protocol schemes, `window.aide`
+JavaScript identifier — the regex pattern `^(\.\/?)?\.aide(\/|$)` matches only filesystem
+paths starting with `.aide`, not protocol scheme names or JS identifiers.
+
+This alias is a v0.1.x compatibility shim. It will be removed in v0.3.x once all generated
+plugins emit `.smalti/` natively.
+
+### Stale comment corrected
+
+The JSDoc in `src/main/plugin/cdn-protocol.ts` referenced `~/.aide/cdn-cache/`. The code
+already used `.smalti`; only the comment was stale. Corrected to `~/.smalti/cdn-cache/`.
+
+## Upgrade notes
+
+### From v0.2.0 or v0.2.1
+
+Install v0.2.2. The workspace migration runs automatically the first time you open each
+workspace — no manual steps.
+
+If something goes wrong, check the log output for
+`[smalti] workspace migration warning: …` lines. The legacy `.aide` directory is only
+deleted after a successful merge, so your data is safe while the migration is in progress.
+
+### From v0.1.x or v0.0.x
+
+Same one-time manual install as v0.2.0/v0.2.1 — the app cannot self-update across the
+rebrand. After installing v0.2.2, open your existing workspaces; the migration runs on
+first open for each one.
+
+### macOS — strip the quarantine attribute
+
+This release is not code-signed. After dragging `Smalti.app` to `/Applications`:
+
+```bash
+xattr -c /Applications/Smalti.app
+```
+
+Then double-click normally. One-time per install.
+
+## Quality gates
+
+- All unit tests passing (3 pre-existing skipped) — includes 14 new migration and alias cases
+- ESLint clean
+- TypeScript strict — zero errors
+
+## Known limitations
+
+- The `.aide/` alias in the sandbox is applied at path-resolution time only. Plugin code that
+  constructs paths via string concatenation and then passes the result to native Node APIs
+  outside the sandbox `fs` shim is not covered. All code-generated plugins use the shim
+  exclusively, so this is not a practical concern for v0.1.x plugins.
+- Cross-platform migration logic is unit-tested but the macOS path is the only one exercised
+  end-to-end before release. Please file an issue if Windows or Linux migration misbehaves.
+
+---
+
+**Full diff**: [`v0.2.1...v0.2.2`](https://github.com/Achelous1/smalti/compare/v0.2.1...v0.2.2)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "smalti",
   "productName": "Smalti",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Smalti — a terminal-centric AI-driven IDE with natural-language plugin generation",
   "homepage": "https://github.com/Achelous1/smalti",
   "repository": {

--- a/src/main/ipc/workspace-handlers.ts
+++ b/src/main/ipc/workspace-handlers.ts
@@ -5,6 +5,7 @@ import Store from 'electron-store';
 import { IPC_CHANNELS } from './channels';
 import type { WorkspaceInfo } from '../../types/ipc';
 import { writeMcpConfig } from '../mcp/config-writer';
+import { migrateAideWorkspace } from '../migrate-aide-workspace';
 import { setWorkspaceWatcher } from './fs-handlers';
 
 const store = new Store({ name: 'aide-workspaces' });
@@ -111,13 +112,22 @@ export function registerWorkspaceHandlers(ipcMain: IpcMain): void {
     return workspace;
   });
 
-  ipcMain.handle(IPC_CHANNELS.WORKSPACE_OPEN, (_event, path: string) => {
+  ipcMain.handle(IPC_CHANNELS.WORKSPACE_OPEN, async (_event, path: string) => {
     activeWorkspacePath = path;
     const workspaces = getWorkspaces();
     const workspace = workspaces.find((w) => w.path === path);
     if (workspace) {
       workspace.lastOpened = Date.now();
       setWorkspaces(workspaces);
+    }
+    // Migrate <workspace>/.aide → .smalti so plugin loader sees the correct dir.
+    try {
+      const result = await migrateAideWorkspace(path);
+      if (result.warnings?.length) {
+        result.warnings.forEach((w) => console.warn('[smalti] workspace migration warning:', w));
+      }
+    } catch (err) {
+      console.warn('[smalti] workspace migration error:', (err as Error).message);
     }
     // Migrate legacy .mcp.json (remove smalti entries from project root)
     migrateProjectMcpJson(path);

--- a/src/main/migrate-aide-workspace.ts
+++ b/src/main/migrate-aide-workspace.ts
@@ -1,0 +1,83 @@
+/**
+ * Per-workspace migration: <workspace>/.aide → <workspace>/.smalti
+ *
+ * Strategy mirrors migrateAideToSmalti() in migrate-aide-data.ts but operates
+ * on a caller-supplied workspace path rather than the user home directory.
+ *
+ *   1. <ws>/.aide doesn't exist           → no-op.
+ *   2. <ws>/.smalti doesn't exist          → atomic rename.
+ *   3. Both exist                          → directory merge with destination
+ *                                            winning conflicts, then delete
+ *                                            the now-emptied <ws>/.aide.
+ *
+ * Marker (<ws>/.smalti/.migrated-from-aide) records that migration has run.
+ * If the marker exists but <ws>/.aide has reappeared (e.g. partial failure
+ * on a previous run), a fresh merge attempt is made and the marker preserved.
+ *
+ * Idempotent: marker present + no <ws>/.aide → skipped 'no-aide-dir'.
+ */
+import * as fs from 'fs';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import { MigrateResult, mergeDirectory } from './migrate-aide-data';
+
+export async function migrateAideWorkspace(workspacePath: string): Promise<MigrateResult> {
+  const oldDir = path.join(workspacePath, '.aide');
+  const newDir = path.join(workspacePath, '.smalti');
+  const marker = path.join(newDir, '.migrated-from-aide');
+  const warnings: string[] = [];
+
+  if (!fs.existsSync(oldDir)) {
+    return { migrated: false, skipped: 'no-aide-dir' };
+  }
+
+  // Same-path guard: should not arise in practice but protects against
+  // workspacePath being exactly <parent>/.aide.
+  if (path.resolve(oldDir) === path.resolve(newDir)) {
+    return { migrated: false, skipped: 'same-path' };
+  }
+
+  // Branch 1: <ws>/.smalti doesn't exist — atomic rename.
+  if (!fs.existsSync(newDir)) {
+    try {
+      await fsp.rename(oldDir, newDir);
+    } catch (err) {
+      // Cross-filesystem rename (EXDEV) — fall back to cp + rm.
+      warnings.push(`rename ${oldDir} → ${newDir}: ${(err as Error).message}`);
+      try {
+        await fsp.cp(oldDir, newDir, { recursive: true });
+        await fsp.rm(oldDir, { recursive: true, force: true });
+      } catch (cpErr) {
+        warnings.push(`cp fallback: ${(cpErr as Error).message}`);
+        return { migrated: false, skipped: 'rename-and-copy-failed', warnings };
+      }
+    }
+    try {
+      await fsp.writeFile(marker, new Date().toISOString());
+    } catch (err) {
+      warnings.push(`marker write: ${(err as Error).message}`);
+    }
+    return { migrated: true, mode: 'renamed', deletedLegacy: true, warnings };
+  }
+
+  // Branch 2: both exist — merge, then drop the source.
+  await mergeDirectory(oldDir, newDir, warnings);
+  if (!fs.existsSync(marker)) {
+    try {
+      await fsp.writeFile(marker, new Date().toISOString());
+    } catch (err) {
+      warnings.push(`marker write: ${(err as Error).message}`);
+    }
+  }
+  let deletedLegacy = false;
+  try {
+    await fsp.rm(oldDir, { recursive: true, force: true });
+    deletedLegacy = !fs.existsSync(oldDir);
+    if (!deletedLegacy) {
+      warnings.push(`rm ${oldDir}: directory still present after rm — likely held by another process`);
+    }
+  } catch (err) {
+    warnings.push(`rm ${oldDir}: ${(err as Error).message}`);
+  }
+  return { migrated: true, mode: 'merged', deletedLegacy, warnings };
+}

--- a/src/main/plugin/cdn-protocol.ts
+++ b/src/main/plugin/cdn-protocol.ts
@@ -4,7 +4,7 @@
  * Plugins use `<script src="aide-cdn://cdn.jsdelivr.net/npm/lib@1/dist/lib.js">`
  * instead of `https://...`. The handler:
  *   1. Validates hostname against CDN allowlist
- *   2. Checks ~/.aide/cdn-cache/ for a cached copy
+ *   2. Checks ~/.smalti/cdn-cache/ for a cached copy
  *   3. If cached: serves from disk (works offline)
  *   4. If not cached: downloads from the real HTTPS URL, caches, then serves
  *

--- a/src/main/plugin/sandbox.ts
+++ b/src/main/plugin/sandbox.ts
@@ -7,6 +7,25 @@ import type { PluginSpec } from './spec-generator';
 
 export type PluginEmitter = (event: string, data: Record<string, unknown>) => void;
 
+/**
+ * Resolve a workspace-relative path, rewriting a leading `.aide/` segment to
+ * `.smalti/` so legacy plugins (v0.1.x) that hardcode `.aide/` as their data
+ * directory transparently see the migrated location.
+ *
+ * Only the first path segment is rewritten — `.aide/` buried inside a deeper
+ * path (e.g. `a/.aide/x`) is left untouched because that cannot be a workspace
+ * root data directory.
+ *
+ * Removed in v0.3.x once all generated plugins use `.smalti/` natively.
+ */
+export function resolveWorkspaceRel(workspacePath: string, filePath: string): string {
+  // v0.1.x compat: pre-rebrand plugins hardcode `.aide/` as a workspace data
+  // dir. Rewrite first segment to `.smalti/` so legacy plugins see migrated
+  // data without needing regeneration.
+  const normalized = filePath.replace(/^(\.\/?)?\.aide(\/|$)/, '$1.smalti$2');
+  return path.resolve(workspacePath, normalized);
+}
+
 function sendToRenderer(channel: string, payload?: unknown): void {
   const win = BrowserWindow.getAllWindows()[0];
   if (win) win.webContents.send(channel, payload);
@@ -50,55 +69,55 @@ export class PluginSandbox {
     const scopedFs = {
       // Legacy methods (backward compat)
       read: (filePath: string): string => {
-        const resolved = path.resolve(workspacePath, filePath);
+        const resolved = resolveWorkspaceRel(workspacePath, filePath);
         assertInWorkspace(resolved);
         return fs.readFileSync(resolved, 'utf-8');
       },
       write: (filePath: string, content: string): void => {
         assertWrite();
-        const resolved = path.resolve(workspacePath, filePath);
+        const resolved = resolveWorkspaceRel(workspacePath, filePath);
         assertInWorkspace(resolved);
         fs.writeFileSync(resolved, content);
       },
       // Standard fs methods
       existsSync: (filePath: string): boolean => {
-        const resolved = path.resolve(workspacePath, filePath);
+        const resolved = resolveWorkspaceRel(workspacePath, filePath);
         assertInWorkspace(resolved);
         return fs.existsSync(resolved);
       },
       readFileSync: (filePath: string, encoding?: BufferEncoding): string | Buffer => {
         assertRead();
-        const resolved = path.resolve(workspacePath, filePath);
+        const resolved = resolveWorkspaceRel(workspacePath, filePath);
         assertInWorkspace(resolved);
         return encoding ? fs.readFileSync(resolved, encoding) : fs.readFileSync(resolved);
       },
       writeFileSync: (filePath: string, content: string | Buffer): void => {
         assertWrite();
-        const resolved = path.resolve(workspacePath, filePath);
+        const resolved = resolveWorkspaceRel(workspacePath, filePath);
         assertInWorkspace(resolved);
         fs.writeFileSync(resolved, content);
       },
       mkdirSync: (dirPath: string, options?: fs.MakeDirectoryOptions): void => {
         assertWrite();
-        const resolved = path.resolve(workspacePath, dirPath);
+        const resolved = resolveWorkspaceRel(workspacePath, dirPath);
         assertInWorkspace(resolved);
         fs.mkdirSync(resolved, options);
       },
       readdirSync: (dirPath: string, options?: Parameters<typeof fs.readdirSync>[1]): string[] | Buffer[] | fs.Dirent[] => {
         assertRead();
-        const resolved = path.resolve(workspacePath, dirPath);
+        const resolved = resolveWorkspaceRel(workspacePath, dirPath);
         assertInWorkspace(resolved);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return (fs.readdirSync as any)(resolved, options);
       },
       statSync: (filePath: string): fs.Stats => {
-        const resolved = path.resolve(workspacePath, filePath);
+        const resolved = resolveWorkspaceRel(workspacePath, filePath);
         assertInWorkspace(resolved);
         return fs.statSync(resolved);
       },
       unlinkSync: (filePath: string): void => {
         assertWrite();
-        const resolved = path.resolve(workspacePath, filePath);
+        const resolved = resolveWorkspaceRel(workspacePath, filePath);
         assertInWorkspace(resolved);
         fs.unlinkSync(resolved);
       },

--- a/tests/unit/migrate-aide-workspace.test.ts
+++ b/tests/unit/migrate-aide-workspace.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for migrate-aide-workspace: per-workspace .aide → .smalti migration.
+ *
+ *   1. <ws>/.aide absent             → no-op (skipped: no-aide-dir).
+ *   2. .aide only, .smalti absent    → atomic rename, marker written, .aide gone.
+ *   3. Both exist                    → merge, dest wins conflicts, .aide deleted.
+ *   4. File collision — dest content preserved.
+ *   5. Nested files/directories preserved.
+ *   6. Second call idempotent (marker present, .aide gone → no-aide-dir skip).
+ *   7. Marker present but .aide reappeared → re-merge, marker preserved.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { migrateAideWorkspace } from '../../src/main/migrate-aide-workspace';
+
+describe('migrateAideWorkspace', () => {
+  let wsDir: string;
+  let aideDir: string;
+  let smaltiDir: string;
+  let marker: string;
+
+  beforeEach(async () => {
+    wsDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'ws-migrate-test-'));
+    aideDir = path.join(wsDir, '.aide');
+    smaltiDir = path.join(wsDir, '.smalti');
+    marker = path.join(smaltiDir, '.migrated-from-aide');
+  });
+
+  afterEach(async () => {
+    await fsp.rm(wsDir, { recursive: true, force: true });
+  });
+
+  // ── Case 1: .aide absent ──────────────────────────────────────────────────
+
+  it('returns migrated:false skipped:no-aide-dir when .aide does not exist', async () => {
+    const result = await migrateAideWorkspace(wsDir);
+    expect(result.migrated).toBe(false);
+    expect(result.skipped).toBe('no-aide-dir');
+    expect(result.deletedLegacy).toBeUndefined();
+  });
+
+  // ── Case 2: rename branch ─────────────────────────────────────────────────
+
+  it('rename branch: .smalti absent — atomic rename, marker written, .aide gone', async () => {
+    await fsp.mkdir(aideDir);
+    await fsp.writeFile(path.join(aideDir, 'agent-todos.json'), '[]');
+
+    const result = await migrateAideWorkspace(wsDir);
+
+    expect(result.migrated).toBe(true);
+    expect(result.mode).toBe('renamed');
+    expect(result.deletedLegacy).toBe(true);
+    expect(fs.existsSync(smaltiDir)).toBe(true);
+    expect(fs.existsSync(path.join(smaltiDir, 'agent-todos.json'))).toBe(true);
+    expect(fs.existsSync(marker)).toBe(true);
+    expect(fs.existsSync(aideDir)).toBe(false);
+  });
+
+  // ── Case 3: merge branch ──────────────────────────────────────────────────
+
+  it('merge branch: both exist — moves missing items, keeps dest winners, deletes .aide', async () => {
+    await fsp.mkdir(path.join(aideDir, 'plugins'), { recursive: true });
+    await fsp.writeFile(path.join(aideDir, 'leftover.json'), 'old');
+    await fsp.writeFile(path.join(aideDir, 'plugins', 'spec.json'), 'plugin');
+    await fsp.mkdir(path.join(smaltiDir, 'plugins'), { recursive: true });
+    await fsp.writeFile(path.join(smaltiDir, 'existing.json'), 'existing');
+
+    const result = await migrateAideWorkspace(wsDir);
+
+    expect(result.migrated).toBe(true);
+    expect(result.mode).toBe('merged');
+    expect(result.deletedLegacy).toBe(true);
+    expect(await fsp.readFile(path.join(smaltiDir, 'existing.json'), 'utf-8')).toBe('existing');
+    expect(await fsp.readFile(path.join(smaltiDir, 'leftover.json'), 'utf-8')).toBe('old');
+    expect(await fsp.readFile(path.join(smaltiDir, 'plugins', 'spec.json'), 'utf-8')).toBe('plugin');
+    expect(fs.existsSync(marker)).toBe(true);
+    expect(fs.existsSync(aideDir)).toBe(false);
+  });
+
+  // ── Case 4: conflict — dest wins ─────────────────────────────────────────
+
+  it('merge branch: dest wins file collision', async () => {
+    await fsp.mkdir(aideDir);
+    await fsp.mkdir(smaltiDir);
+    await fsp.writeFile(path.join(aideDir, 'config.json'), 'aide-version');
+    await fsp.writeFile(path.join(smaltiDir, 'config.json'), 'smalti-version');
+
+    await migrateAideWorkspace(wsDir);
+
+    expect(await fsp.readFile(path.join(smaltiDir, 'config.json'), 'utf-8')).toBe('smalti-version');
+    expect(fs.existsSync(aideDir)).toBe(false);
+  });
+
+  // ── Case 5: nested files/directories preserved ────────────────────────────
+
+  it('rename branch: preserves nested directory structure and file content', async () => {
+    await fsp.mkdir(path.join(aideDir, 'plugins', 'agent-todo-board', 'src'), { recursive: true });
+    const content = JSON.stringify({ tasks: [] });
+    await fsp.writeFile(path.join(aideDir, 'plugins', 'agent-todo-board', 'src', 'index.js'), content);
+
+    await migrateAideWorkspace(wsDir);
+
+    const destFile = path.join(smaltiDir, 'plugins', 'agent-todo-board', 'src', 'index.js');
+    expect(await fsp.readFile(destFile, 'utf-8')).toBe(content);
+  });
+
+  // ── Case 6: idempotent — second call skips ───────────────────────────────
+
+  it('second call is a no-op when marker exists and .aide is gone', async () => {
+    await fsp.mkdir(aideDir);
+    await fsp.writeFile(path.join(aideDir, 'x.json'), '1');
+    await migrateAideWorkspace(wsDir);
+    expect(fs.existsSync(aideDir)).toBe(false);
+
+    const result = await migrateAideWorkspace(wsDir);
+    expect(result.migrated).toBe(false);
+    expect(result.skipped).toBe('no-aide-dir');
+  });
+
+  // ── Case 7: stale marker + .aide reappeared → re-merge ───────────────────
+
+  it('re-merges when marker exists but .aide has reappeared, preserves marker', async () => {
+    // Simulate: marker from previous run, .aide recreated externally.
+    await fsp.mkdir(smaltiDir, { recursive: true });
+    await fsp.writeFile(marker, '2026-04-01T00:00:00Z');
+    await fsp.mkdir(aideDir);
+    await fsp.writeFile(path.join(aideDir, 'stale.json'), 'stale');
+
+    const result = await migrateAideWorkspace(wsDir);
+
+    expect(result.migrated).toBe(true);
+    expect(result.mode).toBe('merged');
+    expect(fs.existsSync(path.join(smaltiDir, 'stale.json'))).toBe(true);
+    expect(fs.existsSync(aideDir)).toBe(false);
+    // Marker content was already present — kept as-is (merge branch doesn't overwrite).
+    expect(await fsp.readFile(marker, 'utf-8')).toBe('2026-04-01T00:00:00Z');
+  });
+});

--- a/tests/unit/sandbox-aide-alias.test.ts
+++ b/tests/unit/sandbox-aide-alias.test.ts
@@ -12,39 +12,39 @@ describe('resolveWorkspaceRel — .aide alias', () => {
   // Case 1: .aide/file → .smalti/file
   it('rewrites .aide/file to .smalti/file', () => {
     expect(resolveWorkspaceRel(WS, '.aide/agent-todos.json')).toBe(
-      path.join(WS, '.smalti', 'agent-todos.json'),
+      path.resolve(WS, '.smalti', 'agent-todos.json'),
     );
   });
 
   // Case 2: .aide (directory only, no trailing slash)
   it('rewrites bare .aide to .smalti', () => {
-    expect(resolveWorkspaceRel(WS, '.aide')).toBe(path.join(WS, '.smalti'));
+    expect(resolveWorkspaceRel(WS, '.aide')).toBe(path.resolve(WS, '.smalti'));
   });
 
   // Case 3: ./.aide/x → .smalti/x
   it('rewrites ./.aide/x to .smalti/x', () => {
-    expect(resolveWorkspaceRel(WS, './.aide/x')).toBe(path.join(WS, '.smalti', 'x'));
+    expect(resolveWorkspaceRel(WS, './.aide/x')).toBe(path.resolve(WS, '.smalti', 'x'));
   });
 
   // Case 4: .smalti/x → .smalti/x (already new path — no change)
   it('leaves .smalti/ paths unchanged', () => {
-    expect(resolveWorkspaceRel(WS, '.smalti/x')).toBe(path.join(WS, '.smalti', 'x'));
+    expect(resolveWorkspaceRel(WS, '.smalti/x')).toBe(path.resolve(WS, '.smalti', 'x'));
   });
 
   // Case 5: a/.aide/x (mid-path .aide) → left untouched
   it('does not rewrite .aide in a non-root segment', () => {
-    expect(resolveWorkspaceRel(WS, 'a/.aide/x')).toBe(path.join(WS, 'a', '.aide', 'x'));
+    expect(resolveWorkspaceRel(WS, 'a/.aide/x')).toBe(path.resolve(WS, 'a', '.aide', 'x'));
   });
 
   // Case 6: unrelated plugin path — no change
   it('leaves plugin paths without .aide unchanged', () => {
     expect(resolveWorkspaceRel(WS, 'plugins/agent-todo-board/index.html')).toBe(
-      path.join(WS, 'plugins', 'agent-todo-board', 'index.html'),
+      path.resolve(WS, 'plugins', 'agent-todo-board', 'index.html'),
     );
   });
 
   // Case 7: identifier with 'aide' but no leading dot (e.g. 'aide-foo') — no change
   it('does not rewrite identifiers without a leading dot-aide pattern', () => {
-    expect(resolveWorkspaceRel(WS, 'aide-foo')).toBe(path.join(WS, 'aide-foo'));
+    expect(resolveWorkspaceRel(WS, 'aide-foo')).toBe(path.resolve(WS, 'aide-foo'));
   });
 });

--- a/tests/unit/sandbox-aide-alias.test.ts
+++ b/tests/unit/sandbox-aide-alias.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Tests for resolveWorkspaceRel — the `.aide/` → `.smalti/` path alias in
+ * the plugin sandbox. Covers the regex cases documented in the function JSDoc.
+ */
+import { describe, it, expect } from 'vitest';
+import * as path from 'node:path';
+import { resolveWorkspaceRel } from '../../src/main/plugin/sandbox';
+
+const WS = '/workspace/myproject';
+
+describe('resolveWorkspaceRel — .aide alias', () => {
+  // Case 1: .aide/file → .smalti/file
+  it('rewrites .aide/file to .smalti/file', () => {
+    expect(resolveWorkspaceRel(WS, '.aide/agent-todos.json')).toBe(
+      path.join(WS, '.smalti', 'agent-todos.json'),
+    );
+  });
+
+  // Case 2: .aide (directory only, no trailing slash)
+  it('rewrites bare .aide to .smalti', () => {
+    expect(resolveWorkspaceRel(WS, '.aide')).toBe(path.join(WS, '.smalti'));
+  });
+
+  // Case 3: ./.aide/x → .smalti/x
+  it('rewrites ./.aide/x to .smalti/x', () => {
+    expect(resolveWorkspaceRel(WS, './.aide/x')).toBe(path.join(WS, '.smalti', 'x'));
+  });
+
+  // Case 4: .smalti/x → .smalti/x (already new path — no change)
+  it('leaves .smalti/ paths unchanged', () => {
+    expect(resolveWorkspaceRel(WS, '.smalti/x')).toBe(path.join(WS, '.smalti', 'x'));
+  });
+
+  // Case 5: a/.aide/x (mid-path .aide) → left untouched
+  it('does not rewrite .aide in a non-root segment', () => {
+    expect(resolveWorkspaceRel(WS, 'a/.aide/x')).toBe(path.join(WS, 'a', '.aide', 'x'));
+  });
+
+  // Case 6: unrelated plugin path — no change
+  it('leaves plugin paths without .aide unchanged', () => {
+    expect(resolveWorkspaceRel(WS, 'plugins/agent-todo-board/index.html')).toBe(
+      path.join(WS, 'plugins', 'agent-todo-board', 'index.html'),
+    );
+  });
+
+  // Case 7: identifier with 'aide' but no leading dot (e.g. 'aide-foo') — no change
+  it('does not rewrite identifiers without a leading dot-aide pattern', () => {
+    expect(resolveWorkspaceRel(WS, 'aide-foo')).toBe(path.join(WS, 'aide-foo'));
+  });
+});


### PR DESCRIPTION
## Summary

GitFlow back-merge of v0.2.2 hotfix (#127) from \`main\` into \`develop\`.

Carries:
- \`src/main/migrate-aide-workspace.ts\` (workspace .aide → .smalti migration)
- \`src/main/plugin/sandbox.ts\` (resolveWorkspaceRel alias for legacy plugin paths)
- \`src/main/plugin/cdn-protocol.ts\` (comment fix)
- \`src/main/ipc/workspace-handlers.ts\` (WORKSPACE_OPEN async + migration call)
- \`tests/unit/migrate-aide-workspace.test.ts\`, \`tests/unit/sandbox-aide-alias.test.ts\` (14 cases)
- \`package.json\` 0.2.1 → 0.2.2, \`CHANGELOG.md\`, \`docs/release/v0.2.2.md\`

## Verification

- [x] Released: https://github.com/Achelous1/smalti/releases/tag/v0.2.2
- [x] Linear merge from main — no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)