### PR TITLE
chore: back-merge v0.2.3 hotfix into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to Smalti are documented here.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning per [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] — 2026-04-27
+
+Hotfix for blank plugin iframes after the v0.2.0 rebrand.
+
+### Fixed
+- **Plugin iframes rendered blank on every workspace.** v0.2.0 switched the iframe URL in `PluginView.tsx` from `aide-plugin://` to `smalti-plugin://`, but the renderer's `index.html` Content-Security-Policy `frame-src` allowlist was not updated and still permitted only `aide-plugin:`. Chromium silently blocked every iframe on CSP grounds, so users saw an empty pane regardless of whether the workspace migration (#127) had run.
+- `frame-src` now allows both `smalti-plugin:` and `aide-plugin:` (legacy alias retained for 1–2 releases, in line with the existing scheme registration).
+- `<title>AIDE</title>` updated to `<title>Smalti</title>` (stale since v0.2.0).
+
+### Tests
+- New `tests/unit/index-html-csp.test.ts` pins the `frame-src` allowlist so future scheme renames cannot drop CSP coverage silently.
+
+### Upgrade notes
+- v0.2.2 users: install v0.2.3 and reopen the workspace. No data migration required.
+- macOS still requires `xattr -c /Applications/Smalti.app` after install (unsigned build).
+
 ## [0.2.2] — 2026-04-27
 
 Hotfix for v0.2.0/v0.2.1 rebrand migration gap — workspace-level `.aide` directory and plugin path alias.

--- a/docs/release/v0.2.3.md
+++ b/docs/release/v0.2.3.md
@@ -1,0 +1,58 @@
+# Smalti v0.2.3
+
+> Hotfix for v0.2.0–v0.2.2. Fixes blank plugin iframes on every workspace.
+
+## What's fixed
+
+### Plugin iframes were silently blocked by CSP
+
+v0.2.0 switched the iframe URL in `src/renderer/components/plugin/PluginView.tsx` from `aide-plugin://${pluginId}/index.html` to `smalti-plugin://${pluginId}/index.html`. The renderer's `index.html` Content-Security-Policy still listed only `aide-plugin:` under `frame-src`:
+
+```
+frame-src 'self' aide-plugin:
+```
+
+Chromium blocked every iframe whose URL didn't match the allowlist. The protocol handler succeeded, the HTML was served, but the iframe never received it — users saw an empty pane regardless of plugin or workspace state.
+
+The earlier hotfixes (#125 userData migration, #127 workspace migration + sandbox alias) addressed real but adjacent gaps. None of them moved the iframe past the CSP gate, so plugin pages stayed blank.
+
+**v0.2.3** updates the CSP allowlist:
+
+```
+frame-src 'self' smalti-plugin: aide-plugin:
+```
+
+`aide-plugin:` is kept for 1–2 releases for parity with the protocol scheme registrations.
+
+Also: `<title>AIDE</title>` → `<title>Smalti</title>` (stale since v0.2.0).
+
+## Upgrade notes
+
+### From v0.2.2 (or earlier v0.2.x)
+
+Install v0.2.3 and reopen the workspace. No data migration runs in this hotfix — only the renderer's CSP and title change.
+
+### macOS — still strip the quarantine attribute
+
+This release is **not code-signed**. After dragging `Smalti.app` to `/Applications`:
+
+```bash
+xattr -c /Applications/Smalti.app
+```
+
+One-time per install.
+
+## Quality gates
+
+- Unit tests pass (52 files + 1 new CSP regression suite)
+- ESLint clean
+- TypeScript strict — zero errors
+
+## Known limitations
+
+- Same as v0.2.2: cross-platform migration logic is identical, but only the macOS path is exercised end-to-end before release.
+- Legacy `aide-*` scheme aliases will be removed after v0.3.x.
+
+---
+
+**Full diff**: [`v0.2.2...v0.2.3`](https://github.com/Achelous1/smalti/compare/v0.2.2...v0.2.3)

--- a/index.html
+++ b/index.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; frame-src 'self' aide-plugin:"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; frame-src 'self' smalti-plugin: aide-plugin:"
     />
-    <title>AIDE</title>
+    <title>Smalti</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "smalti",
   "productName": "Smalti",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Smalti — a terminal-centric AI-driven IDE with natural-language plugin generation",
   "homepage": "https://github.com/Achelous1/smalti",
   "repository": {

--- a/tests/unit/index-html-csp.test.ts
+++ b/tests/unit/index-html-csp.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Regression test for the CSP `frame-src` allowlist in index.html.
+ *
+ * Background: v0.2.0 switched plugin iframes from `aide-plugin://` to
+ * `smalti-plugin://` but did not extend the CSP `frame-src` directive.
+ * Chromium silently blocked every iframe → blank plugin panes.
+ *
+ * This test pins both schemes in the allowlist so any future rebrand
+ * that drops one without auditing the iframe URL will fail loudly.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const ROOT = path.resolve(__dirname, '../..');
+const html = fs.readFileSync(path.resolve(ROOT, 'index.html'), 'utf-8');
+
+function frameSrc(): string {
+  const match = html.match(/frame-src\s+([^;"]+)/);
+  if (!match) throw new Error('frame-src directive not found in index.html');
+  return match[1].trim();
+}
+
+describe('index.html CSP', () => {
+  it('frame-src allows smalti-plugin: (primary scheme used by PluginView.tsx)', () => {
+    expect(frameSrc()).toMatch(/\bsmalti-plugin:/);
+  });
+
+  it('frame-src still allows aide-plugin: (legacy alias retained for 1–2 releases)', () => {
+    expect(frameSrc()).toMatch(/\baide-plugin:/);
+  });
+
+  it('frame-src includes self', () => {
+    expect(frameSrc()).toMatch(/'self'/);
+  });
+
+  it('title reflects current brand', () => {
+    expect(html).toMatch(/<title>Smalti<\/title>/);
+  });
+});


### PR DESCRIPTION
## Summary

GitFlow back-merge of v0.2.3 hotfix (#129) from \`main\` into \`develop\`. Carries the CSP \`frame-src\` allowlist fix (and any pending v0.2.2 work that hasn't reached develop yet via #128).

## Verification

- [x] Released: https://github.com/Achelous1/smalti/releases/tag/v0.2.3
- [x] Linear merge from main — no conflicts.