### PR TITLE
feat(plugin): lazy modifiedFiles IPC for registry diff

### DIFF
--- a/src/main/ipc/channels.ts
+++ b/src/main/ipc/channels.ts
@@ -40,6 +40,7 @@ export const IPC_CHANNELS = {
   PLUGIN_REGISTRY_PULL: 'plugin:registry:pull',
   PLUGIN_REGISTRY_PUSH: 'plugin:registry:push',
   PLUGIN_REGISTRY_REMOVE: 'plugin:registry:remove',
+  PLUGIN_REGISTRY_MODIFIED_FILES: 'plugin:registry:modified-files',
 
   // Settings
   SETTINGS_READ: 'settings:read',

--- a/src/main/ipc/plugin-handlers.ts
+++ b/src/main/ipc/plugin-handlers.ts
@@ -465,4 +465,21 @@ export function registerPluginHandlers(ipcMain: IpcMain, cwd: string): void {
       return { ok: false, error: (err as Error).message };
     }
   });
+
+  ipcMain.handle(IPC_CHANNELS.PLUGIN_REGISTRY_MODIFIED_FILES, async (_e, pluginName: string) => {
+    try {
+      const effectiveCwd = getEffectiveCwd(cwd);
+      const localDir = getLocalPluginsDir(effectiveCwd);
+      const pluginDir = path.join(localDir, pluginName);
+      const spec = readPluginSpec(pluginDir);
+      if (!spec || !spec.source) return [];
+      return registryGlobal.getModifiedFiles(pluginDir, {
+        registryId: spec.source.registryId,
+        installedVersion: spec.source.installedVersion,
+      });
+    } catch (err) {
+      console.error('[plugin:registry:modified-files] error:', err);
+      return [];
+    }
+  });
 }

--- a/src/main/plugin/registry-global.ts
+++ b/src/main/plugin/registry-global.ts
@@ -5,7 +5,9 @@ import {
   packDirectoryToZipBuffer,
   unpackZipBufferToDirectory,
   computeDirectoryContentHash,
+  diffDirectories,
 } from './zip-utils';
+import os from 'os';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -314,5 +316,53 @@ export function removePlugin(id: string): void {
   if (id in idx.plugins) {
     delete idx.plugins[id];
     writeIndex(idx);
+  }
+}
+
+/**
+ * For a workspace plugin that has a `source` block, compute file-level
+ * modifications relative to its installed registry version. Useful for
+ * surfacing "what will be lost" before applying an update.
+ *
+ * Returns a flat list of "<status> <relPath>" entries — e.g.
+ * ["modified src/index.js", "added src/utils/new.js"]. Removed files
+ * are also flagged.
+ *
+ * Returns [] when:
+ * - the registry doesn't have the installedVersion zip (data loss / sandbox tests)
+ *
+ * Throws on filesystem errors. Caller should treat as best-effort and
+ * fall back to "files unknown" UI.
+ */
+export function getModifiedFiles(
+  workspacePluginDir: string,
+  source: { registryId: string; installedVersion: string },
+): string[] {
+  const zipFilePath = path.join(
+    versionDir(source.registryId, source.installedVersion),
+    'plugin.zip',
+  );
+
+  if (!fs.existsSync(zipFilePath)) {
+    return [];
+  }
+
+  const tmpDir = path.join(os.tmpdir(), `smalti-diff-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  fs.mkdirSync(tmpDir, { recursive: true });
+  try {
+    const buf = fs.readFileSync(zipFilePath);
+    unpackZipBufferToDirectory(buf, tmpDir);
+
+    const diff = diffDirectories(tmpDir, workspacePluginDir);
+
+    const results: string[] = [
+      ...diff.modified.map((p) => `modified ${p}`),
+      ...diff.added.map((p) => `added ${p}`),
+      ...diff.removed.map((p) => `removed ${p}`),
+    ];
+
+    return results;
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 }

--- a/src/main/plugin/zip-utils.ts
+++ b/src/main/plugin/zip-utils.ts
@@ -133,3 +133,58 @@ export function sha256OfBuffer(buf: Buffer): ContentHash {
   const hex = crypto.createHash('sha256').update(buf).digest('hex');
   return makeContentHash(hex);
 }
+
+/**
+ * Compute file-level diff between two directory trees. Honors the same
+ * hidden/excluded-from-hash rules as computeDirectoryContentHash.
+ *
+ * Returns relative paths (forward-slash separated) of files that differ.
+ * `added`: in B, not in A.
+ * `removed`: in A, not in B.
+ * `modified`: present in both with different sha256 of content.
+ */
+export interface DirectoryDiff {
+  added: string[];
+  removed: string[];
+  modified: string[];
+}
+
+export function diffDirectories(srcA: string, srcB: string): DirectoryDiff {
+  function buildMap(dir: string): Map<string, string> {
+    const map = new Map<string, string>();
+    const files = walkFiles(dir).filter((rel) => !isExcludedFromHash(rel));
+    for (const rel of files) {
+      const content = fs.readFileSync(path.join(dir, rel));
+      const hex = crypto.createHash('sha256').update(content).digest('hex');
+      map.set(rel.split(path.sep).join('/'), hex);
+    }
+    return map;
+  }
+
+  const mapA = buildMap(srcA);
+  const mapB = buildMap(srcB);
+
+  const added: string[] = [];
+  const removed: string[] = [];
+  const modified: string[] = [];
+
+  for (const [key, hashB] of mapB) {
+    if (!mapA.has(key)) {
+      added.push(key);
+    } else if (mapA.get(key) !== hashB) {
+      modified.push(key);
+    }
+  }
+
+  for (const key of mapA.keys()) {
+    if (!mapB.has(key)) {
+      removed.push(key);
+    }
+  }
+
+  added.sort();
+  removed.sort();
+  modified.sort();
+
+  return { added, removed, modified };
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -132,6 +132,8 @@ const aideAPI: AideAPI = {
       push: (pluginName: string, opts?: { bumpPatch?: boolean }) =>
         ipcRenderer.invoke(IPC_CHANNELS.PLUGIN_REGISTRY_PUSH, pluginName, opts),
       remove: (registryId: string) => ipcRenderer.invoke(IPC_CHANNELS.PLUGIN_REGISTRY_REMOVE, registryId),
+      modifiedFiles: (pluginName: string): Promise<string[]> =>
+        ipcRenderer.invoke(IPC_CHANNELS.PLUGIN_REGISTRY_MODIFIED_FILES, pluginName) as Promise<string[]>,
     },
   },
 

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -271,6 +271,7 @@ export interface AideAPI {
       pull(registryId: string, version?: string, targetName?: string): Promise<{ ok: true; pluginPath: string; contentHash: string } | { ok: false; reason?: string; error?: string }>;
       push(pluginName: string, opts?: { bumpPatch?: boolean }): Promise<{ ok: true; version: string; contentHash: string } | { ok: false; error?: string }>;
       remove(registryId: string): Promise<{ ok: true } | { ok: false; error?: string }>;
+      modifiedFiles(pluginName: string): Promise<string[]>;
     };
   };
   mcp: {

--- a/tests/unit/plugin-handlers-modified-files.test.ts
+++ b/tests/unit/plugin-handlers-modified-files.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for PLUGIN_REGISTRY_MODIFIED_FILES IPC handler logic.
+ *
+ * Strategy: extract the handler logic and test it directly against a real
+ * sandbox filesystem + _setRegistryRootForTesting (same pattern as
+ * plugin-handlers-registry.test.ts).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  pushPlugin,
+  getModifiedFiles,
+  _setRegistryRootForTesting,
+} from '../../src/main/plugin/registry-global';
+import type { PluginSpec } from '../../src/main/plugin/spec-generator';
+
+// ---------------------------------------------------------------------------
+// Sandbox helpers
+// ---------------------------------------------------------------------------
+
+let sandbox: string;
+let workspacePluginsDir: string;
+
+function mkSandbox(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'aide-handlers-modified-'));
+}
+
+function makeWorkspacePlugin(
+  name: string,
+  extraFiles: Record<string, string> = {},
+  specOverride: Partial<PluginSpec> = {},
+): { pluginDir: string; spec: PluginSpec } {
+  const pluginDir = path.join(workspacePluginsDir, name);
+  fs.mkdirSync(pluginDir, { recursive: true });
+  fs.writeFileSync(path.join(pluginDir, 'index.js'), `// ${name}\nexports.run = () => {};`);
+  for (const [rel, content] of Object.entries(extraFiles)) {
+    const full = path.join(pluginDir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+
+  const spec: PluginSpec = {
+    id: specOverride.id ?? `plugin-${name.replace(/[^a-z0-9]/g, '')}`,
+    name,
+    description: specOverride.description ?? `${name} plugin`,
+    version: specOverride.version ?? '0.1.0',
+    permissions: [],
+    entryPoint: 'src/index.js',
+    dependencies: {},
+    tools: [],
+    ...specOverride,
+  };
+  fs.writeFileSync(path.join(pluginDir, 'plugin.spec.json'), JSON.stringify(spec, null, 2));
+  return { pluginDir, spec };
+}
+
+function readSpec(pluginDir: string): PluginSpec {
+  return JSON.parse(fs.readFileSync(path.join(pluginDir, 'plugin.spec.json'), 'utf-8')) as PluginSpec;
+}
+
+// ---------------------------------------------------------------------------
+// Simulate PLUGIN_REGISTRY_MODIFIED_FILES handler logic
+// (mirrors what plugin-handlers.ts would wire up)
+// ---------------------------------------------------------------------------
+
+async function handleModifiedFiles(pluginName: string): Promise<string[]> {
+  try {
+    const pluginDir = path.join(workspacePluginsDir, pluginName);
+    if (!fs.existsSync(pluginDir)) return [];
+    const specPath = path.join(pluginDir, 'plugin.spec.json');
+    if (!fs.existsSync(specPath)) return [];
+    const spec = JSON.parse(fs.readFileSync(specPath, 'utf-8')) as PluginSpec;
+    if (!spec.source) return [];
+    return getModifiedFiles(pluginDir, {
+      registryId: spec.source.registryId,
+      installedVersion: spec.source.installedVersion,
+    });
+  } catch (err) {
+    console.error('[plugin:registry:modified-files] error:', err);
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  sandbox = mkSandbox();
+  workspacePluginsDir = path.join(sandbox, 'workspace', '.smalti', 'plugins');
+  fs.mkdirSync(workspacePluginsDir, { recursive: true });
+  _setRegistryRootForTesting(path.join(sandbox, 'registry'));
+});
+
+afterEach(() => {
+  _setRegistryRootForTesting(null);
+  fs.rmSync(sandbox, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PLUGIN_REGISTRY_MODIFIED_FILES handler', () => {
+  it('spec has no source block → returns []', async () => {
+    const { pluginDir } = makeWorkspacePlugin('no-source');
+    // Spec written without source — already the case from makeWorkspacePlugin
+    expect(readSpec(pluginDir).source).toBeUndefined();
+
+    const result = await handleModifiedFiles('no-source');
+
+    expect(result).toEqual([]);
+  });
+
+  it('spec has source and workspace has changes → returns change list', async () => {
+    const { pluginDir, spec } = makeWorkspacePlugin('my-plugin');
+    const pushed = pushPlugin(pluginDir, {
+      id: spec.id,
+      name: spec.name,
+      description: spec.description,
+      version: spec.version,
+    });
+    // Write source back to spec
+    spec.source = {
+      registryId: spec.id,
+      installedVersion: pushed.version,
+      installedContentHash: pushed.contentHash,
+    };
+    fs.writeFileSync(path.join(pluginDir, 'plugin.spec.json'), JSON.stringify(spec, null, 2));
+
+    // Modify workspace after push
+    fs.writeFileSync(path.join(pluginDir, 'index.js'), 'exports.run = () => { return 42; };');
+
+    const result = await handleModifiedFiles('my-plugin');
+
+    expect(result).toContain('modified index.js');
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('getModifiedFiles throws → handler catches and returns []', async () => {
+    const { pluginDir, spec } = makeWorkspacePlugin('error-plugin');
+    const pushed = pushPlugin(pluginDir, {
+      id: spec.id,
+      name: spec.name,
+      description: spec.description,
+      version: spec.version,
+    });
+    spec.source = {
+      registryId: spec.id,
+      installedVersion: pushed.version,
+      installedContentHash: pushed.contentHash,
+    };
+    fs.writeFileSync(path.join(pluginDir, 'plugin.spec.json'), JSON.stringify(spec, null, 2));
+
+    // Make workspaceDir unreadable to provoke an error from getModifiedFiles
+    vi.spyOn(fs, 'readdirSync').mockImplementationOnce(() => {
+      throw new Error('EPERM: permission denied');
+    });
+
+    const result = await handleModifiedFiles('error-plugin');
+
+    expect(result).toEqual([]);
+  });
+
+  it('plugin name does not exist on disk → returns []', async () => {
+    const result = await handleModifiedFiles('nonexistent-plugin');
+
+    expect(result).toEqual([]);
+  });
+});

--- a/tests/unit/registry-modified-files.test.ts
+++ b/tests/unit/registry-modified-files.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  pushPlugin,
+  getModifiedFiles,
+  _setRegistryRootForTesting,
+} from '../../src/main/plugin/registry-global';
+
+let sandbox: string;
+
+function mkSandbox(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'aide-modified-files-'));
+}
+
+function makePluginDir(base: string, name: string, files: Record<string, string> = {}): string {
+  const dir = path.join(base, name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'index.js'), files['index.js'] ?? `// ${name}\nexports.run = () => {};`);
+  for (const [rel, content] of Object.entries(files)) {
+    if (rel === 'index.js') continue;
+    const full = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+  return dir;
+}
+
+const BASE_OPTS = {
+  id: 'plugin-abc123',
+  name: 'my-plugin',
+  description: 'test plugin',
+  version: '0.1.0',
+} as const;
+
+beforeEach(() => {
+  sandbox = mkSandbox();
+  _setRegistryRootForTesting(path.join(sandbox, 'registry'));
+});
+
+afterEach(() => {
+  _setRegistryRootForTesting(null);
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+describe('getModifiedFiles', () => {
+  it('identical workspace and registry → returns []', () => {
+    const workspaceDir = makePluginDir(sandbox, 'my-plugin', {
+      'index.js': 'exports.run = () => {};',
+    });
+    const pushed = pushPlugin(workspaceDir, BASE_OPTS);
+    const source = { registryId: BASE_OPTS.id, installedVersion: pushed.version };
+
+    const result = getModifiedFiles(workspaceDir, source);
+
+    expect(result).toEqual([]);
+  });
+
+  it('workspace has modified file → returns ["modified src/index.js"]', () => {
+    const workspaceDir = makePluginDir(sandbox, 'my-plugin', {
+      'index.js': 'exports.run = () => {};',
+    });
+    const pushed = pushPlugin(workspaceDir, BASE_OPTS);
+    const source = { registryId: BASE_OPTS.id, installedVersion: pushed.version };
+
+    // Modify workspace after push
+    fs.writeFileSync(path.join(workspaceDir, 'index.js'), 'exports.run = () => { return 42; };');
+
+    const result = getModifiedFiles(workspaceDir, source);
+
+    expect(result).toContain('modified index.js');
+    expect(result.length).toBe(1);
+  });
+
+  it('workspace has new file → returns ["added <path>"]', () => {
+    const workspaceDir = makePluginDir(sandbox, 'my-plugin', {
+      'index.js': 'exports.run = () => {};',
+    });
+    const pushed = pushPlugin(workspaceDir, BASE_OPTS);
+    const source = { registryId: BASE_OPTS.id, installedVersion: pushed.version };
+
+    // Add new file after push
+    fs.writeFileSync(path.join(workspaceDir, 'utils.js'), 'exports.util = () => {};');
+
+    const result = getModifiedFiles(workspaceDir, source);
+
+    expect(result).toContain('added utils.js');
+    expect(result.length).toBe(1);
+  });
+
+  it('workspace has deleted file → returns ["removed <path>"]', () => {
+    const workspaceDir = makePluginDir(sandbox, 'my-plugin', {
+      'index.js': 'exports.run = () => {};',
+      'extra.js': 'exports.extra = () => {};',
+    });
+    const pushed = pushPlugin(workspaceDir, BASE_OPTS);
+    const source = { registryId: BASE_OPTS.id, installedVersion: pushed.version };
+
+    // Delete file after push
+    fs.rmSync(path.join(workspaceDir, 'extra.js'));
+
+    const result = getModifiedFiles(workspaceDir, source);
+
+    expect(result).toContain('removed extra.js');
+    expect(result.length).toBe(1);
+  });
+
+  it('registry zip not found for installedVersion → returns []', () => {
+    const workspaceDir = makePluginDir(sandbox, 'my-plugin', {
+      'index.js': 'exports.run = () => {};',
+    });
+    // Push so registryId exists in meta but use a non-existent version
+    pushPlugin(workspaceDir, BASE_OPTS);
+    const source = { registryId: BASE_OPTS.id, installedVersion: '99.99.99' };
+
+    const result = getModifiedFiles(workspaceDir, source);
+
+    expect(result).toEqual([]);
+  });
+
+  it('completely unknown registryId (no zip, no meta) → returns []', () => {
+    const workspaceDir = makePluginDir(sandbox, 'my-plugin', {
+      'index.js': 'exports.run = () => {};',
+    });
+    const source = { registryId: 'unknown-id-xyz', installedVersion: '0.1.0' };
+
+    const result = getModifiedFiles(workspaceDir, source);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/tests/unit/zip-utils-diff.test.ts
+++ b/tests/unit/zip-utils-diff.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { diffDirectories } from '../../src/main/plugin/zip-utils';
+
+let tmpDirs: string[] = [];
+
+function makeTmpDir(suffix = ''): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `aide-diff-${suffix}`));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function writeFile(base: string, rel: string, content = 'hello'): void {
+  const full = path.join(base, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+beforeEach(() => {
+  tmpDirs = [];
+});
+
+afterEach(() => {
+  for (const dir of tmpDirs) {
+    if (fs.existsSync(dir)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+  tmpDirs = [];
+});
+
+describe('diffDirectories', () => {
+  it('identical trees → all arrays empty', () => {
+    const a = makeTmpDir('a-');
+    const b = makeTmpDir('b-');
+    writeFile(a, 'index.js', 'same');
+    writeFile(a, 'utils.js', 'util');
+    writeFile(b, 'index.js', 'same');
+    writeFile(b, 'utils.js', 'util');
+
+    const diff = diffDirectories(a, b);
+
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    expect(diff.modified).toEqual([]);
+  });
+
+  it('file only in B → added', () => {
+    const a = makeTmpDir('a-');
+    const b = makeTmpDir('b-');
+    writeFile(a, 'index.js', 'base');
+    writeFile(b, 'index.js', 'base');
+    writeFile(b, 'new.js', 'new file');
+
+    const diff = diffDirectories(a, b);
+
+    expect(diff.added).toEqual(['new.js']);
+    expect(diff.removed).toEqual([]);
+    expect(diff.modified).toEqual([]);
+  });
+
+  it('file only in A → removed', () => {
+    const a = makeTmpDir('a-');
+    const b = makeTmpDir('b-');
+    writeFile(a, 'index.js', 'base');
+    writeFile(a, 'old.js', 'old file');
+    writeFile(b, 'index.js', 'base');
+
+    const diff = diffDirectories(a, b);
+
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual(['old.js']);
+    expect(diff.modified).toEqual([]);
+  });
+
+  it('same file name, different content → modified', () => {
+    const a = makeTmpDir('a-');
+    const b = makeTmpDir('b-');
+    writeFile(a, 'index.js', 'original');
+    writeFile(b, 'index.js', 'changed');
+
+    const diff = diffDirectories(a, b);
+
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    expect(diff.modified).toEqual(['index.js']);
+  });
+
+  it('plugin.spec.json differences are ignored', () => {
+    const a = makeTmpDir('a-');
+    const b = makeTmpDir('b-');
+    writeFile(a, 'index.js', 'same');
+    writeFile(a, 'plugin.spec.json', '{"version":"0.1.0"}');
+    writeFile(b, 'index.js', 'same');
+    writeFile(b, 'plugin.spec.json', '{"version":"0.2.0","source":{}}');
+
+    const diff = diffDirectories(a, b);
+
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    expect(diff.modified).toEqual([]);
+  });
+
+  it('.DS_Store / .git / node_modules differences are ignored', () => {
+    const a = makeTmpDir('a-');
+    const b = makeTmpDir('b-');
+    writeFile(a, 'index.js', 'same');
+    writeFile(b, 'index.js', 'same');
+    writeFile(b, '.DS_Store', 'mac junk');
+    writeFile(b, '.git/HEAD', 'ref: refs/heads/main');
+    writeFile(b, 'node_modules/foo.js', 'dep');
+
+    const diff = diffDirectories(a, b);
+
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    expect(diff.modified).toEqual([]);
+  });
+
+  it('nested directory paths are classified correctly', () => {
+    const a = makeTmpDir('a-');
+    const b = makeTmpDir('b-');
+    writeFile(a, 'src/index.js', 'original');
+    writeFile(a, 'src/utils/helper.js', 'helper');
+    writeFile(b, 'src/index.js', 'changed');
+    writeFile(b, 'src/utils/new.js', 'new util');
+
+    const diff = diffDirectories(a, b);
+
+    expect(diff.modified).toEqual(['src/index.js']);
+    expect(diff.added).toEqual(['src/utils/new.js']);
+    expect(diff.removed).toEqual(['src/utils/helper.js']);
+  });
+
+  it('result arrays are sorted alphabetically', () => {
+    const a = makeTmpDir('a-');
+    const b = makeTmpDir('b-');
+    // modified: z-file, a-file (expect sorted a-file, z-file)
+    writeFile(a, 'z-file.js', 'old');
+    writeFile(a, 'a-file.js', 'old');
+    writeFile(b, 'z-file.js', 'new');
+    writeFile(b, 'a-file.js', 'new');
+    // added: z-add, a-add
+    writeFile(b, 'z-add.js', 'add');
+    writeFile(b, 'a-add.js', 'add');
+    // removed: z-rm, a-rm
+    writeFile(a, 'z-rm.js', 'rm');
+    writeFile(a, 'a-rm.js', 'rm');
+
+    const diff = diffDirectories(a, b);
+
+    expect(diff.modified).toEqual(['a-file.js', 'z-file.js']);
+    expect(diff.added).toEqual(['a-add.js', 'z-add.js']);
+    expect(diff.removed).toEqual(['a-rm.js', 'z-rm.js']);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a lazy IPC channel that surfaces file-level diff between a workspace plugin and its installed registry version. Backend only — UI wiring lands after [#135](https://github.com/Achelous1/smalti/pull/135) merges so the new `UpdateConfirmDialog.modifiedFiles` prop can be populated instead of staying `[]`.

Independent of #135 — develops cleanly and ships immediately. No conflict with the in-flight UI PR.

## Why a separate channel rather than extending RegistryDiff

`RegistryDiff` is fetched **eagerly** for every workspace plugin on PluginPanel mount. Computing modified files requires unpacking the installed-version zip into a temp dir per plugin — that multiplies mount cost by N plugins for data that is only needed at the moment a destructive-update dialog is about to render.

Lazy fetch via `PLUGIN_REGISTRY_MODIFIED_FILES` keeps steady-state cost at zero and only pays the unpack cost when the user actually clicks Update on a `locally-modified` plugin.

## Two commits

### `7b7622c` feat(plugin): add diffDirectories helper to zip-utils

Pure file-level diff helper. Returns alphabetically-sorted `{added, removed, modified}` arrays of forward-slash relative paths. Honors the same hidden/excluded rules as `computeDirectoryContentHash` so `.DS_Store` / `.git/` / `node_modules/` / `plugin.spec.json` differences don't show up in the result.

7 tests covering identical trees, one-sided files, content divergence, hidden-file invariance, nested paths, and result ordering.

### `eed84b0` feat(plugin): expose modifiedFiles via lazy IPC channel

Stack:
- `registry-global.getModifiedFiles(workspaceDir, source)` — unpacks the installed-version zip into `os.tmpdir()`, runs `diffDirectories`, cleans up in a `finally` block (runs even on throw)
- IPC channel `plugin:registry:modified-files`
- IPC handler swallows errors with `[]` + `console.error` so the UI never crashes on a registry filesystem hiccup
- preload exposes `window.aide.plugin.registry.modifiedFiles(pluginName): Promise<string[]>`
- `AideAPI` type in `src/types/ipc.ts` gets the matching method signature

Returns `[]` when:
- The plugin has no `source` (locally-created, never pushed)
- The registry zip is missing (test sandbox / data loss)
- The workspace tree is unchanged from the installed version

Output shape: `["modified src/index.js", "added src/utils/new.js", "removed legacy.json"]`

10 tests (6 registry-level + 4 IPC-handler-level).

## Tests

Suite: 553 → **571 passed**, 3 skipped, 0 failed. Lint clean.

## Follow-up (after #135 lands)

`UpdateConfirmDialog` already accepts `modifiedFiles: string[]` props and renders the list when non-empty. PluginPanel currently passes `[]`. The follow-up PR is a small one-liner change in PluginPanel:

```tsx
// before
<UpdateConfirmDialog ... modifiedFiles={[]} />

// after  
<UpdateConfirmDialog ... modifiedFiles={modifiedFilesForDialog} />
```

with a small `useState` + `useEffect` that calls `window.aide.plugin.registry.modifiedFiles(name)` on dialog mount.

## Test plan

- [x] `pnpm test` — 571 passed
- [x] `pnpm lint` — 0 errors
- [ ] Reviewer manual smoke (optional): dispatch `PLUGIN_REGISTRY_MODIFIED_FILES` from devtools after editing a plugin file; verify list contains `"modified <path>"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)