### PR TITLE
refactor(mcp): rename builtin tools + server key from aide to smalti

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,7 +15,7 @@ import { registerAppSettingsHandlers, getAppSettings, setAppSetting } from './ip
 import { registerUpdaterHandlers } from './ipc/updater-handlers';
 import { startUpdatePolling } from './updater/check';
 import { killAllSessions } from './ipc/terminal-handlers';
-import { writeMcpConfig, getMcpConfigPath, unregisterAideFromJsonConfig } from './mcp/config-writer';
+import { writeMcpConfig, getMcpConfigPath, unregisterSmaltiFromJsonConfig } from './mcp/config-writer';
 import { registerCustomSchemes, registerPluginProtocol } from './plugin/protocol';
 import { registerCdnProtocol } from './plugin/cdn-protocol';
 import { getHome } from './utils/home';
@@ -134,10 +134,10 @@ app.on('ready', () => {
       if (fs.existsSync(mcpConfigPath)) {
         const config = JSON.parse(fs.readFileSync(mcpConfigPath, 'utf-8')) as Record<string, unknown>;
         const servers = config.mcpServers as Record<string, { args?: string[] }> | undefined;
-        const aideEntry = servers?.['aide'];
+        const aideEntry = servers?.['smalti'] ?? servers?.['aide'];
         if (aideEntry?.args?.[0] && !fs.existsSync(aideEntry.args[0])) {
-          unregisterAideFromJsonConfig(mcpConfigPath);
-          console.log('[smalti] Cleaned dead-path mcpServers.aide from merged mcp-config.json');
+          unregisterSmaltiFromJsonConfig(mcpConfigPath);
+          console.log('[smalti] Cleaned dead-path mcpServers.smalti from merged mcp-config.json');
         }
       }
     } catch (err) {

--- a/src/main/mcp/config-writer.ts
+++ b/src/main/mcp/config-writer.ts
@@ -73,7 +73,13 @@ function registerJsonMcpConfig(configPath: string, nodePath: string, serverPath:
   if (!config.mcpServers || typeof config.mcpServers !== 'object') {
     config.mcpServers = {};
   }
-  (config.mcpServers as Record<string, unknown>)['aide'] = {
+  const servers = config.mcpServers as Record<string, unknown>;
+  // Migrate legacy 'aide' entry to 'smalti'
+  if ('aide' in servers) {
+    delete servers['aide'];
+    console.error(`[smalti-mcp] migrated 'aide' entry to 'smalti' in ${configPath}`);
+  }
+  servers['smalti'] = {
     command: nodePath,
     args: [serverPath],
   };
@@ -81,12 +87,12 @@ function registerJsonMcpConfig(configPath: string, nodePath: string, serverPath:
 }
 
 /**
- * Removes the mcpServers.aide entry from a JSON MCP config file.
+ * Removes both mcpServers.smalti and mcpServers.aide entries from a JSON MCP config file.
  * Preserves other mcpServers and top-level keys. If mcpServers becomes
  * empty after removal, the key is dropped. If the file does not exist
- * or contains no aide entry, this is a no-op.
+ * or contains neither entry, this is a no-op.
  */
-export function unregisterAideFromJsonConfig(configPath: string): void {
+export function unregisterSmaltiFromJsonConfig(configPath: string): void {
   if (!fs.existsSync(configPath)) return;
   let config: Record<string, unknown>;
   try {
@@ -95,8 +101,10 @@ export function unregisterAideFromJsonConfig(configPath: string): void {
     return; // corrupt — leave untouched
   }
   const servers = config.mcpServers as Record<string, unknown> | undefined;
-  if (!servers || typeof servers !== 'object' || !('aide' in servers)) return;
+  if (!servers || typeof servers !== 'object') return;
+  if (!('aide' in servers) && !('smalti' in servers)) return;
   delete servers['aide'];
+  delete servers['smalti'];
   if (Object.keys(servers).length === 0) {
     delete config.mcpServers;
   }
@@ -139,12 +147,12 @@ export function writeMcpConfig(workspacePath: string): string {
   //                      so it's always picked up alongside --mcp-config)
   // Idempotent — safe to run on every workspace change.
   try {
-    unregisterAideFromJsonConfig(path.join(home, '.claude.json'));
+    unregisterSmaltiFromJsonConfig(path.join(home, '.claude.json'));
   } catch (err) {
     console.warn('[smalti] Failed to clean legacy Claude MCP entry:', (err as Error).message);
   }
   try {
-    unregisterAideFromJsonConfig(path.join(home, '.mcp.json'));
+    unregisterSmaltiFromJsonConfig(path.join(home, '.mcp.json'));
   } catch (err) {
     console.warn('[smalti] Failed to clean legacy ~/.mcp.json entry:', (err as Error).message);
   }
@@ -161,9 +169,14 @@ export function writeMcpConfig(workspacePath: string): string {
     const codexConfigPath = path.join(home, '.codex', 'config.toml');
     fs.mkdirSync(path.dirname(codexConfigPath), { recursive: true });
     let content = fs.existsSync(codexConfigPath) ? fs.readFileSync(codexConfigPath, 'utf-8') : '';
-    content = removeTomlSection(content, '[mcp_servers.aide]');
+    // Migrate legacy [mcp_servers.aide] section and write [mcp_servers.smalti]
+    if (content.includes('[mcp_servers.aide]')) {
+      content = removeTomlSection(content, '[mcp_servers.aide]');
+      console.error(`[smalti-mcp] migrated 'aide' entry to 'smalti' in ${codexConfigPath}`);
+    }
+    content = removeTomlSection(content, '[mcp_servers.smalti]');
     const prefix = content.trimEnd();
-    const block = `[mcp_servers.aide]\ncommand = ${JSON.stringify(nodePath)}\nargs = [${JSON.stringify(serverPath)}]\n`;
+    const block = `[mcp_servers.smalti]\ncommand = ${JSON.stringify(nodePath)}\nargs = [${JSON.stringify(serverPath)}]\n`;
     fs.writeFileSync(codexConfigPath, prefix.length > 0 ? `${prefix}\n\n${block}` : block);
   } catch (err) {
     console.warn('[smalti] Failed to register Codex MCP config:', (err as Error).message);
@@ -171,7 +184,7 @@ export function writeMcpConfig(workspacePath: string): string {
 
   const config = {
     mcpServers: {
-      aide: {
+      smalti: {
         command: 'node',
         args: [getMcpServerPath()],
         env: {

--- a/src/main/mcp/server.js
+++ b/src/main/mcp/server.js
@@ -301,10 +301,12 @@ Common examples:
   Tailwind CSS: smalti-cdn://cdn.jsdelivr.net/npm/@tailwindcss/browser@4/cdn.min.js
 NEVER use raw https:// URLs — they are blocked by the plugin sandbox. ALWAYS use smalti-cdn:// prefix.`;
 
+var _deprecationWarned = new Set();
+
 function getBuiltinTools() {
   const builtins = [
     {
-      name: "aide_create_plugin",
+      name: "smalti_create_plugin",
       description: CREATE_PLUGIN_DESC,
       inputSchema: {
         type: "object",
@@ -321,17 +323,17 @@ function getBuiltinTools() {
       }
     },
     {
-      name: "aide_list_plugins",
+      name: "smalti_list_plugins",
       description: "List all installed Smalti plugins with their tools.",
       inputSchema: { type: "object", properties: {} }
     },
     {
-      name: "aide_invoke_tool",
+      name: "smalti_invoke_tool",
       description: "Invoke a tool from an installed Smalti plugin.",
       inputSchema: { type: "object", properties: { plugin_name: { type: "string" }, tool_name: { type: "string" }, args: { type: "object" } }, required: ["plugin_name", "tool_name"] }
     },
     {
-      name: "aide_edit_plugin",
+      name: "smalti_edit_plugin",
       description: "Edit an existing Smalti plugin in-place. Only provided fields are updated — omitted fields are left unchanged. Useful for patching code or UI without deleting and recreating the plugin.",
       inputSchema: {
         type: "object",
@@ -348,7 +350,7 @@ function getBuiltinTools() {
       }
     },
     {
-      name: "aide_delete_plugin",
+      name: "smalti_delete_plugin",
       description: "Delete an installed Smalti plugin.",
       inputSchema: {
         type: "object",
@@ -382,15 +384,31 @@ function handleRequest(method, id, params) {
       sendResult(id, { tools: getBuiltinTools() });
     } else if (method === "tools/call") {
       const tn = params.name, ta = params.arguments || {};
-      if (tn === "aide_create_plugin") {
+      // Backward-compat: map old aide_* names to their smalti_* equivalents
+      var _DEPRECATED_ALIASES = {
+        "aide_create_plugin":  "smalti_create_plugin",
+        "aide_list_plugins":   "smalti_list_plugins",
+        "aide_invoke_tool":    "smalti_invoke_tool",
+        "aide_edit_plugin":    "smalti_edit_plugin",
+        "aide_delete_plugin":  "smalti_delete_plugin"
+      };
+      if (_DEPRECATED_ALIASES[tn]) {
+        var _newName = _DEPRECATED_ALIASES[tn];
+        if (!_deprecationWarned.has(tn)) {
+          _deprecationWarned.add(tn);
+          console.error("[smalti-mcp] DEPRECATED: tool name '" + tn + "' will be removed in a future version. Use '" + _newName + "' instead.");
+        }
+      }
+      var _resolved = _DEPRECATED_ALIASES[tn] || tn;
+      if (_resolved === "smalti_create_plugin") {
         sendResult(id, { content: [{ type: "text", text: JSON.stringify(createPlugin(ta), null, 2) }] });
-      } else if (tn === "aide_list_plugins") {
+      } else if (_resolved === "smalti_list_plugins") {
         sendResult(id, { content: [{ type: "text", text: JSON.stringify(listPluginSpecs(), null, 2) }] });
-      } else if (tn === "aide_invoke_tool") {
+      } else if (_resolved === "smalti_invoke_tool") {
         sendResult(id, { content: [{ type: "text", text: JSON.stringify(invokePluginTool(ta.plugin_name, ta.tool_name, ta.args || {})) }] });
-      } else if (tn === "aide_edit_plugin") {
+      } else if (_resolved === "smalti_edit_plugin") {
         sendResult(id, { content: [{ type: "text", text: JSON.stringify(editPlugin(ta), null, 2) }] });
-      } else if (tn === "aide_delete_plugin") {
+      } else if (_resolved === "smalti_delete_plugin") {
         const dir = path.join(PLUGINS_DIR, ta.plugin_name);
         if (!path.resolve(dir).startsWith(path.resolve(PLUGINS_DIR) + path.sep)) throw new Error("Invalid plugin name");
         if (fs.existsSync(dir)) fs.rmSync(dir, { recursive: true });

--- a/tests/unit/mcp-config-write.test.ts
+++ b/tests/unit/mcp-config-write.test.ts
@@ -67,7 +67,7 @@ describe('writeMcpConfig — post-release startup registration', () => {
     expect(content).toContain('node');
   });
 
-  it('registers mcpServers.aide in ~/.gemini/settings.json with smalti server path', async () => {
+  it('registers mcpServers.smalti in ~/.gemini/settings.json with smalti server path', async () => {
     const { writeMcpConfig } = await loadConfigWriter();
     writeMcpConfig(path.join(sandboxHome, 'workspace'));
 
@@ -76,13 +76,13 @@ describe('writeMcpConfig — post-release startup registration', () => {
 
     const cfg = JSON.parse(fs.readFileSync(geminiConfigPath, 'utf-8'));
     expect(cfg.mcpServers).toBeDefined();
-    expect(cfg.mcpServers.aide).toBeDefined();
-    expect(cfg.mcpServers.aide.args[0]).toBe(
+    expect(cfg.mcpServers.smalti).toBeDefined();
+    expect(cfg.mcpServers.smalti.args[0]).toBe(
       path.join(sandboxHome, '.smalti', 'smalti-mcp-server.js'),
     );
   });
 
-  it('registers [mcp_servers.aide] in ~/.codex/config.toml with smalti server path', async () => {
+  it('registers [mcp_servers.smalti] in ~/.codex/config.toml with smalti server path', async () => {
     const { writeMcpConfig } = await loadConfigWriter();
     writeMcpConfig(path.join(sandboxHome, 'workspace'));
 
@@ -90,7 +90,7 @@ describe('writeMcpConfig — post-release startup registration', () => {
     expect(fs.existsSync(codexConfigPath)).toBe(true);
 
     const content = fs.readFileSync(codexConfigPath, 'utf-8');
-    expect(content).toContain('[mcp_servers.aide]');
+    expect(content).toContain('[mcp_servers.smalti]');
     // Path is written via JSON.stringify in TOML, which escapes \ → \\ on
     // Windows. Compare against the JSON-stringified form so the assertion
     // works on both win32 and posix.
@@ -171,6 +171,67 @@ describe('writeMcpConfig — post-release startup registration', () => {
     expect(codexAfter2).toBe(codexAfter1);
   });
 
+  it('migrates legacy aide entry to smalti in ~/.gemini/settings.json', async () => {
+    const geminiConfigPath = path.join(sandboxHome, '.gemini', 'settings.json');
+    fs.mkdirSync(path.dirname(geminiConfigPath), { recursive: true });
+    fs.writeFileSync(
+      geminiConfigPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            aide: { command: 'node', args: ['/old/aide-mcp-server.js'] },
+            other: { command: 'node', args: ['/other/server.js'] },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const { writeMcpConfig } = await loadConfigWriter();
+    writeMcpConfig(path.join(sandboxHome, 'workspace'));
+
+    const cfg = JSON.parse(fs.readFileSync(geminiConfigPath, 'utf-8'));
+    // Legacy aide entry must be gone
+    expect(cfg.mcpServers.aide).toBeUndefined();
+    // smalti entry must be present with new path
+    expect(cfg.mcpServers.smalti).toBeDefined();
+    expect(cfg.mcpServers.smalti.args[0]).toBe(
+      path.join(sandboxHome, '.smalti', 'smalti-mcp-server.js'),
+    );
+    // Unrelated servers preserved
+    expect(cfg.mcpServers.other).toBeDefined();
+    expect(cfg.mcpServers.other.args[0]).toBe('/other/server.js');
+  });
+
+  it('migrates legacy [mcp_servers.aide] section to smalti in ~/.codex/config.toml', async () => {
+    const codexConfigPath = path.join(sandboxHome, '.codex', 'config.toml');
+    fs.mkdirSync(path.dirname(codexConfigPath), { recursive: true });
+    fs.writeFileSync(
+      codexConfigPath,
+      [
+        '[mcp_servers.aide]',
+        'command = "node"',
+        'args = ["/old/aide-mcp-server.js"]',
+        '',
+        '[mcp_servers.other]',
+        'command = "python"',
+        'args = ["other.py"]',
+      ].join('\n'),
+    );
+
+    const { writeMcpConfig } = await loadConfigWriter();
+    writeMcpConfig(path.join(sandboxHome, 'workspace'));
+
+    const content = fs.readFileSync(codexConfigPath, 'utf-8');
+    // Legacy aide section must be gone
+    expect(content).not.toContain('[mcp_servers.aide]');
+    // smalti section must be present
+    expect(content).toContain('[mcp_servers.smalti]');
+    // Unrelated section preserved
+    expect(content).toContain('[mcp_servers.other]');
+  });
+
   it('preserves unrelated servers in ~/.gemini/settings.json (merge, not overwrite)', async () => {
     const geminiConfigPath = path.join(sandboxHome, '.gemini', 'settings.json');
     fs.mkdirSync(path.dirname(geminiConfigPath), { recursive: true });
@@ -192,7 +253,7 @@ describe('writeMcpConfig — post-release startup registration', () => {
     const cfg = JSON.parse(fs.readFileSync(geminiConfigPath, 'utf-8'));
     expect(cfg.mcpServers.sentry).toBeDefined();
     expect(cfg.mcpServers.sentry.command).toBe('sentry-cli');
-    expect(cfg.mcpServers.aide).toBeDefined();
+    expect(cfg.mcpServers.smalti).toBeDefined();
     expect(cfg.someOtherKey).toBe('preserve-me');
   });
 });

--- a/tests/unit/unregister-smalti-claude-global.test.ts
+++ b/tests/unit/unregister-smalti-claude-global.test.ts
@@ -2,14 +2,14 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { unregisterAideFromJsonConfig } from '../../src/main/mcp/config-writer';
+import { unregisterSmaltiFromJsonConfig } from '../../src/main/mcp/config-writer';
 
-describe('unregisterAideFromJsonConfig', () => {
+describe('unregisterSmaltiFromJsonConfig', () => {
   let tmpDir: string;
   let configPath: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aide-unreg-test-'));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smalti-unreg-test-'));
     configPath = path.join(tmpDir, '.claude.json');
   });
 
@@ -18,7 +18,7 @@ describe('unregisterAideFromJsonConfig', () => {
   });
 
   it('does nothing when the config file does not exist', () => {
-    expect(() => unregisterAideFromJsonConfig(configPath)).not.toThrow();
+    expect(() => unregisterSmaltiFromJsonConfig(configPath)).not.toThrow();
     expect(fs.existsSync(configPath)).toBe(false);
   });
 
@@ -30,7 +30,7 @@ describe('unregisterAideFromJsonConfig', () => {
     };
     fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
 
-    unregisterAideFromJsonConfig(configPath);
+    unregisterSmaltiFromJsonConfig(configPath);
 
     const result = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     expect(result.mcpServers).toBeUndefined();
@@ -45,7 +45,7 @@ describe('unregisterAideFromJsonConfig', () => {
     };
     fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
 
-    unregisterAideFromJsonConfig(configPath);
+    unregisterSmaltiFromJsonConfig(configPath);
 
     const result = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     expect(result.mcpServers.aide).toBeUndefined();
@@ -60,7 +60,7 @@ describe('unregisterAideFromJsonConfig', () => {
     };
     fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
 
-    unregisterAideFromJsonConfig(configPath);
+    unregisterSmaltiFromJsonConfig(configPath);
 
     const result = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     expect(result.mcpServers).toBeUndefined();
@@ -75,7 +75,7 @@ describe('unregisterAideFromJsonConfig', () => {
     const raw = JSON.stringify(config, null, 2);
     fs.writeFileSync(configPath, raw);
 
-    unregisterAideFromJsonConfig(configPath);
+    unregisterSmaltiFromJsonConfig(configPath);
 
     expect(fs.readFileSync(configPath, 'utf-8')).toBe(raw);
   });
@@ -85,7 +85,7 @@ describe('unregisterAideFromJsonConfig', () => {
     const raw = JSON.stringify(config, null, 2);
     fs.writeFileSync(configPath, raw);
 
-    unregisterAideFromJsonConfig(configPath);
+    unregisterSmaltiFromJsonConfig(configPath);
 
     expect(fs.readFileSync(configPath, 'utf-8')).toBe(raw);
   });
@@ -94,7 +94,7 @@ describe('unregisterAideFromJsonConfig', () => {
     const raw = '{invalid json!!!';
     fs.writeFileSync(configPath, raw);
 
-    expect(() => unregisterAideFromJsonConfig(configPath)).not.toThrow();
+    expect(() => unregisterSmaltiFromJsonConfig(configPath)).not.toThrow();
     expect(fs.readFileSync(configPath, 'utf-8')).toBe(raw);
   });
 
@@ -107,11 +107,25 @@ describe('unregisterAideFromJsonConfig', () => {
     };
     fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
 
-    unregisterAideFromJsonConfig(configPath);
-    unregisterAideFromJsonConfig(configPath);
+    unregisterSmaltiFromJsonConfig(configPath);
+    unregisterSmaltiFromJsonConfig(configPath);
 
     const result = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     expect(result.mcpServers.aide).toBeUndefined();
     expect(result.mcpServers.other).toBeDefined();
+  });
+
+  it('removes the smalti entry too (defensive cleanup)', () => {
+    const config = {
+      mcpServers: {
+        smalti: { command: 'node', args: ['/path/to/smalti-mcp-server.js'] },
+      },
+    };
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+    unregisterSmaltiFromJsonConfig(configPath);
+
+    const result = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(result.mcpServers).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Aligns the externally-visible MCP surface with the smalti rebrand. Workspace dirs already moved to `.smalti/` — this finishes the public-facing naming so external clients (Claude Code, Gemini CLI, Codex CLI) see `mcp__smalti__*` and `smalti_*` instead of the legacy `aide` names.

Background: this is **D8** of the plugin global registry plan ([PR #131](https://github.com/Achelous1/smalti/pull/131)) split into its own PR per design doc recommendation, since it touches externally-visible interfaces and is independent of the registry implementation.

## Changes

- **Builtin tool names** (5):
  - `aide_create_plugin` → `smalti_create_plugin`
  - `aide_list_plugins` → `smalti_list_plugins`
  - `aide_invoke_tool` → `smalti_invoke_tool`
  - `aide_edit_plugin` → `smalti_edit_plugin`
  - `aide_delete_plugin` → `smalti_delete_plugin`
- `tools/list` exposes only the new names. `tools/call` still accepts the `aide_*` aliases via a routing map and logs a **one-time deprecation warning per alias** (`Set`-tracked in module scope).
- **mcpServers config key** (`aide` → `smalti`) for both:
  - JSON: Gemini `settings.json`, internal `mcp-config.json`
  - TOML: Codex `config.toml`
- **Auto-migration on register**: when the writer detects an existing `aide` entry in the user's config file, it removes the legacy entry and writes `smalti` in its place, logging the migration to stderr (`[smalti-mcp] migrated 'aide' entry to 'smalti' in <path>`). One-shot, idempotent — running register again is a no-op.
- `unregisterAideFromJsonConfig` → `unregisterSmaltiFromJsonConfig`. The unregister path defensively removes **both** keys so stale configs from any prior version are cleaned.
- `src/main/index.ts` dead-path scrubber accepts either legacy `aide` or new `smalti` entry during the transition.

## Out of scope (intentional)

These touch the **plugin runtime API contract** (the surface plugin authors write code against) or are otherwise unrelated to MCP-tool/server naming. They warrant separate, deliberate PRs:

- `CREATE_PLUGIN_DESC` body still references `aide.fs` / `aide.plugin` / `aide.files` — those are the in-iframe shim object names exposed to plugin code.
- `aide://` / `aide-plugin://` / `aide-cdn://` URL schemes registered in `protocol.ts`.
- `AIDE_WORKSPACE` env var fallback (already deprecated, kept for transitional safety).
- `server.js` unit tests — the MCP entry is plain `.js` with no test infra; introducing one belongs in its own scoped PR.

## Test plan

- [x] `pnpm lint` — passes
- [ ] Manual smoke: launch `pnpm start`, verify Gemini/Codex configs get rewritten with `smalti` key on first launch (and the old `aide` key disappears)
- [ ] Manual smoke: external client calling `aide_create_plugin` still works and prints the deprecation warning to the main-process stderr exactly once per process
- [ ] Manual smoke: external client calling `smalti_create_plugin` works without warnings
- [ ] Confirm `tools/list` no longer advertises the `aide_*` names

🤖 Generated with [Claude Code](https://claude.com/claude-code)