### PR TITLE
chore(renderer): remove inline Generate Plugin form from PluginPanel

### DIFF
--- a/src/renderer/components/plugin/PluginPanel.tsx
+++ b/src/renderer/components/plugin/PluginPanel.tsx
@@ -85,9 +85,6 @@ export function PluginPanel() {
     loadPlugins,
     activate,
     deletePlugin,
-    generate,
-    generating,
-    generateError,
     registryDiffs,
     refreshRegistryDiffs,
     applyUpdate,
@@ -103,8 +100,6 @@ export function PluginPanel() {
   const [updateTarget, setUpdateTarget] = useState<PluginInfo | null>(null);
   const [publishConflict, setPublishConflict] =
     useState<{ plugin: PluginInfo; conflict: PublishConflict } | null>(null);
-  const [genName, setGenName] = useState('');
-  const [genDesc, setGenDesc] = useState('');
 
   useEffect(() => {
     loadPlugins();
@@ -237,15 +232,6 @@ export function PluginPanel() {
     }
   };
 
-  const handleGenerate = async () => {
-    if (!genName.trim() || generating) return;
-    const result = await generate(genName.trim(), genDesc.trim());
-    if (result) {
-      setGenName('');
-      setGenDesc('');
-    }
-  };
-
   const renderPlugin = (plugin: PluginInfo) => {
     const status = statusFor(plugin);
     const diff = registryDiffs[plugin.name];
@@ -308,7 +294,7 @@ export function PluginPanel() {
       </div>
 
       {/* Add from registry button */}
-      <div className="px-3 py-2 shrink-0">
+      <div className="px-3 py-2 shrink-0 border-b border-aide-border">
         <button
           onClick={() => setBrowserOpen(true)}
           data-testid="add-from-registry"
@@ -316,36 +302,6 @@ export function PluginPanel() {
         >
           + Add from registry
         </button>
-      </div>
-
-      {/* Generate plugin form */}
-      <div className="px-3 pb-2 shrink-0 flex flex-col gap-2 border-b border-aide-border">
-        <input
-          type="text"
-          value={genName}
-          onChange={(e) => setGenName(e.target.value)}
-          placeholder="plugin name"
-          aria-label="Plugin name"
-          className="w-full bg-aide-background border border-aide-border rounded px-2 py-1.5 text-xs font-mono text-aide-text-primary focus:outline-none focus:border-aide-accent"
-        />
-        <input
-          type="text"
-          value={genDesc}
-          onChange={(e) => setGenDesc(e.target.value)}
-          placeholder="describe what it does"
-          aria-label="Plugin description"
-          className="w-full bg-aide-background border border-aide-border rounded px-2 py-1.5 text-xs font-mono text-aide-text-primary focus:outline-none focus:border-aide-accent"
-        />
-        <button
-          onClick={handleGenerate}
-          disabled={!genName.trim() || generating}
-          className="w-full px-3 py-1.5 text-xs font-mono rounded border border-aide-accent text-aide-accent hover:bg-aide-accent/10 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-        >
-          {generating ? 'Generating…' : '+ Generate plugin'}
-        </button>
-        {generateError && (
-          <span className="text-[10px] font-mono text-smalti-crimson">{generateError}</span>
-        )}
       </div>
 
       {/* Plugin list */}
@@ -363,7 +319,7 @@ export function PluginPanel() {
         {!loading && !error && plugins.length === 0 && (
           <div className="flex flex-col items-center justify-center py-8 gap-1 text-aide-text-tertiary text-xs font-mono">
             <span>No plugins installed</span>
-            <span className="text-[10px]">Use + Add from registry, or generate one</span>
+            <span className="text-[10px]">Use + Add from registry to install one</span>
           </div>
         )}
 

--- a/tests/unit/plugin-panel-no-generate-form.test.tsx
+++ b/tests/unit/plugin-panel-no-generate-form.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { PluginPanel } from '../../src/renderer/components/plugin/PluginPanel';
+import { usePluginStore } from '../../src/renderer/stores/plugin-store';
+
+// Regression guard for the inline Generate Plugin form removal
+// (chore/remove-plugin-generate-form, PR #139). The form had two text
+// inputs ("plugin name", "describe what it does") and a "+ Generate plugin"
+// button; if any of these slip back into PluginPanel, this test fails so
+// the change is intentional.
+
+beforeEach(() => {
+  // Stub window.aide enough for mount + the onChanged listener.
+  const onChangedUnsub = vi.fn();
+  (globalThis as unknown as { window: { aide: unknown } }).window = {
+    ...((globalThis as unknown as { window?: object }).window ?? {}),
+    aide: {
+      plugin: {
+        onChanged: vi.fn().mockReturnValue(onChangedUnsub),
+        registry: {
+          list: vi.fn().mockResolvedValue([]),
+          diff: vi.fn().mockResolvedValue(null),
+          modifiedFiles: vi.fn().mockResolvedValue([]),
+        },
+      },
+    },
+  } as unknown as typeof window;
+
+  // Reset store to a clean empty state — we don't care about plugin rows here.
+  usePluginStore.setState({
+    plugins: [],
+    loading: false,
+    error: null,
+    generating: false,
+    generateError: null,
+    registryDiffs: {},
+    registrySummaries: [],
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('PluginPanel — Generate form is removed (regression guard)', () => {
+  it('does not render the "plugin name" input', () => {
+    const { queryByPlaceholderText, queryByLabelText } = render(<PluginPanel />);
+    expect(queryByPlaceholderText('plugin name')).toBeNull();
+    expect(queryByLabelText('Plugin name')).toBeNull();
+  });
+
+  it('does not render the "describe what it does" input', () => {
+    const { queryByPlaceholderText, queryByLabelText } = render(<PluginPanel />);
+    expect(queryByPlaceholderText('describe what it does')).toBeNull();
+    expect(queryByLabelText('Plugin description')).toBeNull();
+  });
+
+  it('does not render the "+ Generate plugin" button', () => {
+    const { queryByText } = render(<PluginPanel />);
+    expect(queryByText('+ Generate plugin')).toBeNull();
+    expect(queryByText('Generating…')).toBeNull();
+  });
+
+  it('still renders the "+ Add from registry" entry button', () => {
+    const { getByTestId } = render(<PluginPanel />);
+    // Sanity: the panel is alive and the surviving entry control is intact.
+    expect(getByTestId('add-from-registry')).not.toBeNull();
+  });
+
+  it('empty-state copy no longer references generation', () => {
+    const { container, queryByText } = render(<PluginPanel />);
+    // With no plugins the empty-state hint should not mention "generate".
+    const text = container.textContent ?? '';
+    expect(text.toLowerCase()).not.toContain('generate one');
+    expect(queryByText(/generate/i)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Removes the two-input + button "Generate plugin" form from the workspace plugin sidebar, matching the v2 design mockup more faithfully. The form was a Phase 3 holdover preserved out of regression caution; per @ confirmation it can come out.

## What stays

- \`PLUGIN_GENERATE\` IPC channel — untouched
- \`plugin-store.generate\` / \`generating\` / \`generateError\` state and action — untouched

Other entry points still drive plugin creation through the same backend:
- MCP clients call \`smalti_create_plugin\`
- The terminal/CLI hand-off is unchanged

Only the **sidebar UI surface** is removed.

## What changed

- \`PluginPanel.tsx\`: dropped the form JSX, the \`genName\`/\`genDesc\` state, the \`handleGenerate\` callback, and the \`generate\`/\`generating\`/\`generateError\` store imports.
- Empty-state copy: \`"Use + Add from registry, or generate one"\` → \`"Use + Add from registry to install one"\` so the hint no longer references a removed control.
- Add-from-registry button now owns the bottom border instead of sharing one with the (gone) form section.

## Out of scope

- design.pen: the v2 PluginPanel mockup already showed no form, so no design update needed
- store cleanup: the \`generate\` action and friends are referenced by ~10 existing tests (\`stores.test.ts\`, \`plugin-deactivate.test.ts\`, \`workspace-activate-ordering.test.ts\`); removing them would force unrelated test rewrites with no user-facing benefit. Backend stays.

## Test plan

- [x] \`pnpm test\` — 604 passed, 3 skipped, 0 failed
- [x] \`pnpm lint\` — clean
- [ ] Reviewer manual smoke: open PluginPanel, confirm only \`+ Add from registry\` button + plugin list (no form), and that generating a plugin via Claude Code MCP still surfaces it in the panel as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)