### PR TITLE
feat(renderer): plugin registry UI — PluginPanel v2 + dialogs + browser

### DIFF
--- a/src/renderer/components/plugin/PluginPanel.tsx
+++ b/src/renderer/components/plugin/PluginPanel.tsx
@@ -1,6 +1,81 @@
-import { useEffect, useState } from 'react';
-import { usePluginStore } from '../../stores/plugin-store';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { usePluginStore, type PublishConflict } from '../../stores/plugin-store';
 import { useLayoutStore } from '../../stores/layout-store';
+import type { PluginInfo } from '../../../types/ipc';
+import type { SyncStatus } from '../../../types/plugin-registry';
+import { PluginStatusBadge } from './registry/PluginStatusBadge';
+import { RegistryBrowser } from './registry/RegistryBrowser';
+import { ForkAsNewPluginDialog } from './registry/dialogs/ForkAsNewPluginDialog';
+import { UpdateConfirmDialog } from './registry/dialogs/UpdateConfirmDialog';
+import { PublishConflictDialog } from './registry/dialogs/PublishConflictDialog';
+
+const PluginIconStub = () => (
+  <div className="grid grid-cols-2 grid-rows-2 gap-0.5 shrink-0" style={{ width: 22, height: 22 }}>
+    <span className="bg-smalti-cyan rounded-[2px]" />
+    <span className="bg-aide-text-tertiary/50 rounded-[2px]" />
+    <span className="bg-aide-text-tertiary/50 rounded-[2px]" />
+    <span className="bg-smalti-gold rounded-[2px]" />
+  </div>
+);
+
+interface ActionMenuItem {
+  key: string;
+  label: string;
+  danger?: boolean;
+  onSelect: () => void;
+}
+
+function ActionMenu({
+  items,
+  onClose,
+}: {
+  items: ActionMenuItem[];
+  onClose: () => void;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const onDocClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('mousedown', onDocClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDocClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={ref}
+      role="menu"
+      data-testid="plugin-action-menu"
+      className="absolute right-0 top-6 z-20 bg-aide-surface-elevated border border-aide-border rounded-md shadow-xl py-1 min-w-[180px]"
+    >
+      {items.map((item) => (
+        <button
+          key={item.key}
+          role="menuitem"
+          onClick={() => {
+            item.onSelect();
+            onClose();
+          }}
+          className={`w-full text-left px-3 py-1.5 text-xs font-mono transition-colors ${
+            item.danger
+              ? 'text-smalti-crimson hover:bg-smalti-crimson/10'
+              : 'text-aide-text-primary hover:bg-aide-surface'
+          }`}
+        >
+          {item.label}
+        </button>
+      ))}
+    </div>
+  );
+}
 
 export function PluginPanel() {
   const {
@@ -9,20 +84,56 @@ export function PluginPanel() {
     error,
     loadPlugins,
     activate,
-    deactivate,
     deletePlugin,
+    generate,
+    generating,
+    generateError,
+    registryDiffs,
+    refreshRegistryDiffs,
+    applyUpdate,
+    forkAsNew,
+    publish,
+    importFromRegistry,
   } = usePluginStore();
 
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
+  const [openMenuFor, setOpenMenuFor] = useState<string | null>(null);
+  const [browserOpen, setBrowserOpen] = useState(false);
+  const [forkTarget, setForkTarget] = useState<PluginInfo | null>(null);
+  const [updateTarget, setUpdateTarget] = useState<PluginInfo | null>(null);
+  const [publishConflict, setPublishConflict] =
+    useState<{ plugin: PluginInfo; conflict: PublishConflict } | null>(null);
+  const [genName, setGenName] = useState('');
+  const [genDesc, setGenDesc] = useState('');
 
   useEffect(() => {
     loadPlugins();
-    const unsub = window.aide.plugin.onChanged(loadPlugins);
+    const unsub = window.aide.plugin.onChanged(() => {
+      loadPlugins();
+      refreshRegistryDiffs();
+    });
     return unsub;
-  }, [loadPlugins]);
+  }, [loadPlugins, refreshRegistryDiffs]);
 
-  const handleOpenTab = async (plugin: typeof plugins[number]) => {
-    // Focus existing tab if already open
+  const installedNames = useMemo(
+    () => new Set(plugins.map((p) => p.name)),
+    [plugins]
+  );
+
+  const updateAvailableIds = useMemo(() => {
+    const set = new Set<string>();
+    for (const diff of Object.values(registryDiffs)) {
+      if (diff && diff.status === 'update-available') set.add(diff.registryId);
+    }
+    return set;
+  }, [registryDiffs]);
+
+  const statusFor = (plugin: PluginInfo): SyncStatus => {
+    const diff = registryDiffs[plugin.name];
+    return diff?.status ?? 'unknown';
+  };
+
+  const handleOpenTab = async (plugin: PluginInfo) => {
     const allPanes = useLayoutStore.getState().getAllPanes();
     const existing = allPanes
       .flatMap((pane) => pane.tabs.map((tab) => ({ paneId: pane.id, tab })))
@@ -31,97 +142,210 @@ export function PluginPanel() {
       useLayoutStore.getState().setActiveTab(existing.paneId, existing.tab.id);
       return;
     }
-    // Smart Open: activate (also adds tab via plugin-store.activate) regardless of current state.
-    // activate() is idempotent on already-active plugins and skips tab creation if tab exists.
     await activate(plugin.id);
   };
 
-  const handleDeleteClick = (name: string) => {
-    setDeleteConfirm(name);
+  const handleUpdateClick = async (plugin: PluginInfo) => {
+    const diff = registryDiffs[plugin.name];
+    // If the workspace has local modifications, show confirm dialog first.
+    if (diff && diff.status === 'locally-modified') {
+      setUpdateTarget(plugin);
+      return;
+    }
+    try {
+      await applyUpdate(plugin.name);
+    } catch (e) {
+      console.error('Update failed', e);
+    }
+  };
+
+  const handlePublishClick = async (plugin: PluginInfo) => {
+    try {
+      const conflict = await publish(plugin.name, true);
+      if (conflict && conflict.reason === 'pull-latest-first') {
+        setPublishConflict({ plugin, conflict });
+      }
+    } catch (e) {
+      console.error('Publish failed', e);
+    }
+  };
+
+  const buildActionItems = (plugin: PluginInfo): ActionMenuItem[] => {
+    const status = statusFor(plugin);
+    const diff = registryDiffs[plugin.name];
+    const items: ActionMenuItem[] = [];
+
+    if (status === 'update-available') {
+      items.push({
+        key: 'update',
+        label: diff?.latestVersion ? `Update to ${diff.latestVersion}` : 'Update',
+        onSelect: () => handleUpdateClick(plugin),
+      });
+      items.push({
+        key: 'fork',
+        label: 'Fork as new plugin',
+        onSelect: () => setForkTarget(plugin),
+      });
+    } else if (status === 'locally-modified') {
+      items.push({
+        key: 'update',
+        label: 'Update to latest (discard local)',
+        onSelect: () => handleUpdateClick(plugin),
+      });
+      items.push({
+        key: 'fork',
+        label: 'Fork as new plugin',
+        onSelect: () => setForkTarget(plugin),
+      });
+    }
+
+    items.push({
+      key: 'publish',
+      label:
+        status === 'locally-modified'
+          ? 'Publish to registry (bump patch)'
+          : 'Publish to registry',
+      onSelect: () => handlePublishClick(plugin),
+    });
+
+    items.push({
+      key: 'remove',
+      label: 'Remove',
+      danger: true,
+      onSelect: () => setDeleteConfirm(plugin.name),
+    });
+
+    return items;
   };
 
   const handleDeleteConfirm = async () => {
     if (!deleteConfirm) return;
-    await deletePlugin(deleteConfirm);
-    setDeleteConfirm(null);
+    const target = plugins.find((p) => p.name === deleteConfirm);
+    const diff = target ? registryDiffs[target.name] : null;
+    try {
+      await deletePlugin(deleteConfirm);
+      // Best-effort: also remove from registry if we can identify the source id.
+      if (diff?.registryId) {
+        try {
+          await window.aide.plugin.registry.remove(diff.registryId);
+        } catch {
+          /* registry remove failures are non-fatal */
+        }
+      }
+    } finally {
+      setDeleteConfirm(null);
+    }
   };
 
-  const activeCount = plugins.filter((p) => p.active).length;
+  const handleGenerate = async () => {
+    if (!genName.trim() || generating) return;
+    const result = await generate(genName.trim(), genDesc.trim());
+    if (result) {
+      setGenName('');
+      setGenDesc('');
+    }
+  };
 
-  const renderPlugin = (plugin: typeof plugins[number]) => (
-    <div
-      key={plugin.id}
-      className="flex items-start gap-2 px-2 py-2 rounded bg-aide-surface-elevated"
-    >
-      <div className="flex flex-col flex-1 min-w-0">
-        <span className="text-xs font-mono text-aide-text-primary truncate">
-          {plugin.name}
-        </span>
-        {plugin.description && (
-          <span className="text-[10px] text-aide-text-secondary truncate">
-            {plugin.description}
-          </span>
-        )}
-        <span className="text-[10px] text-aide-text-tertiary">
-          v{plugin.version}
-        </span>
-      </div>
-      <div className="flex items-center gap-1 shrink-0 pt-0.5">
-        <button
-          onClick={() =>
-            plugin.active ? deactivate(plugin.id) : activate(plugin.id)
-          }
-          className={`px-2 py-0.5 rounded text-[10px] font-mono transition-colors ${
-            plugin.active
-              ? 'border border-aide-accent text-aide-accent'
-              : 'border border-aide-border text-aide-text-secondary hover:text-aide-text-primary hover:border-aide-text-secondary'
-          }`}
-          title={plugin.active ? 'Deactivate plugin' : 'Activate plugin'}
-        >
-          {plugin.active ? 'ON' : 'OFF'}
-        </button>
-        <button
-          onClick={() => window.aide.plugin.reload(plugin.id)}
-          className="px-1.5 py-0.5 rounded text-[10px] font-mono text-aide-text-tertiary hover:text-aide-text-primary hover:bg-aide-surface-elevated transition-colors"
-          title="Reload plugin"
-        >
-          ↻
-        </button>
+  const renderPlugin = (plugin: PluginInfo) => {
+    const status = statusFor(plugin);
+    const diff = registryDiffs[plugin.name];
+    return (
+      <div
+        key={plugin.id}
+        data-testid={`plugin-row-${plugin.id}`}
+        className="relative flex items-start gap-2 px-2 py-2 rounded hover:bg-aide-surface-elevated transition-colors"
+      >
+        <PluginIconStub />
         <button
           onClick={() => handleOpenTab(plugin)}
-          className="px-1.5 py-0.5 rounded text-[10px] font-mono text-aide-text-tertiary hover:text-aide-text-primary hover:bg-aide-surface-elevated transition-colors"
-          title="Open plugin (will activate if off)"
+          className="flex flex-col flex-1 min-w-0 text-left"
         >
-          ↗
+          <span className="text-sm font-mono text-aide-text-primary truncate">
+            {plugin.name}
+          </span>
+          {plugin.description && (
+            <span className="text-[11px] text-aide-text-secondary leading-snug line-clamp-2 font-sans">
+              {plugin.description}
+            </span>
+          )}
         </button>
-        <button
-          onClick={() => handleDeleteClick(plugin.name)}
-          className="px-1.5 py-0.5 rounded text-[10px] font-mono text-aide-text-tertiary hover:text-red-400 hover:bg-red-400/10 transition-colors"
-          title="Delete plugin"
-        >
-          ×
-        </button>
+        <div className="flex flex-col items-end gap-1 shrink-0 pt-0.5">
+          <PluginStatusBadge
+            status={status}
+            latestVersion={diff?.latestVersion ?? undefined}
+          />
+          <button
+            aria-label={`Plugin actions for ${plugin.name}`}
+            data-testid={`plugin-actions-${plugin.id}`}
+            onClick={() =>
+              setOpenMenuFor((cur) => (cur === plugin.id ? null : plugin.id))
+            }
+            className="text-aide-text-tertiary hover:text-aide-text-primary px-1 transition-colors"
+          >
+            ···
+          </button>
+          {openMenuFor === plugin.id && (
+            <ActionMenu
+              items={buildActionItems(plugin)}
+              onClose={() => setOpenMenuFor(null)}
+            />
+          )}
+        </div>
       </div>
-    </div>
-  );
+    );
+  };
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
       {/* Header */}
-      <div className="px-3 py-2 shrink-0 border-b border-aide-border">
+      <div className="flex items-center gap-2 px-3 py-2 shrink-0 border-b border-aide-border">
         <span className="text-[10px] uppercase tracking-widest text-aide-text-tertiary font-mono">
-          Plugins {plugins.length > 0 ? `(${activeCount}/${plugins.length} active)` : ''}
+          Plugins
+        </span>
+        <span className="text-[10px] font-mono text-aide-text-secondary bg-aide-surface-elevated rounded px-1.5 py-0.5">
+          {plugins.length}
         </span>
       </div>
 
-      {/* Agent-driven plugin creation hint */}
-      <div className="px-3 py-2 shrink-0 border-b border-aide-border">
-        <p className="text-[10px] font-mono text-aide-text-secondary leading-relaxed">
-          Ask your AI agent in the terminal to create plugins.
-          <span className="text-aide-text-tertiary block mt-0.5">
-            e.g. &ldquo;Make a plugin that formats JSON files&rdquo;
-          </span>
-        </p>
+      {/* Add from registry button */}
+      <div className="px-3 py-2 shrink-0">
+        <button
+          onClick={() => setBrowserOpen(true)}
+          data-testid="add-from-registry"
+          className="w-full px-3 py-2 text-xs font-mono rounded bg-aide-accent text-aide-background hover:opacity-90 transition-opacity"
+        >
+          + Add from registry
+        </button>
+      </div>
+
+      {/* Generate plugin form */}
+      <div className="px-3 pb-2 shrink-0 flex flex-col gap-2 border-b border-aide-border">
+        <input
+          type="text"
+          value={genName}
+          onChange={(e) => setGenName(e.target.value)}
+          placeholder="plugin name"
+          aria-label="Plugin name"
+          className="w-full bg-aide-background border border-aide-border rounded px-2 py-1.5 text-xs font-mono text-aide-text-primary focus:outline-none focus:border-aide-accent"
+        />
+        <input
+          type="text"
+          value={genDesc}
+          onChange={(e) => setGenDesc(e.target.value)}
+          placeholder="describe what it does"
+          aria-label="Plugin description"
+          className="w-full bg-aide-background border border-aide-border rounded px-2 py-1.5 text-xs font-mono text-aide-text-primary focus:outline-none focus:border-aide-accent"
+        />
+        <button
+          onClick={handleGenerate}
+          disabled={!genName.trim() || generating}
+          className="w-full px-3 py-1.5 text-xs font-mono rounded border border-aide-accent text-aide-accent hover:bg-aide-accent/10 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {generating ? 'Generating…' : '+ Generate plugin'}
+        </button>
+        {generateError && (
+          <span className="text-[10px] font-mono text-smalti-crimson">{generateError}</span>
+        )}
       </div>
 
       {/* Plugin list */}
@@ -133,13 +357,13 @@ export function PluginPanel() {
         )}
 
         {!loading && error && (
-          <div className="px-3 py-2 text-[10px] font-mono text-red-400">{error}</div>
+          <div className="px-3 py-2 text-[10px] font-mono text-smalti-crimson">{error}</div>
         )}
 
         {!loading && !error && plugins.length === 0 && (
           <div className="flex flex-col items-center justify-center py-8 gap-1 text-aide-text-tertiary text-xs font-mono">
             <span>No plugins installed</span>
-            <span className="text-[10px]">Ask an agent to create one</span>
+            <span className="text-[10px]">Use + Add from registry, or generate one</span>
           </div>
         )}
 
@@ -150,17 +374,17 @@ export function PluginPanel() {
         )}
       </div>
 
-      {/* Delete confirmation dialog */}
+      {/* Delete confirmation */}
       {deleteConfirm && (
-        <div className="absolute inset-0 flex items-center justify-center bg-black/50 z-10">
-          <div className="bg-aide-surface-elevated border border-aide-border rounded-lg px-4 py-3 flex flex-col gap-3 max-w-[200px] w-full mx-3">
+        <div className="absolute inset-0 flex items-center justify-center bg-black/50 z-30">
+          <div className="bg-aide-surface-elevated border border-aide-border rounded-lg px-4 py-3 flex flex-col gap-3 max-w-[240px] w-full mx-3">
             <span className="text-xs font-mono text-aide-text-primary">
               Delete &ldquo;{deleteConfirm}&rdquo;?
             </span>
             <div className="flex gap-2">
               <button
                 onClick={handleDeleteConfirm}
-                className="flex-1 px-2 py-1 text-[10px] font-mono bg-red-500 text-white rounded hover:bg-red-600 transition-colors"
+                className="flex-1 px-2 py-1 text-[10px] font-mono bg-smalti-crimson text-white rounded hover:opacity-90 transition-opacity"
               >
                 Delete
               </button>
@@ -173,6 +397,74 @@ export function PluginPanel() {
             </div>
           </div>
         </div>
+      )}
+
+      {/* Registry browser modal */}
+      <RegistryBrowser
+        open={browserOpen}
+        onClose={() => setBrowserOpen(false)}
+        installedNames={installedNames}
+        updateAvailableIds={updateAvailableIds}
+        onImport={async (registryId) => {
+          try {
+            await importFromRegistry(registryId);
+          } catch (e) {
+            console.error('Import failed', e);
+          }
+        }}
+      />
+
+      {/* Fork dialog */}
+      {forkTarget && (
+        <ForkAsNewPluginDialog
+          open
+          onClose={() => setForkTarget(null)}
+          originalPluginName={forkTarget.name}
+          originalPluginId={forkTarget.id}
+          onConfirm={async (opts) => {
+            await forkAsNew(forkTarget.name, {
+              newName: opts.newName,
+              newDescription: opts.newDescription,
+              restoreOriginal: opts.restoreOriginal,
+            });
+          }}
+        />
+      )}
+
+      {/* Update confirm dialog */}
+      {updateTarget && (
+        <UpdateConfirmDialog
+          open
+          onClose={() => setUpdateTarget(null)}
+          pluginName={updateTarget.name}
+          latestVersion={registryDiffs[updateTarget.name]?.latestVersion ?? '?'}
+          modifiedFiles={[]}
+          onConfirm={async () => {
+            await applyUpdate(updateTarget.name);
+          }}
+          onForkInstead={() => {
+            const t = updateTarget;
+            setUpdateTarget(null);
+            setForkTarget(t);
+          }}
+        />
+      )}
+
+      {/* Publish conflict dialog */}
+      {publishConflict && (
+        <PublishConflictDialog
+          open
+          onClose={() => setPublishConflict(null)}
+          pluginName={publishConflict.plugin.name}
+          workspaceVersion={
+            publishConflict.conflict.workspaceVersion ??
+            publishConflict.plugin.version
+          }
+          registryVersion={publishConflict.conflict.registryVersion ?? '?'}
+          onPullLatest={async () => {
+            await applyUpdate(publishConflict.plugin.name);
+          }}
+        />
       )}
     </div>
   );

--- a/src/renderer/components/plugin/registry/PluginStatusBadge.tsx
+++ b/src/renderer/components/plugin/registry/PluginStatusBadge.tsx
@@ -1,0 +1,57 @@
+import type { SyncStatus } from '../../../../types/plugin-registry';
+
+interface PluginStatusBadgeProps {
+  status: SyncStatus;
+  latestVersion?: string;
+}
+
+/**
+ * Small pill badge showing a plugin's sync status with the global registry.
+ * Color-coded per status:
+ * - synced            → accent (cyan)
+ * - update-available  → accent-info (sky blue) + "update X.Y.Z →"
+ * - locally-modified  → accent-warning (gold)
+ * - unknown           → text-tertiary (local only)
+ */
+export function PluginStatusBadge({ status, latestVersion }: PluginStatusBadgeProps) {
+  const cfg = (() => {
+    switch (status) {
+      case 'synced':
+        return {
+          label: 'synced',
+          cls: 'bg-aide-accent/15 text-aide-accent border border-aide-accent/40',
+          testColor: 'accent',
+        };
+      case 'update-available':
+        return {
+          label: latestVersion ? `update ${latestVersion} →` : 'update available',
+          cls: 'bg-aide-accent-info/15 text-aide-accent-info border border-aide-accent-info/40',
+          testColor: 'accent-info',
+        };
+      case 'locally-modified':
+        return {
+          label: 'locally modified',
+          cls: 'bg-aide-accent-warning/15 text-aide-accent-warning border border-aide-accent-warning/40',
+          testColor: 'accent-warning',
+        };
+      case 'unknown':
+      default:
+        return {
+          label: 'local only',
+          cls: 'bg-aide-text-tertiary/15 text-aide-text-tertiary border border-aide-text-tertiary/40',
+          testColor: 'tertiary',
+        };
+    }
+  })();
+
+  return (
+    <span
+      data-status={status}
+      data-color={cfg.testColor}
+      className={`inline-flex items-center font-mono leading-none rounded ${cfg.cls}`}
+      style={{ fontSize: 10, padding: '2px 6px' }}
+    >
+      {cfg.label}
+    </span>
+  );
+}

--- a/src/renderer/components/plugin/registry/RegistryBrowser.tsx
+++ b/src/renderer/components/plugin/registry/RegistryBrowser.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { RegistrySummary } from '../../../../types/plugin-registry';
+import { BaseDialog } from './dialogs/BaseDialog';
+
+type Category = 'all' | 'installed' | 'updates' | 'recent';
+
+interface RegistryBrowserProps {
+  open: boolean;
+  onClose: () => void;
+  /** Names of plugins already installed in the workspace (for "Installed" badge). */
+  installedNames: Set<string>;
+  /** Registry-ids of plugins that have an update available locally. */
+  updateAvailableIds?: Set<string>;
+  onImport: (registryId: string) => Promise<void> | void;
+}
+
+const PluginIconStub = () => (
+  <div className="grid grid-cols-2 grid-rows-2 gap-0.5 shrink-0" style={{ width: 28, height: 28 }}>
+    <span className="bg-smalti-cyan rounded-sm" />
+    <span className="bg-aide-text-tertiary/50 rounded-sm" />
+    <span className="bg-aide-text-tertiary/50 rounded-sm" />
+    <span className="bg-smalti-gold rounded-sm" />
+  </div>
+);
+
+export function RegistryBrowser({
+  open,
+  onClose,
+  installedNames,
+  updateAvailableIds,
+  onImport,
+}: RegistryBrowserProps) {
+  const [summaries, setSummaries] = useState<RegistrySummary[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [category, setCategory] = useState<Category>('all');
+  const [search, setSearch] = useState('');
+  const [importing, setImporting] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const list = await window.aide.plugin.registry.list();
+        if (!cancelled) setSummaries(list);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load registry');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const filtered = useMemo(() => {
+    if (!summaries) return [];
+    const lower = search.trim().toLowerCase();
+    return summaries.filter((s) => {
+      if (lower) {
+        const hay = `${s.name} ${s.description}`.toLowerCase();
+        if (!hay.includes(lower)) return false;
+      }
+      switch (category) {
+        case 'installed':
+          return installedNames.has(s.name);
+        case 'updates':
+          return Boolean(updateAvailableIds?.has(s.id));
+        case 'recent':
+          // Stub: registry summary has no createdAt, treat as no-op (show all).
+          return true;
+        case 'all':
+        default:
+          return true;
+      }
+    });
+  }, [summaries, search, category, installedNames, updateAvailableIds]);
+
+  const handleImport = async (id: string) => {
+    if (importing) return;
+    setImporting(id);
+    try {
+      await onImport(id);
+    } finally {
+      setImporting(null);
+    }
+  };
+
+  return (
+    <BaseDialog open={open} onClose={onClose} title="Plugin Registry" width={800}>
+      {/* Search row */}
+      <div className="flex items-center gap-3 mb-4">
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search plugins..."
+          aria-label="Search plugins"
+          className="flex-1 bg-aide-background border border-aide-border rounded px-3 py-2 text-xs font-mono text-aide-text-primary focus:outline-none focus:border-aide-accent"
+        />
+      </div>
+
+      <div className="flex gap-4" style={{ minHeight: 380, maxHeight: 460 }}>
+        {/* Categories */}
+        <nav
+          className="flex flex-col gap-1 shrink-0 border-r border-aide-border pr-3"
+          style={{ width: 160 }}
+          aria-label="Registry categories"
+        >
+          {(
+            [
+              { key: 'all', label: 'All' },
+              { key: 'installed', label: 'Installed' },
+              { key: 'updates', label: 'Updates available' },
+              { key: 'recent', label: 'Recently added' },
+            ] as { key: Category; label: string }[]
+          ).map((c) => {
+            const active = category === c.key;
+            return (
+              <button
+                key={c.key}
+                onClick={() => setCategory(c.key)}
+                data-testid={`registry-category-${c.key}`}
+                aria-current={active ? 'page' : undefined}
+                className={`text-left text-xs font-mono px-2 py-1.5 rounded transition-colors ${
+                  active
+                    ? 'bg-aide-surface text-aide-text-primary'
+                    : 'text-aide-text-secondary hover:text-aide-text-primary'
+                }`}
+              >
+                {c.label}
+              </button>
+            );
+          })}
+        </nav>
+
+        {/* Card grid */}
+        <div className="flex-1 overflow-y-auto pr-1">
+          {loading && (
+            <div className="text-xs font-mono text-aide-text-secondary py-6 text-center">
+              Loading registry…
+            </div>
+          )}
+          {!loading && error && (
+            <div className="text-xs font-mono text-smalti-crimson py-6 text-center">
+              {error}
+            </div>
+          )}
+          {!loading && !error && filtered.length === 0 && (
+            <div className="text-xs font-mono text-aide-text-tertiary py-6 text-center">
+              No plugins found.
+            </div>
+          )}
+          {!loading && !error && filtered.length > 0 && (
+            <div className="grid grid-cols-2 gap-3" data-testid="registry-grid">
+              {filtered.map((s) => {
+                const isInstalled = installedNames.has(s.name);
+                return (
+                  <article
+                    key={s.id}
+                    data-testid={`registry-card-${s.id}`}
+                    className="border border-aide-border rounded-lg flex flex-col gap-3 bg-aide-background"
+                    style={{ padding: 16 }}
+                  >
+                    <header className="flex items-start gap-3">
+                      <PluginIconStub />
+                      <div className="flex-1 min-w-0">
+                        <h3 className="text-sm font-mono text-aide-text-primary truncate m-0">
+                          {s.name}
+                        </h3>
+                        <p className="text-[11px] font-mono text-aide-text-secondary mt-1 leading-snug line-clamp-2">
+                          {s.description}
+                        </p>
+                      </div>
+                    </header>
+
+                    <footer className="flex items-center justify-between mt-auto">
+                      <span className="inline-flex items-center text-[10px] font-mono text-aide-accent border border-aide-border rounded px-1.5 py-0.5">
+                        v{s.latest}
+                      </span>
+                      {isInstalled ? (
+                        <span
+                          data-testid={`registry-installed-${s.id}`}
+                          className="text-[10px] font-mono text-aide-text-tertiary"
+                        >
+                          Installed
+                        </span>
+                      ) : (
+                        <button
+                          onClick={() => handleImport(s.id)}
+                          disabled={importing === s.id}
+                          data-testid={`registry-import-${s.id}`}
+                          className="px-3 py-1 text-xs font-mono rounded border border-aide-accent text-aide-accent hover:bg-aide-accent hover:text-aide-background transition-colors disabled:opacity-40"
+                        >
+                          {importing === s.id ? 'Importing…' : 'Import'}
+                        </button>
+                      )}
+                    </footer>
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </BaseDialog>
+  );
+}

--- a/src/renderer/components/plugin/registry/dialogs/BaseDialog.tsx
+++ b/src/renderer/components/plugin/registry/dialogs/BaseDialog.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useRef, type ReactNode } from 'react';
+
+interface BaseDialogProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  width?: number;
+  children: ReactNode;
+  footer?: ReactNode;
+  /** Optional icon prefix in the header (e.g. warning triangle). */
+  headerIcon?: ReactNode;
+}
+
+/**
+ * Reusable modal dialog: centered card over a translucent overlay.
+ * - ESC closes
+ * - Overlay click closes
+ * - Close (×) button autoFocus for basic keyboard accessibility
+ */
+export function BaseDialog({
+  open,
+  onClose,
+  title,
+  width = 480,
+  children,
+  footer,
+  headerIcon,
+}: BaseDialogProps) {
+  const closeBtnRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  useEffect(() => {
+    if (open) {
+      // Defer to next frame so the dialog mounts first
+      requestAnimationFrame(() => closeBtnRef.current?.focus());
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      onClick={onClose}
+    >
+      <div
+        data-overlay
+        className="absolute inset-0 bg-black/60"
+        aria-hidden="true"
+      />
+      <div
+        className="relative bg-aide-surface-elevated border border-aide-border rounded-lg shadow-xl flex flex-col overflow-hidden"
+        style={{ width }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div
+          className="flex items-center gap-2 border-b border-aide-border"
+          style={{ padding: '20px 24px' }}
+        >
+          {headerIcon && <span className="shrink-0">{headerIcon}</span>}
+          <h2 className="flex-1 font-mono text-aide-text-primary text-base font-semibold m-0 truncate">
+            {title}
+          </h2>
+          <button
+            ref={closeBtnRef}
+            onClick={onClose}
+            aria-label="Close dialog"
+            className="text-aide-text-tertiary hover:text-aide-text-primary transition-colors px-2 py-1 rounded -mr-2"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Body */}
+        <div style={{ padding: '20px 24px' }} className="text-aide-text-primary">
+          {children}
+        </div>
+
+        {/* Footer */}
+        {footer && (
+          <div
+            className="flex items-center justify-end gap-2 border-t border-aide-border bg-aide-surface"
+            style={{ padding: '14px 24px' }}
+          >
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/plugin/registry/dialogs/ForkAsNewPluginDialog.tsx
+++ b/src/renderer/components/plugin/registry/dialogs/ForkAsNewPluginDialog.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from 'react';
+import { BaseDialog } from './BaseDialog';
+
+interface ForkAsNewPluginDialogProps {
+  open: boolean;
+  onClose: () => void;
+  originalPluginName: string;
+  originalPluginId: string;
+  onConfirm: (opts: {
+    newName: string;
+    newDescription: string;
+    restoreOriginal: boolean;
+  }) => Promise<void>;
+}
+
+export function ForkAsNewPluginDialog({
+  open,
+  onClose,
+  originalPluginName,
+  originalPluginId,
+  onConfirm,
+}: ForkAsNewPluginDialogProps) {
+  const [newName, setNewName] = useState(`${originalPluginName}-fork`);
+  const [newDescription, setNewDescription] = useState(
+    `Custom variant of ${originalPluginName}`
+  );
+  const [restoreOriginal, setRestoreOriginal] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Reset on open with the (possibly updated) original name
+  useEffect(() => {
+    if (open) {
+      setNewName(`${originalPluginName}-fork`);
+      setNewDescription(`Custom variant of ${originalPluginName}`);
+      setRestoreOriginal(false);
+      setSubmitting(false);
+    }
+  }, [open, originalPluginName]);
+
+  const handleConfirm = async () => {
+    if (!newName.trim() || submitting) return;
+    setSubmitting(true);
+    try {
+      await onConfirm({
+        newName: newName.trim(),
+        newDescription: newDescription.trim(),
+        restoreOriginal,
+      });
+      onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <BaseDialog
+      open={open}
+      onClose={onClose}
+      title="Fork as new plugin"
+      width={480}
+      footer={
+        <>
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs font-mono rounded border border-aide-border text-aide-text-secondary hover:text-aide-text-primary hover:border-aide-text-secondary transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={!newName.trim() || submitting}
+            data-testid="fork-confirm"
+            className="px-3 py-1.5 text-xs font-mono rounded bg-aide-accent text-aide-background hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {submitting ? 'Forking…' : 'Fork plugin'}
+          </button>
+        </>
+      }
+    >
+      <p className="text-xs font-mono text-aide-text-secondary mb-4 leading-relaxed">
+        This creates a new plugin with its own identity. Updates from the
+        original will no longer apply.
+      </p>
+
+      <label className="block">
+        <span className="text-xs font-mono text-aide-text-primary">New name</span>
+        <input
+          type="text"
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          data-testid="fork-name-input"
+          className="mt-1 w-full bg-aide-background border border-aide-border rounded px-3 py-2 text-xs font-mono text-aide-text-primary focus:outline-none focus:border-aide-accent"
+        />
+      </label>
+
+      <label className="block mt-4">
+        <span className="text-xs font-mono text-aide-text-primary">Description</span>
+        <input
+          type="text"
+          value={newDescription}
+          onChange={(e) => setNewDescription(e.target.value)}
+          data-testid="fork-description-input"
+          className="mt-1 w-full bg-aide-background border border-aide-border rounded px-3 py-2 text-xs font-mono text-aide-text-primary focus:outline-none focus:border-aide-accent"
+        />
+      </label>
+
+      <fieldset className="mt-5">
+        <legend className="text-xs font-mono text-aide-text-primary mb-2">
+          Original plugin
+        </legend>
+        <label className="flex items-center gap-2 cursor-pointer py-1">
+          <input
+            type="radio"
+            name={`fork-original-${originalPluginId}`}
+            checked={!restoreOriginal}
+            onChange={() => setRestoreOriginal(false)}
+            data-testid="fork-keep-original"
+            className="accent-aide-accent"
+          />
+          <span className="text-xs font-mono text-aide-text-primary">
+            Keep original as-is (recommended)
+          </span>
+        </label>
+        <label className="flex items-center gap-2 cursor-pointer py-1">
+          <input
+            type="radio"
+            name={`fork-original-${originalPluginId}`}
+            checked={restoreOriginal}
+            onChange={() => setRestoreOriginal(true)}
+            data-testid="fork-restore-original"
+            className="accent-aide-accent"
+          />
+          <span className="text-xs font-mono text-aide-text-primary">
+            Restore original to upstream
+          </span>
+        </label>
+      </fieldset>
+    </BaseDialog>
+  );
+}

--- a/src/renderer/components/plugin/registry/dialogs/PublishConflictDialog.tsx
+++ b/src/renderer/components/plugin/registry/dialogs/PublishConflictDialog.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import { BaseDialog } from './BaseDialog';
+
+interface PublishConflictDialogProps {
+  open: boolean;
+  onClose: () => void;
+  pluginName: string;
+  workspaceVersion: string;
+  registryVersion: string;
+  onPullLatest: () => Promise<void>;
+}
+
+const WarningIcon = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    className="text-aide-accent-warning"
+    aria-hidden="true"
+  >
+    <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
+    <line x1="12" y1="9" x2="12" y2="13" />
+    <circle cx="12" cy="17" r="0.5" fill="currentColor" />
+  </svg>
+);
+
+export function PublishConflictDialog({
+  open,
+  onClose,
+  pluginName,
+  workspaceVersion,
+  registryVersion,
+  onPullLatest,
+}: PublishConflictDialogProps) {
+  const [submitting, setSubmitting] = useState(false);
+
+  const handlePull = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      await onPullLatest();
+      onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <BaseDialog
+      open={open}
+      onClose={onClose}
+      title="Pull latest before publishing"
+      width={480}
+      headerIcon={<WarningIcon />}
+      footer={
+        <>
+          <button
+            onClick={onClose}
+            data-testid="publish-conflict-cancel"
+            className="px-3 py-1.5 text-xs font-mono rounded border border-aide-border text-aide-text-secondary hover:text-aide-text-primary transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handlePull}
+            disabled={submitting}
+            data-testid="publish-conflict-pull"
+            className="px-3 py-1.5 text-xs font-mono rounded bg-aide-accent text-aide-background hover:opacity-90 transition-opacity disabled:opacity-40"
+          >
+            {submitting ? 'Pulling…' : 'Pull latest'}
+          </button>
+        </>
+      }
+    >
+      <p className="text-xs font-mono text-aide-text-primary leading-relaxed">
+        Registry has a newer version (
+        <span className="font-semibold">{registryVersion}</span>) than your base
+        of <span className="font-semibold">{pluginName}</span> (
+        <span className="font-semibold">{workspaceVersion}</span>). Publishing
+        now is blocked.
+      </p>
+
+      <div className="flex items-center justify-center gap-3 my-5">
+        <div
+          className="bg-aide-background border border-aide-border rounded text-center"
+          style={{ padding: '12px 16px', minWidth: 110 }}
+        >
+          <div className="text-[10px] font-mono text-aide-text-tertiary uppercase tracking-wider">
+            Your base
+          </div>
+          <div className="text-base font-mono text-aide-text-primary mt-1">
+            {workspaceVersion}
+          </div>
+        </div>
+        <span className="text-aide-text-tertiary">→</span>
+        <div
+          className="bg-aide-background border border-aide-accent rounded text-center"
+          style={{ padding: '12px 16px', minWidth: 110 }}
+        >
+          <div className="text-[10px] font-mono text-aide-accent uppercase tracking-wider">
+            Registry latest
+          </div>
+          <div className="text-base font-mono text-aide-accent mt-1">
+            {registryVersion}
+          </div>
+        </div>
+      </div>
+
+      <p className="text-[11px] font-mono text-aide-text-tertiary leading-relaxed">
+        Pull the latest version first, then re-apply your changes if needed.
+      </p>
+    </BaseDialog>
+  );
+}

--- a/src/renderer/components/plugin/registry/dialogs/UpdateConfirmDialog.tsx
+++ b/src/renderer/components/plugin/registry/dialogs/UpdateConfirmDialog.tsx
@@ -1,0 +1,113 @@
+import { useState } from 'react';
+import { BaseDialog } from './BaseDialog';
+
+interface UpdateConfirmDialogProps {
+  open: boolean;
+  onClose: () => void;
+  pluginName: string;
+  latestVersion: string;
+  modifiedFiles: string[];
+  onConfirm: () => Promise<void>;
+  onForkInstead: () => void;
+}
+
+const WarningIcon = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    className="text-aide-accent-warning"
+    aria-hidden="true"
+  >
+    <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
+    <line x1="12" y1="9" x2="12" y2="13" />
+    <circle cx="12" cy="17" r="0.5" fill="currentColor" />
+  </svg>
+);
+
+export function UpdateConfirmDialog({
+  open,
+  onClose,
+  pluginName,
+  latestVersion,
+  modifiedFiles,
+  onConfirm,
+  onForkInstead,
+}: UpdateConfirmDialogProps) {
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleConfirm = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      await onConfirm();
+      onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <BaseDialog
+      open={open}
+      onClose={onClose}
+      title="Update will overwrite local changes"
+      width={480}
+      headerIcon={<WarningIcon />}
+      footer={
+        <>
+          <button
+            onClick={onClose}
+            data-testid="update-cancel"
+            className="px-3 py-1.5 text-xs font-mono rounded border border-aide-border text-aide-text-secondary hover:text-aide-text-primary transition-colors mr-auto"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onForkInstead}
+            data-testid="update-fork-instead"
+            className="px-3 py-1.5 text-xs font-mono rounded text-aide-text-secondary hover:text-aide-text-primary transition-colors"
+          >
+            Fork instead
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={submitting}
+            data-testid="update-discard"
+            className="px-3 py-1.5 text-xs font-mono rounded bg-smalti-crimson text-white hover:opacity-90 transition-opacity disabled:opacity-40"
+          >
+            {submitting ? 'Updating…' : 'Discard & update'}
+          </button>
+        </>
+      }
+    >
+      <p className="text-xs font-mono text-aide-text-primary leading-relaxed">
+        <span className="font-semibold">{pluginName}</span> has local
+        modifications that will be lost when updating to{' '}
+        <span className="font-semibold">{latestVersion}</span>.
+      </p>
+
+      {modifiedFiles.length > 0 && (
+        <div
+          className="mt-3 bg-aide-background border border-aide-border rounded font-mono text-[11px] text-aide-text-secondary"
+          style={{ padding: '10px 14px' }}
+        >
+          {modifiedFiles.map((file) => (
+            <div key={file} className="flex items-center gap-3 py-0.5">
+              <span className="text-aide-text-primary">{file}</span>
+              <span className="text-aide-text-tertiary">·</span>
+              <span>modified</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <p className="mt-3 text-[11px] font-mono text-aide-text-tertiary leading-relaxed">
+        To preserve your changes, fork the plugin first.
+      </p>
+    </BaseDialog>
+  );
+}

--- a/src/renderer/stores/plugin-store.ts
+++ b/src/renderer/stores/plugin-store.ts
@@ -1,8 +1,15 @@
 import { create } from 'zustand';
 import type { PluginInfo, TerminalTab } from '../../types/ipc';
+import type { RegistryDiff, RegistrySummary } from '../../types/plugin-registry';
 import { useLayoutStore } from './layout-store';
 import { useTerminalStore } from './terminal-store';
 import { deactivatingPluginIds } from './plugin-deactivate-guard';
+
+export interface PublishConflict {
+  reason: 'pull-latest-first' | string;
+  workspaceVersion?: string;
+  registryVersion?: string;
+}
 
 interface PluginState {
   plugins: PluginInfo[];
@@ -10,11 +17,33 @@ interface PluginState {
   generating: boolean;
   error: string | null;
   generateError: string | null;
+
+  // Phase 3: registry state
+  registryDiffs: Record<string, RegistryDiff | null>;
+  registrySummaries: RegistrySummary[];
+  registryLoading: boolean;
+
   loadPlugins: () => Promise<void>;
   activate: (id: string) => Promise<void>;
   deactivate: (id: string) => Promise<void>;
   deletePlugin: (name: string) => Promise<void>;
   generate: (name: string, description: string) => Promise<{ id: string } | null>;
+
+  refreshRegistryDiffs: () => Promise<void>;
+  refreshRegistrySummaries: () => Promise<void>;
+
+  applyUpdate: (pluginName: string) => Promise<void>;
+  forkAsNew: (
+    originalName: string,
+    opts: { newName: string; newDescription?: string; restoreOriginal: boolean }
+  ) => Promise<void>;
+  /**
+   * Publish workspace plugin to global registry. Resolves to a PublishConflict
+   * descriptor on conflict (e.g. registry has newer version) so the UI can
+   * surface PublishConflictDialog. Resolves to null on success.
+   */
+  publish: (pluginName: string, bumpPatch?: boolean) => Promise<PublishConflict | null>;
+  importFromRegistry: (registryId: string, targetName?: string) => Promise<void>;
 }
 
 export const usePluginStore = create<PluginState>((set, get) => ({
@@ -24,11 +53,17 @@ export const usePluginStore = create<PluginState>((set, get) => ({
   error: null,
   generateError: null,
 
+  registryDiffs: {},
+  registrySummaries: [],
+  registryLoading: false,
+
   loadPlugins: async () => {
     set({ loading: true, error: null });
     try {
       const plugins = await window.aide.plugin.list();
       set({ plugins, loading: false });
+      // Best-effort registry diff refresh after a list reload — non-blocking.
+      void get().refreshRegistryDiffs();
     } catch (e) {
       set({ loading: false, error: e instanceof Error ? e.message : 'Failed to load plugins' });
     }
@@ -71,17 +106,11 @@ export const usePluginStore = create<PluginState>((set, get) => ({
   },
 
   deactivate: async (id: string) => {
-    // Guard: layout-store.removeTabFromPane auto-deactivates plugin tabs when
-    // they are closed directly (× click, ⌘W). That path calls back into
-    // window.aide.plugin.deactivate, which would recurse here. By marking
-    // the id as in-flight, we tell the layout-store hook to skip its own
-    // deactivate side effect while this function owns the lifecycle.
     deactivatingPluginIds.add(id);
     try {
       await window.aide.plugin.deactivate(id);
       const plugins = await window.aide.plugin.list();
       set({ plugins });
-      // Remove plugin tab from all panes
       const layout = useLayoutStore.getState();
       const allPanes = layout.getAllPanes();
       for (const pane of allPanes) {
@@ -91,7 +120,6 @@ export const usePluginStore = create<PluginState>((set, get) => ({
           useTerminalStore.getState().removeTab(pluginTab.id);
         }
       }
-      // Persist plugin active state immediately — don't rely on beforeunload
       const { useWorkspaceStore } = await import('./workspace-store');
       const wsId = useWorkspaceStore.getState().activeWorkspaceId;
       if (wsId) {
@@ -106,16 +134,21 @@ export const usePluginStore = create<PluginState>((set, get) => ({
 
   deletePlugin: async (name: string) => {
     await window.aide.plugin.delete(name);
-    set({ plugins: get().plugins.filter((p) => p.name !== name) });
+    set({
+      plugins: get().plugins.filter((p) => p.name !== name),
+      registryDiffs: Object.fromEntries(
+        Object.entries(get().registryDiffs).filter(([k]) => k !== name)
+      ),
+    });
   },
 
   generate: async (name: string, description: string) => {
     set({ generating: true, generateError: null });
     try {
       const spec = await window.aide.plugin.generate(name, description);
-      // Reload the plugin list after generation
       const plugins = await window.aide.plugin.list();
       set({ plugins, generating: false });
+      void get().refreshRegistryDiffs();
       return { id: spec.id };
     } catch (e) {
       set({
@@ -124,5 +157,114 @@ export const usePluginStore = create<PluginState>((set, get) => ({
       });
       return null;
     }
+  },
+
+  refreshRegistryDiffs: async () => {
+    const plugins = get().plugins;
+    if (plugins.length === 0) {
+      set({ registryDiffs: {} });
+      return;
+    }
+    try {
+      const entries = await Promise.all(
+        plugins.map(async (p) => {
+          try {
+            const diff = await window.aide.plugin.registry.diff(p.name);
+            return [p.name, diff] as const;
+          } catch {
+            return [p.name, null] as const;
+          }
+        })
+      );
+      const diffs: Record<string, RegistryDiff | null> = {};
+      for (const [name, diff] of entries) diffs[name] = diff;
+      set({ registryDiffs: diffs });
+    } catch (e) {
+      set({ error: e instanceof Error ? e.message : 'Failed to load registry diffs' });
+    }
+  },
+
+  refreshRegistrySummaries: async () => {
+    set({ registryLoading: true });
+    try {
+      const summaries = await window.aide.plugin.registry.list();
+      set({ registrySummaries: summaries, registryLoading: false });
+    } catch (e) {
+      set({
+        registryLoading: false,
+        error: e instanceof Error ? e.message : 'Failed to load registry summaries',
+      });
+    }
+  },
+
+  applyUpdate: async (pluginName: string) => {
+    const diff = get().registryDiffs[pluginName];
+    if (!diff) throw new Error(`No registry diff for "${pluginName}"`);
+    const result = await window.aide.plugin.registry.pull(
+      diff.registryId,
+      diff.latestVersion ?? undefined,
+      pluginName
+    );
+    if (!result.ok) {
+      throw new Error(`Update failed: ${result.reason}`);
+    }
+    await get().loadPlugins();
+  },
+
+  forkAsNew: async (originalName, opts) => {
+    const diff = get().registryDiffs[originalName];
+    if (!diff) throw new Error(`No registry diff for "${originalName}"`);
+    // Pull the original (registry version) into a new workspace plugin name.
+    const pull = await window.aide.plugin.registry.pull(
+      diff.registryId,
+      diff.installedVersion ?? diff.latestVersion ?? undefined,
+      opts.newName
+    );
+    if (!pull.ok) {
+      throw new Error(`Fork failed: ${pull.reason}`);
+    }
+    if (opts.restoreOriginal) {
+      // Restoring original to upstream = re-pull latest over the original name.
+      await window.aide.plugin.registry.pull(
+        diff.registryId,
+        diff.latestVersion ?? undefined,
+        originalName
+      );
+    }
+    await get().loadPlugins();
+  },
+
+  publish: async (pluginName, bumpPatch = true) => {
+    try {
+      const result = await window.aide.plugin.registry.push(pluginName, { bumpPatch });
+      // Backend may return { ok:false, reason:'pull-latest-first', ... } as a structured error.
+      if (result && typeof result === 'object' && 'ok' in result && (result as { ok: boolean }).ok === false) {
+        const r = result as PublishConflict & { ok: false };
+        await get().refreshRegistryDiffs();
+        return r;
+      }
+      await get().loadPlugins();
+      return null;
+    } catch (e) {
+      // Surface as conflict if the backend throws with a recognizable reason.
+      const msg = e instanceof Error ? e.message : String(e);
+      if (msg.toLowerCase().includes('pull-latest-first') || msg.toLowerCase().includes('pull latest')) {
+        const diff = get().registryDiffs[pluginName];
+        return {
+          reason: 'pull-latest-first',
+          workspaceVersion: diff?.installedVersion ?? undefined,
+          registryVersion: diff?.latestVersion ?? undefined,
+        };
+      }
+      throw e;
+    }
+  },
+
+  importFromRegistry: async (registryId, targetName) => {
+    const result = await window.aide.plugin.registry.pull(registryId, undefined, targetName);
+    if (!result.ok) {
+      throw new Error(`Import failed: ${result.reason}`);
+    }
+    await get().loadPlugins();
   },
 }));

--- a/tests/unit/fork-dialog.test.tsx
+++ b/tests/unit/fork-dialog.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent, act, waitFor } from '@testing-library/react';
+import { ForkAsNewPluginDialog } from '../../src/renderer/components/plugin/registry/dialogs/ForkAsNewPluginDialog';
+
+afterEach(() => cleanup());
+
+const baseProps = {
+  open: true,
+  onClose: () => {},
+  originalPluginName: 'tail-errors',
+  originalPluginId: 'plugin-x',
+};
+
+describe('ForkAsNewPluginDialog', () => {
+  it('seeds new name and description from original', () => {
+    const { getByTestId } = render(
+      <ForkAsNewPluginDialog {...baseProps} onConfirm={vi.fn()} />
+    );
+    const name = getByTestId('fork-name-input') as HTMLInputElement;
+    const desc = getByTestId('fork-description-input') as HTMLInputElement;
+    expect(name.value).toBe('tail-errors-fork');
+    expect(desc.value).toBe('Custom variant of tail-errors');
+  });
+
+  it('toggles restoreOriginal radio', () => {
+    const { getByTestId } = render(
+      <ForkAsNewPluginDialog {...baseProps} onConfirm={vi.fn()} />
+    );
+    const restore = getByTestId('fork-restore-original') as HTMLInputElement;
+    const keep = getByTestId('fork-keep-original') as HTMLInputElement;
+    expect(keep.checked).toBe(true);
+    fireEvent.click(restore);
+    expect(restore.checked).toBe(true);
+    expect(keep.checked).toBe(false);
+  });
+
+  it('calls onConfirm with chosen values when Fork clicked', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    const { getByTestId } = render(
+      <ForkAsNewPluginDialog
+        {...baseProps}
+        onClose={onClose}
+        onConfirm={onConfirm}
+      />
+    );
+    const name = getByTestId('fork-name-input') as HTMLInputElement;
+    fireEvent.change(name, { target: { value: 'my-fork' } });
+    fireEvent.click(getByTestId('fork-restore-original'));
+    await act(async () => {
+      fireEvent.click(getByTestId('fork-confirm'));
+    });
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledWith({
+        newName: 'my-fork',
+        newDescription: 'Custom variant of tail-errors',
+        restoreOriginal: true,
+      });
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it('disables Fork button when name is empty', () => {
+    const { getByTestId } = render(
+      <ForkAsNewPluginDialog {...baseProps} onConfirm={vi.fn()} />
+    );
+    const name = getByTestId('fork-name-input') as HTMLInputElement;
+    fireEvent.change(name, { target: { value: '   ' } });
+    const btn = getByTestId('fork-confirm') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+});

--- a/tests/unit/plugin-status-badge.test.tsx
+++ b/tests/unit/plugin-status-badge.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { PluginStatusBadge } from '../../src/renderer/components/plugin/registry/PluginStatusBadge';
+
+afterEach(() => cleanup());
+
+describe('PluginStatusBadge', () => {
+  it('renders synced label with accent color', () => {
+    const { container } = render(<PluginStatusBadge status="synced" />);
+    const el = container.querySelector('[data-status="synced"]') as HTMLElement;
+    expect(el).toBeTruthy();
+    expect(el.textContent).toBe('synced');
+    expect(el.getAttribute('data-color')).toBe('accent');
+    expect(el.className).toMatch(/text-aide-accent/);
+  });
+
+  it('renders update-available with latest version arrow', () => {
+    const { container } = render(
+      <PluginStatusBadge status="update-available" latestVersion="0.2.1" />
+    );
+    const el = container.querySelector('[data-status="update-available"]') as HTMLElement;
+    expect(el).toBeTruthy();
+    expect(el.textContent).toBe('update 0.2.1 →');
+    expect(el.getAttribute('data-color')).toBe('accent-info');
+    expect(el.className).toMatch(/text-aide-accent-info/);
+  });
+
+  it('renders update-available without version when not provided', () => {
+    const { container } = render(<PluginStatusBadge status="update-available" />);
+    const el = container.querySelector('[data-status="update-available"]') as HTMLElement;
+    expect(el.textContent).toBe('update available');
+  });
+
+  it('renders locally-modified with warning color', () => {
+    const { container } = render(<PluginStatusBadge status="locally-modified" />);
+    const el = container.querySelector('[data-status="locally-modified"]') as HTMLElement;
+    expect(el).toBeTruthy();
+    expect(el.textContent).toBe('locally modified');
+    expect(el.getAttribute('data-color')).toBe('accent-warning');
+    expect(el.className).toMatch(/text-aide-accent-warning/);
+  });
+
+  it('renders unknown as "local only" with tertiary color', () => {
+    const { container } = render(<PluginStatusBadge status="unknown" />);
+    const el = container.querySelector('[data-status="unknown"]') as HTMLElement;
+    expect(el).toBeTruthy();
+    expect(el.textContent).toBe('local only');
+    expect(el.getAttribute('data-color')).toBe('tertiary');
+  });
+});

--- a/tests/unit/plugin-store-registry.test.ts
+++ b/tests/unit/plugin-store-registry.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { PluginInfo } from '../../src/types/ipc';
+import type { RegistryDiff, RegistrySummary } from '../../src/types/plugin-registry';
+
+// --- Mock collaborator stores so plugin-store imports don't blow up.
+vi.mock('../../src/renderer/stores/layout-store', () => ({
+  useLayoutStore: {
+    getState: () => ({
+      getAllPanes: () => [],
+      getFocusedPane: () => null,
+      addTabToPane: vi.fn(),
+      removeTabFromPane: vi.fn(),
+      saveSession: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+vi.mock('../../src/renderer/stores/terminal-store', () => ({
+  useTerminalStore: {
+    getState: () => ({ addTab: vi.fn(), removeTab: vi.fn() }),
+  },
+}));
+vi.mock('../../src/renderer/stores/plugin-deactivate-guard', () => ({
+  deactivatingPluginIds: new Set<string>(),
+}));
+vi.mock('../../src/renderer/stores/workspace-store', () => ({
+  useWorkspaceStore: {
+    getState: () => ({ activeWorkspaceId: null }),
+  },
+}));
+
+interface MockApi {
+  list: ReturnType<typeof vi.fn>;
+  registryList: ReturnType<typeof vi.fn>;
+  registryDiff: ReturnType<typeof vi.fn>;
+  registryPull: ReturnType<typeof vi.fn>;
+  registryPush: ReturnType<typeof vi.fn>;
+  registryRemove: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+}
+
+function setupWindow(): MockApi {
+  const api: MockApi = {
+    list: vi.fn().mockResolvedValue([] as PluginInfo[]),
+    registryList: vi.fn().mockResolvedValue([] as RegistrySummary[]),
+    registryDiff: vi.fn(),
+    registryPull: vi.fn().mockResolvedValue({ ok: true, pluginPath: '/x', contentHash: 'h' }),
+    registryPush: vi.fn().mockResolvedValue({ ok: true }),
+    registryRemove: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+  };
+  (globalThis as unknown as { window: object }).window = {
+    aide: {
+      plugin: {
+        list: api.list,
+        delete: api.delete,
+        activate: vi.fn(),
+        deactivate: vi.fn(),
+        generate: vi.fn(),
+        registry: {
+          list: api.registryList,
+          diff: api.registryDiff,
+          pull: api.registryPull,
+          push: api.registryPush,
+          remove: api.registryRemove,
+        },
+      },
+    },
+  } as unknown as Window;
+  return api;
+}
+
+const mkPlugin = (name: string, id = `plugin-${name}`): PluginInfo => ({
+  id,
+  name,
+  version: '0.1.0',
+  description: '',
+  active: false,
+  tools: [],
+});
+
+const mkDiff = (
+  registryId: string,
+  status: RegistryDiff['status'],
+  latest = '0.2.0',
+  installed = '0.1.0'
+): RegistryDiff => ({
+  registryId,
+  status,
+  installedVersion: installed,
+  latestVersion: latest,
+  installedContentHash: 'sha256:installed',
+  workspaceContentHash: 'sha256:workspace',
+});
+
+describe('plugin-store registry actions', () => {
+  let api: MockApi;
+  // Re-import store fresh per test so state doesn't leak.
+  let store: typeof import('../../src/renderer/stores/plugin-store').usePluginStore;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    api = setupWindow();
+    const mod = await import('../../src/renderer/stores/plugin-store');
+    store = mod.usePluginStore;
+  });
+
+  it('refreshRegistryDiffs fetches diff for each plugin', async () => {
+    api.list.mockResolvedValue([mkPlugin('a'), mkPlugin('b')]);
+    api.registryDiff.mockImplementation((name: string) =>
+      Promise.resolve(mkDiff(`reg-${name}`, 'synced'))
+    );
+
+    await store.getState().loadPlugins();
+    // refreshRegistryDiffs is fired inside loadPlugins (best-effort void).
+    // Wait one microtask cycle.
+    await Promise.resolve();
+    await Promise.resolve();
+    await store.getState().refreshRegistryDiffs();
+
+    expect(api.registryDiff).toHaveBeenCalledWith('a');
+    expect(api.registryDiff).toHaveBeenCalledWith('b');
+    const diffs = store.getState().registryDiffs;
+    expect(diffs.a?.status).toBe('synced');
+    expect(diffs.b?.status).toBe('synced');
+  });
+
+  it('refreshRegistryDiffs empties record when no plugins', async () => {
+    await store.getState().refreshRegistryDiffs();
+    expect(store.getState().registryDiffs).toEqual({});
+  });
+
+  it('applyUpdate calls registry.pull with latest version and target name', async () => {
+    api.list.mockResolvedValue([mkPlugin('a')]);
+    api.registryDiff.mockResolvedValue(mkDiff('reg-a', 'update-available', '0.3.0'));
+
+    await store.getState().loadPlugins();
+    await store.getState().refreshRegistryDiffs();
+    await store.getState().applyUpdate('a');
+
+    expect(api.registryPull).toHaveBeenCalledWith('reg-a', '0.3.0', 'a');
+  });
+
+  it('applyUpdate throws when registry pull returns not ok', async () => {
+    api.list.mockResolvedValue([mkPlugin('a')]);
+    api.registryDiff.mockResolvedValue(mkDiff('reg-a', 'update-available'));
+    api.registryPull.mockResolvedValueOnce({ ok: false, reason: 'corrupt' });
+    await store.getState().loadPlugins();
+    await store.getState().refreshRegistryDiffs();
+    await expect(store.getState().applyUpdate('a')).rejects.toThrow(/corrupt/);
+  });
+
+  it('forkAsNew pulls into newName and optionally restores original', async () => {
+    api.list.mockResolvedValue([mkPlugin('a')]);
+    api.registryDiff.mockResolvedValue(mkDiff('reg-a', 'locally-modified'));
+    await store.getState().loadPlugins();
+    await store.getState().refreshRegistryDiffs();
+
+    await store.getState().forkAsNew('a', {
+      newName: 'a-fork',
+      restoreOriginal: true,
+    });
+
+    // First call: clone original into new name (using installed/version as base)
+    expect(api.registryPull).toHaveBeenNthCalledWith(1, 'reg-a', '0.1.0', 'a-fork');
+    // Second call: restore original to upstream (latest)
+    expect(api.registryPull).toHaveBeenNthCalledWith(2, 'reg-a', '0.2.0', 'a');
+  });
+
+  it('forkAsNew skips restore call when restoreOriginal=false', async () => {
+    api.list.mockResolvedValue([mkPlugin('a')]);
+    api.registryDiff.mockResolvedValue(mkDiff('reg-a', 'locally-modified'));
+    await store.getState().loadPlugins();
+    await store.getState().refreshRegistryDiffs();
+
+    await store.getState().forkAsNew('a', {
+      newName: 'a-fork',
+      restoreOriginal: false,
+    });
+
+    expect(api.registryPull).toHaveBeenCalledTimes(1);
+    expect(api.registryPull).toHaveBeenCalledWith('reg-a', '0.1.0', 'a-fork');
+  });
+
+  it('publish returns null on success', async () => {
+    api.list.mockResolvedValue([mkPlugin('a')]);
+    api.registryPush.mockResolvedValue({ ok: true });
+    await store.getState().loadPlugins();
+    const result = await store.getState().publish('a', true);
+    expect(result).toBeNull();
+    expect(api.registryPush).toHaveBeenCalledWith('a', { bumpPatch: true });
+  });
+
+  it('publish surfaces pull-latest-first conflict from structured response', async () => {
+    api.list.mockResolvedValue([mkPlugin('a')]);
+    api.registryDiff.mockResolvedValue(mkDiff('reg-a', 'update-available', '0.3.0', '0.2.0'));
+    api.registryPush.mockResolvedValue({
+      ok: false,
+      reason: 'pull-latest-first',
+      workspaceVersion: '0.2.0',
+      registryVersion: '0.3.0',
+    });
+    await store.getState().loadPlugins();
+    await store.getState().refreshRegistryDiffs();
+    const result = await store.getState().publish('a');
+    expect(result).not.toBeNull();
+    expect(result?.reason).toBe('pull-latest-first');
+    expect(result?.registryVersion).toBe('0.3.0');
+  });
+
+  it('publish surfaces pull-latest-first conflict from thrown error message', async () => {
+    api.list.mockResolvedValue([mkPlugin('a')]);
+    api.registryDiff.mockResolvedValue(mkDiff('reg-a', 'update-available', '0.3.0'));
+    api.registryPush.mockRejectedValue(new Error('pull-latest-first: registry newer'));
+    await store.getState().loadPlugins();
+    await store.getState().refreshRegistryDiffs();
+    const result = await store.getState().publish('a');
+    expect(result?.reason).toBe('pull-latest-first');
+    expect(result?.registryVersion).toBe('0.3.0');
+  });
+
+  it('importFromRegistry calls pull and reloads plugins', async () => {
+    api.list.mockResolvedValue([]);
+    await store.getState().importFromRegistry('reg-x', 'imported');
+    expect(api.registryPull).toHaveBeenCalledWith('reg-x', undefined, 'imported');
+    expect(api.list).toHaveBeenCalled();
+  });
+
+  it('importFromRegistry throws when pull fails', async () => {
+    api.registryPull.mockResolvedValueOnce({ ok: false, reason: 'name-conflict' });
+    await expect(store.getState().importFromRegistry('reg-x')).rejects.toThrow(/name-conflict/);
+  });
+
+  it('refreshRegistrySummaries populates summaries', async () => {
+    const summaries: RegistrySummary[] = [
+      { id: 'reg-a', name: 'a', description: 'd', latest: '1.0.0' },
+    ];
+    api.registryList.mockResolvedValue(summaries);
+    await store.getState().refreshRegistrySummaries();
+    expect(store.getState().registrySummaries).toEqual(summaries);
+  });
+});

--- a/tests/unit/publish-conflict-dialog.test.tsx
+++ b/tests/unit/publish-conflict-dialog.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent, act, waitFor } from '@testing-library/react';
+import { PublishConflictDialog } from '../../src/renderer/components/plugin/registry/dialogs/PublishConflictDialog';
+
+afterEach(() => cleanup());
+
+const baseProps = {
+  open: true,
+  pluginName: 'tail-errors',
+  workspaceVersion: '0.2.0',
+  registryVersion: '0.3.0',
+};
+
+describe('PublishConflictDialog', () => {
+  it('shows both versions in compare boxes', () => {
+    const { getByText, getAllByText } = render(
+      <PublishConflictDialog
+        {...baseProps}
+        onClose={() => {}}
+        onPullLatest={vi.fn()}
+      />
+    );
+    expect(getByText('Pull latest before publishing')).toBeTruthy();
+    // versions appear in both the body sentence and the compare box
+    expect(getAllByText('0.2.0').length).toBeGreaterThanOrEqual(1);
+    expect(getAllByText('0.3.0').length).toBeGreaterThanOrEqual(1);
+    expect(getByText('Your base')).toBeTruthy();
+    expect(getByText('Registry latest')).toBeTruthy();
+  });
+
+  it('Cancel calls onClose', () => {
+    const onClose = vi.fn();
+    const { getByTestId } = render(
+      <PublishConflictDialog
+        {...baseProps}
+        onClose={onClose}
+        onPullLatest={vi.fn()}
+      />
+    );
+    fireEvent.click(getByTestId('publish-conflict-cancel'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('Pull latest invokes onPullLatest then closes', async () => {
+    const onPullLatest = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    const { getByTestId } = render(
+      <PublishConflictDialog
+        {...baseProps}
+        onClose={onClose}
+        onPullLatest={onPullLatest}
+      />
+    );
+    await act(async () => {
+      fireEvent.click(getByTestId('publish-conflict-pull'));
+    });
+    await waitFor(() => {
+      expect(onPullLatest).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/registry-browser.test.tsx
+++ b/tests/unit/registry-browser.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, cleanup, fireEvent, waitFor, act } from '@testing-library/react';
+import { RegistryBrowser } from '../../src/renderer/components/plugin/registry/RegistryBrowser';
+import type { RegistrySummary } from '../../src/types/plugin-registry';
+
+const SUMMARIES: RegistrySummary[] = [
+  { id: 'plugin-aaa', name: 'tail-errors', description: 'Tail build logs', latest: '0.2.0' },
+  { id: 'plugin-bbb', name: 'git-context', description: 'Inject git diff', latest: '0.1.4' },
+];
+
+beforeEach(() => {
+  (globalThis as unknown as { window: { aide: unknown } }).window = {
+    ...((globalThis as unknown as { window?: object }).window ?? {}),
+    aide: {
+      plugin: {
+        registry: {
+          list: vi.fn().mockResolvedValue(SUMMARIES),
+        },
+      },
+    },
+  } as unknown as typeof window;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('RegistryBrowser', () => {
+  it('does not render when closed', () => {
+    const { container } = render(
+      <RegistryBrowser
+        open={false}
+        onClose={() => {}}
+        installedNames={new Set()}
+        onImport={() => {}}
+      />
+    );
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it('lists registry plugins after open', async () => {
+    const { findByText } = render(
+      <RegistryBrowser
+        open
+        onClose={() => {}}
+        installedNames={new Set()}
+        onImport={() => {}}
+      />
+    );
+    expect(await findByText('tail-errors')).toBeTruthy();
+    expect(await findByText('git-context')).toBeTruthy();
+  });
+
+  it('shows "Installed" label for already-installed plugins', async () => {
+    const { findByTestId, queryByTestId } = render(
+      <RegistryBrowser
+        open
+        onClose={() => {}}
+        installedNames={new Set(['tail-errors'])}
+        onImport={() => {}}
+      />
+    );
+    expect(await findByTestId('registry-installed-plugin-aaa')).toBeTruthy();
+    expect(queryByTestId('registry-import-plugin-aaa')).toBeNull();
+    expect(await findByTestId('registry-import-plugin-bbb')).toBeTruthy();
+  });
+
+  it('invokes onImport with correct id when Import clicked', async () => {
+    const onImport = vi.fn().mockResolvedValue(undefined);
+    const { findByTestId } = render(
+      <RegistryBrowser
+        open
+        onClose={() => {}}
+        installedNames={new Set()}
+        onImport={onImport}
+      />
+    );
+    const importBtn = await findByTestId('registry-import-plugin-bbb');
+    await act(async () => {
+      fireEvent.click(importBtn);
+    });
+    expect(onImport).toHaveBeenCalledWith('plugin-bbb');
+  });
+
+  it('filters by Installed category', async () => {
+    const { findByTestId, queryByText, queryByTestId } = render(
+      <RegistryBrowser
+        open
+        onClose={() => {}}
+        installedNames={new Set(['tail-errors'])}
+        onImport={() => {}}
+      />
+    );
+    // Wait for initial render
+    expect(await findByTestId('registry-card-plugin-aaa')).toBeTruthy();
+    await act(async () => {
+      fireEvent.click(await findByTestId('registry-category-installed'));
+    });
+    expect(queryByText('git-context')).toBeNull();
+    expect(queryByTestId('registry-card-plugin-aaa')).toBeTruthy();
+  });
+});

--- a/tests/unit/update-confirm-dialog.test.tsx
+++ b/tests/unit/update-confirm-dialog.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent, act, waitFor } from '@testing-library/react';
+import { UpdateConfirmDialog } from '../../src/renderer/components/plugin/registry/dialogs/UpdateConfirmDialog';
+
+afterEach(() => cleanup());
+
+const baseProps = {
+  open: true,
+  pluginName: 'tail-errors',
+  latestVersion: '0.2.1',
+  modifiedFiles: ['src/index.js', 'tool.json'],
+};
+
+describe('UpdateConfirmDialog', () => {
+  it('renders title, plugin name, version, and modified files', () => {
+    const { getByText, getAllByText } = render(
+      <UpdateConfirmDialog
+        {...baseProps}
+        onClose={() => {}}
+        onConfirm={vi.fn()}
+        onForkInstead={() => {}}
+      />
+    );
+    expect(getByText(/Update will overwrite local changes/)).toBeTruthy();
+    expect(getByText('tail-errors')).toBeTruthy();
+    expect(getByText('0.2.1')).toBeTruthy();
+    expect(getByText('src/index.js')).toBeTruthy();
+    expect(getByText('tool.json')).toBeTruthy();
+    // both files render "modified" label
+    expect(getAllByText('modified').length).toBe(2);
+  });
+
+  it('Cancel button calls onClose', () => {
+    const onClose = vi.fn();
+    const { getByTestId } = render(
+      <UpdateConfirmDialog
+        {...baseProps}
+        onClose={onClose}
+        onConfirm={vi.fn()}
+        onForkInstead={() => {}}
+      />
+    );
+    fireEvent.click(getByTestId('update-cancel'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('Fork instead button calls onForkInstead', () => {
+    const onForkInstead = vi.fn();
+    const { getByTestId } = render(
+      <UpdateConfirmDialog
+        {...baseProps}
+        onClose={() => {}}
+        onConfirm={vi.fn()}
+        onForkInstead={onForkInstead}
+      />
+    );
+    fireEvent.click(getByTestId('update-fork-instead'));
+    expect(onForkInstead).toHaveBeenCalled();
+  });
+
+  it('Discard & update calls onConfirm and then onClose', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    const { getByTestId } = render(
+      <UpdateConfirmDialog
+        {...baseProps}
+        onClose={onClose}
+        onConfirm={onConfirm}
+        onForkInstead={() => {}}
+      />
+    );
+    await act(async () => {
+      fireEvent.click(getByTestId('update-discard'));
+    });
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 of the plugin global registry feature ([design #131](https://github.com/Achelous1/smalti/pull/131), [backend #133](https://github.com/Achelous1/smalti/pull/133), [IPC #134](https://github.com/Achelous1/smalti/pull/134)).

Wires the IPC surface (\`window.aide.plugin.registry.*\`) into the renderer. Replaces the existing PluginPanel with a status-badge-driven v2 and adds 5 supporting components (badge, base dialog, 3 dialogs, registry browser).

## Three commits

1. \`cd37cb4\` **feat(renderer): extend plugin-store with registry actions** — 7 store actions + diff cache (392 LoC, 11 tests)
2. \`eb40b73\` **feat(renderer): add registry UI primitives** — badge + BaseDialog + 3 dialogs + RegistryBrowser (1112 LoC, 21 tests)
3. \`146acc2\` **feat(renderer): replace PluginPanel with v2** — status badges + action menu + dialog wiring (373 LoC, replaces old impl)

## Mockup vs implementation

The 5 mockups merged in [#131](https://github.com/Achelous1/smalti/pull/131) drive this implementation. PNGs:

- [plugin-panel-v2.png](docs/design/plugin-registry/plugin-panel-v2.png)
- [registry-browser.png](docs/design/plugin-registry/registry-browser.png)
- [dialog-fork-as-new-plugin.png](docs/design/plugin-registry/dialog-fork-as-new-plugin.png)
- [dialog-update-confirm.png](docs/design/plugin-registry/dialog-update-confirm.png)
- [dialog-publish-conflict.png](docs/design/plugin-registry/dialog-publish-conflict.png)

## Action wiring

Per-row action menu items are status-aware:

| Status | Menu items |
|---|---|
| synced | Publish to registry, Remove |
| update-available | Update to X.Y.Z, Fork as new plugin, Publish, Remove |
| locally-modified | Update (discard local), Fork as new plugin, Publish (bump patch), Remove |
| unknown | Publish to registry, Remove |

- **Update** on \`locally-modified\` → \`UpdateConfirmDialog\` (warns about loss, offers Fork instead). Update on \`synced\`/\`update-available\` → \`store.applyUpdate\` immediately.
- **Fork as new plugin** → \`ForkAsNewPluginDialog\` (name + description + restore-original radio).
- **Publish** → \`store.publish(name, { bumpPatch: true })\`. If backend returns a pull-latest-first conflict, \`PublishConflictDialog\` is promoted automatically.
- **Add from registry** (header button) → mounts \`RegistryBrowser\`.

## Intentional removals from the old PluginPanel

These existed in the previous panel and are gone from v2 — calling them out explicitly so reviewers can flag if any are critical:

- ON/OFF activation toggle  → activation now via row body click
- Reload (↻) icon  → \`window.aide.plugin.reload()\` still exists; just not surfaced. Easy to re-add to the action menu.
- Open tab (↗) icon  → folded into row body click
- Inline version label  → latest version shows on the badge; full version in RegistryBrowser
- "Ask your AI agent…" hint box  → Generate Plugin form's placeholder absorbs the hint

The Generate Plugin form is preserved in the panel header — core "Create n Play" flow is intact.

## Tests

| File | Cases |
|---|---|
| plugin-store-registry.test.ts | 11 (window.aide mocked, all 7 actions + state propagation) |
| plugin-status-badge.test.tsx | 5 (status × label/color) |
| registry-browser.test.tsx | 5 (list render, Installed flag, Import wiring) |
| fork-dialog.test.tsx | 4 |
| update-confirm-dialog.test.tsx | 4 |
| publish-conflict-dialog.test.tsx | 3 |

Suite: 553 → **586 passed**, 3 skipped, 0 failed. Lint clean.

## Out of scope (separate PR)

- **MCPEditConflictDialog (D7)** — design pending pencil MCP recovery; PluginPanel's dialog-slot pattern is ready to host it (\`mcpEditTarget\` follows same shape as \`forkTarget\` etc.)
- **Per-file modified list in UpdateConfirmDialog** — needs \`RegistryDiff.modifiedFiles\` field on backend. Currently passed as \`[]\`; dialog gracefully omits the list.
- **\`RegistrySummary.createdAt\`** — would let "Recently added" filter actually sort
- **Full focus trap / a11y pass** — BaseDialog has close-button autoFocus only

## Test plan

- [x] \`pnpm test\` — 586 passed
- [x] \`pnpm lint\` — 0 errors
- [ ] Manual smoke: open PluginPanel, verify status badges render after generating a plugin (auto-push from #134 should land it in registry → badge \`synced\`)
- [ ] Manual smoke: edit a plugin file, verify badge transitions to \`locally-modified\`
- [ ] Manual smoke: open RegistryBrowser, verify list shows the plugin and Import works into a fresh workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)