### PR TITLE
chore(build): add --local flag for isolated local-build artifacts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,25 @@
 #!/bin/bash
 set -e
 
-echo "=== Smalti Build Script ==="
+# Local-build mode: --local flag or SMALTI_LOCAL_BUILD env var
+LOCAL_BUILD=0
+for arg in "$@"; do
+  if [ "$arg" = "--local" ]; then
+    LOCAL_BUILD=1
+  fi
+done
+if [ -n "$SMALTI_LOCAL_BUILD" ] && [ "$SMALTI_LOCAL_BUILD" != "0" ]; then
+  LOCAL_BUILD=1
+fi
+
+if [ "$LOCAL_BUILD" = "1" ]; then
+  echo "=== Smalti LOCAL Build (Smalti-Local-Build, isolated bundle ID) ==="
+  PRODUCT_NAME="Smalti-Local-Build"
+  export SMALTI_LOCAL_BUILD=1
+else
+  echo "=== Smalti Build Script ==="
+  PRODUCT_NAME="Smalti"
+fi
 echo ""
 
 # Check pnpm
@@ -13,15 +31,15 @@ fi
 # Detect arch
 ARCH=$(uname -m)
 if [ "$ARCH" = "arm64" ]; then
-  APP_DIR="out/Smalti-darwin-arm64"
+  APP_DIR="out/${PRODUCT_NAME}-darwin-arm64"
 else
-  APP_DIR="out/Smalti-darwin-x64"
+  APP_DIR="out/${PRODUCT_NAME}-darwin-x64"
 fi
 
-APP_PATH="$APP_DIR/Smalti.app"
-DMG_NAME="Smalti"
-DMG_PATH="out/Smalti.dmg"
-DMG_TMP_PATH="out/Smalti-tmp.dmg"
+APP_PATH="$APP_DIR/${PRODUCT_NAME}.app"
+DMG_NAME="$PRODUCT_NAME"
+DMG_PATH="out/${PRODUCT_NAME}.dmg"
+DMG_TMP_PATH="out/${PRODUCT_NAME}-tmp.dmg"
 
 # Install dependencies (postinstall hook builds the Rust .node via scripts/build-native.mjs)
 echo "[1/4] Installing dependencies..."
@@ -98,7 +116,7 @@ tell application "Finder"
     set viewOptions to the icon view options of container window
     set arrangement of viewOptions to not arranged
     set icon size of viewOptions to 100
-    set position of item "Smalti.app" of container window to {125, 160}
+    set position of item "${PRODUCT_NAME}.app" of container window to {125, 160}
     set position of item "Applications" of container window to {375, 160}
     close
     open
@@ -124,7 +142,7 @@ rm -f "$DMG_TMP_PATH"
 
 # Create .app.zip for in-place auto-update
 echo "[+] Creating app.zip for auto-update..."
-ZIP_PATH="out/Smalti.app.zip"
+ZIP_PATH="out/${PRODUCT_NAME}.app.zip"
 rm -f "$ZIP_PATH"
 ditto -c -k --keepParent "$APP_PATH" "$ZIP_PATH"
 

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -8,6 +8,10 @@ import { FuseV1Options, FuseVersion } from '@electron/fuses';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 
+const isLocalBuild = !!process.env.SMALTI_LOCAL_BUILD;
+const productName = isLocalBuild ? 'Smalti-Local-Build' : 'Smalti';
+const appBundleId = isLocalBuild ? 'com.smaltihq.smalti.local' : 'com.smaltihq.smalti';
+
 const nativeNodeFiles = ['src/main/native'];
 
 function copyNativeModules(buildPath: string) {
@@ -43,15 +47,15 @@ const config: ForgeConfig = {
     asar: {
       unpack: '**/native/*.node',
     },
-    name: 'Smalti',
+    name: productName,
     icon: path.resolve(__dirname, 'resources', 'icon'),
-    // Stable bundle ID — decoupled from packagerConfig.name so future brand
-    // text adjustments (capitalization, etc.) don't change CFBundleIdentifier
-    // and force users to re-grant TCC permissions (Full Disk Access, etc.).
-    appBundleId: 'com.smaltihq.smalti',
+    // Bundle ID is stable for release builds. Local builds use a separate
+    // bundle ID so they are recognised as a distinct app by macOS, keeping
+    // Application Support directories and TCC permissions isolated.
+    appBundleId,
     win32metadata: {
       CompanyName: 'smalti',
-      ProductName: 'Smalti',
+      ProductName: productName,
     },
     extendInfo: {
       NSDocumentsFolderUsageDescription: 'Smalti reads workspace files from your Documents folder.',
@@ -70,7 +74,7 @@ const config: ForgeConfig = {
   },
   rebuildConfig: {},
   makers: [
-    new MakerSquirrel({ name: 'Smalti' }),
+    new MakerSquirrel({ name: productName }),
     new MakerZIP({}, ['darwin']),
   ],
   plugins: [

--- a/tests/unit/forge-config-brand.test.ts
+++ b/tests/unit/forge-config-brand.test.ts
@@ -6,12 +6,34 @@ describe('forge.config.ts brand identifiers', () => {
   const content = fs.readFileSync(path.resolve(__dirname, '../../forge.config.ts'), 'utf-8');
 
   describe('D8: productName and packager fields flipped to Smalti (capitalized brand display)', () => {
-    it("packagerConfig.name is 'Smalti'", () => {
-      expect(content).toMatch(/name:\s*['"]Smalti['"]/);
+    it("default productName is 'Smalti'", () => {
+      // After the local-build flag was introduced, the literal lives in a
+      // ternary: `isLocalBuild ? 'Smalti-Local-Build' : 'Smalti'`.
+      expect(content).toMatch(/['"]Smalti-Local-Build['"]\s*:\s*['"]Smalti['"]/);
+    });
+
+    it('packagerConfig.name is wired to the productName binding', () => {
+      expect(content).toMatch(/name:\s*productName/);
     });
 
     it("packagerConfig.name no longer uses 'AIDE'", () => {
       expect(content).not.toMatch(/name:\s*['"]AIDE['"]/);
+    });
+  });
+
+  describe('local-build mode (chore/local-build-flag)', () => {
+    it('isLocalBuild is gated on the SMALTI_LOCAL_BUILD env var', () => {
+      expect(content).toMatch(/SMALTI_LOCAL_BUILD/);
+      expect(content).toMatch(/const\s+isLocalBuild/);
+    });
+
+    it('local-build appBundleId is namespaced under .local', () => {
+      expect(content).toMatch(/['"]com\.smaltihq\.smalti\.local['"]/);
+    });
+
+    it("default appBundleId remains 'com.smaltihq.smalti'", () => {
+      // Match the literal but exclude the .local variant via a negative lookahead.
+      expect(content).toMatch(/['"]com\.smaltihq\.smalti['"](?!\.)/);
     });
   });
 


### PR DESCRIPTION
## Summary

\`sh build.sh --local\` (or \`SMALTI_LOCAL_BUILD=1 sh build.sh\`) produces a **Smalti-Local-Build** app/dmg with a separate macOS bundle ID, so it coexists with the released Smalti app instead of overwriting it. Default \`sh build.sh\` is unchanged.

## Why a separate bundle ID matters

macOS identifies apps by \`CFBundleIdentifier\`, not by display name. Without a distinct ID:

- The local-build install would share \`~/Library/Application Support/Smalti/\` with the released app — easy to corrupt real user state while testing unfinished changes.
- TCC permission grants (Full Disk Access, Documents folder, etc.) would be shared — a local-build could silently inherit production permissions.
- Dock would show one entry where two apps run.

With a \`.local\` suffix the two coexist as fully isolated apps.

## What is and isn't isolated

| Resource | Isolated? | Why |
|---|---|---|
| App bundle ID | ✅ \`com.smaltihq.smalti\` vs \`com.smaltihq.smalti.local\` | macOS app identity |
| Application Support dir | ✅ derived by Electron from productName | Settings, IndexedDB, sessions, mcp-config.json |
| TCC permissions | ✅ keyed on bundle ID | Full Disk Access, etc. |
| Dock / Launchpad entry | ✅ different productName | UX |
| \`~/.smalti/\` workspace dir | ❌ shared on purpose | Both builds should be able to open the same project |
| Global plugin registry (\`~/.smalti/registry/\`) | ❌ shared | Same reason |

## Usage

\`\`\`bash
sh build.sh           # default — out/Smalti.dmg
sh build.sh --local   # local-build — out/Smalti-Local-Build.dmg
SMALTI_LOCAL_BUILD=1 sh build.sh   # equivalent
\`\`\`

## Implementation

- \`forge.config.ts\`: const \`isLocalBuild = !!process.env.SMALTI_LOCAL_BUILD\` at file top, \`productName\` + \`appBundleId\` derived from it. Threaded through \`packagerConfig.name\`, \`packagerConfig.appBundleId\`, \`win32metadata.ProductName\`, \`MakerSquirrel.name\`.
- \`build.sh\`: \`--local\` flag or env-var detection at top sets \`PRODUCT_NAME\` and exports \`SMALTI_LOCAL_BUILD\` before \`pnpm run package\`. \`PRODUCT_NAME\` is threaded through \`APP_DIR\`/\`APP_PATH\`/\`DMG_NAME\`/\`DMG_PATH\`/\`DMG_TMP_PATH\`/\`MOUNT_DIR\`/AppleScript/\`ZIP_PATH\`.
- \`tests/unit/forge-config-brand.test.ts\`: existing \`name: 'Smalti'\` literal assertion updated to match the new ternary. New cases cover the \`productName\` binding, \`isLocalBuild\` env gating, and both bundle ID variants.

## Test plan

- [x] \`pnpm test\` — 608 passed, 3 skipped, 0 failed
- [x] \`pnpm lint\` — passes
- [ ] Reviewer manual smoke: \`sh build.sh --local\` produces \`out/Smalti-Local-Build.dmg\` containing \`Smalti-Local-Build.app\`, double-clicking installs as a separate app from the released Smalti

🤖 Generated with [Claude Code](https://claude.com/claude-code)