### PR TITLE
fix(mcp): restore legacy .aide/ plugin paths via server.js sandbox alias + migration redesign

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,9 @@ Claude accepts `--mcp-config <path>` per invocation. Gemini and Codex do not —
 
 All three are written by `writeMcpConfig()` in `src/main/mcp/config-writer.ts`. See `registerJsonMcpConfig()` for the shared JSON merge helper.
 
+### MCP server.js: sandbox alias는 sandbox.ts와 동기화 필수
+`src/main/mcp/server.js`는 `?raw` import되는 standalone JS로, `src/main/plugin/sandbox.ts`의 `resolveWorkspaceRel()`을 import할 수 없다. server.js 내부에 동등 로직을 inline으로 유지하며 `tests/unit/server-sandbox-alias.test.ts`가 양쪽의 동등성을 검증한다. `sandbox.ts`의 alias 로직을 변경할 때는 반드시 server.js의 inline 로직도 함께 업데이트할 것.
+
 ## Platform Notes
 
 - macOS: bash/zsh default shell, .dmg/.zip packaging

--- a/docs/spec/migration-prd.md
+++ b/docs/spec/migration-prd.md
@@ -1,0 +1,254 @@
+# Migration PRD: aide → smalti (v0.2.x → v0.3.x)
+
+> **문서 버전**: 1.0  
+> **작성일**: 2026-05-02  
+> **대상 릴리즈**: v0.3.1  
+> **상태**: 초안(Draft)
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+smalti(구 aide)는 v0.2.0에서 브랜드 리네이밍을 수행했습니다. 사용자 데이터 디렉토리(`~/.aide/` → `~/.smalti/`), 워크스페이스 디렉토리(`<ws>/.aide/` → `<ws>/.smalti/`), Electron userData, 환경변수(`AIDE_*` → `SMALTI_*`), MCP 서버 엔트리, 커스텀 프로토콜 스킴 등 다수의 식별자가 변경되었습니다.
+
+v0.2.2 핫픽스(commit af12c95)에서 home, userData, workspace 디렉토리 마이그레이션 스크립트가 추가되었으나, 일부 영역에서 누락이 존재합니다.
+
+### 1.2 현재 발견된 버그: server.js sandbox alias 누락
+
+**증상**: MCP 서버를 통해 호출된 v0.1.x plugin이 `.aide/` 경로로 데이터를 읽으려 할 때, 빈 데이터를 반환하거나 `<ws>/.aide/` 아래에 새로운 빈 파일을 생성합니다. 사용자의 칸반 보드(86개 task)가 보이지 않는 실제 사례가 보고되었습니다.
+
+**근본 원인**: 두 개의 sandbox 구현이 존재합니다.
+
+| 구현 | 파일 | alias rewrite | 비고 |
+|------|------|---------------|------|
+| Electron 앱 내 sandbox | `src/main/plugin/sandbox.ts` | **있음** (`resolveWorkspaceRel()`) | v0.2.2에서 추가됨 |
+| MCP server standalone sandbox | `src/main/mcp/server.js` | **없음** | DRY 위반 — 동일 로직을 중복 구현했으나 alias를 누락 |
+
+`sandbox.ts:25`의 `resolveWorkspaceRel()` 함수는 `filePath.replace(/^(\.\/?)?\.aide(\/|$)/, '$1.smalti$2')`로 `.aide/` 접두사를 `.smalti/`로 rewrite합니다. 그러나 `server.js:78`의 `scopedFs.read()`는 `path.resolve(ws, fp)`만 수행하므로, `.aide/data.json`이라는 경로가 그대로 `<ws>/.aide/data.json`으로 resolve됩니다.
+
+**영향 범위**: MCP를 통해 plugin을 호출하는 모든 외부 에이전트(Claude, Gemini, Codex)가 영향을 받습니다. Electron 앱 내부의 iframe 기반 plugin 호출은 `sandbox.ts`를 거치므로 정상 동작합니다.
+
+### 1.3 마이그레이션 누락 영역 식별
+
+전체 코드베이스 감사 결과, 아래 누락/위험 영역이 식별되었습니다:
+
+1. **server.js sandbox alias** (P0 — 실제 데이터 유실 버그) — 본 작업의 T2에서 패치 완료
+2. **Migration 테스트 0건** — 단위 테스트가 전혀 없어 회귀 방지가 불가능
+3. **server.js 문서 문자열 내 `.aide/` 참조** — 에이전트에게 잘못된 경로를 안내
+4. **home migration marker 재실행 정책 불명확** — marker 존재 시 `.aide` 재출현에 대한 처리가 문서화되지 않음
+5. **Back-compat drop 일정 미정의** — 6개 이상의 legacy alias에 구체적 만료 버전 없음
+
+---
+
+## 2. 마이그레이션 영역 매트릭스
+
+| # | 영역 | 옛 위치/식별자 | 새 위치/식별자 | 현재 상태 | 이슈 |
+|---|------|---------------|---------------|-----------|------|
+| M1 | Home 데이터 디렉토리 | `~/.aide/` | `~/.smalti/` | **완료** | `migrate-aide-data.ts` — rename-first, merge fallback, marker 기록. 단, marker 존재 시 재실행 정책이 코드에만 존재하고 문서화 안 됨 |
+| M2 | Electron userData | `~/Library/Application Support/aide/` (macOS) | `.../Smalti/` | **완료** | `migrate-aide-userdata.ts` — `aide`, `AIDE` 두 후보 검색. `migrateAideUserData(app.getPath('userData'))` |
+| M3 | Workspace 데이터 디렉토리 | `<ws>/.aide/` | `<ws>/.smalti/` | **완료** | `migrate-aide-workspace.ts` — WORKSPACE_OPEN 시점 호출 |
+| M4 | MCP global config (Claude) | `~/.claude.json` → `mcpServers.aide` | `mcpServers.smalti` | **완료** | `config-writer.ts:77-81` — `aide` 키 삭제 + `smalti` 등록. `~/.claude.json`과 `~/.mcp.json`에서 legacy 엔트리 unregister |
+| M5 | MCP global config (Gemini) | `~/.gemini/settings.json` → `mcpServers.aide` | `mcpServers.smalti` | **완료** | `config-writer.ts:162` — `registerJsonMcpConfig()` 내부에서 aide→smalti 마이그레이션 |
+| M6 | MCP global config (Codex) | `~/.codex/config.toml` → `[mcp_servers.aide]` | `[mcp_servers.smalti]` | **완료** | `config-writer.ts:173` — TOML section 교체 |
+| M7 | Workspace `.mcp.json` | `<ws>/.mcp.json` → `mcpServers.aide` | 삭제 | **완료** | `migrateProjectMcpJson()` — aide 엔트리만 삭제. `smalti`는 `--mcp-config`로 별도 전달하므로 workspace-level 등록 불필요 |
+| M8 | 환경변수 | `AIDE_WORKSPACE` | `SMALTI_WORKSPACE` | **완료 (back-compat 유지)** | `env-compat.ts` — `SMALTI_*` 우선, `AIDE_*` fallback. `terminal-handlers.ts:148` — allowlist에 양쪽 포함. `server.js:19` — 양쪽 fallback |
+| M9 | 커스텀 프로토콜 스킴 | `aide-plugin://`, `aide-cdn://` | `smalti-plugin://`, `smalti-cdn://` | **완료 (back-compat 유지)** | `protocol.ts`, `cdn-protocol.ts` — 양쪽 스킴 모두 등록 |
+| M10 | MCP tool 이름 | `aide_create_plugin` 등 | `smalti_create_plugin` 등 | **완료 (back-compat 유지)** | `server.js:388-393` — deprecated alias 매핑 + 경고 |
+| M11 | MCP server script 위치 | `~/.aide/aide-mcp-server.js` | `~/.smalti/smalti-mcp-server.js` | **완료** | `config-writer.ts:56`. `index.ts:132-146` — dead-path 정리 |
+| M12 | **Sandbox alias (Electron)** | plugin이 `.aide/` 경로 사용 | `.smalti/`로 rewrite | **완료** | `sandbox.ts:21-27` — `resolveWorkspaceRel()` |
+| M13 | **Sandbox alias (MCP server)** | plugin이 `.aide/` 경로 사용 | `.smalti/`로 rewrite | **완료(T2 패치)** | `server.js`에 동등 함수 inline 추가 |
+| M14 | Plugin 전역 객체 | `aide.fs`, `aide.plugin` 등 | 유지 (`window.aide`) | **의도적 유지** | `sandbox.ts:145`, `server.js:101` — plugin API 식별자. breaking change 방지를 위해 유지 |
+| M15 | PostMessage 프로토콜 | `aide:file-event`, `aide:invoke` 등 | 유지 | **의도적 유지** | `protocol.ts:104`, `PluginView.tsx:19-43` — iframe 통신 프로토콜. 변경 시 모든 기존 plugin HTML이 깨짐 |
+| M16 | Preload API | `window.aide` (contextBridge) | 유지 | **의도적 유지** | `preload/index.ts:212` — renderer 전역 API. 내부 코드 전체가 의존 |
+| M17 | server.js 문서 문자열 | `.aide/settings.json`, `AIDE` 등 참조 | `.smalti/settings.json` 등 | **미완료 — P2** | L241, L319 등 에이전트에게 노출되는 설명 텍스트에 구버전 경로/브랜드명 잔존 |
+| M18 | CDN 캐시 디렉토리 | `~/.aide/cdn-cache/` | `~/.smalti/cdn-cache/` | **완료 (M1에 포함)** | home directory 전체 마이그레이션에 포함. `cdn-protocol.ts:52` — `~/.smalti/cdn-cache/` 하드코딩 |
+| M19 | 단위 테스트 | N/A | 없음 | **누락 — P0** | migration 관련 `*.test.ts` 파일 0개 (T4에서 추가) |
+
+---
+
+## 3. 수용 기준 (Acceptance Criteria)
+
+### AC-1: MCP sandbox alias (P0) — T2 완료
+
+**조건**: v0.1.x에서 생성된 plugin이 `require('fs').readFileSync('.aide/data.json', 'utf-8')` 형태로 데이터에 접근할 때  
+**결과**: MCP server의 `scopedFs`가 경로를 `.smalti/data.json`으로 rewrite하여 마이그레이션된 데이터를 정상 반환합니다.  
+**검증 방법**:
+- 단위 테스트: `scopedFs.read('.aide/foo.json')` 호출 시 `path.resolve(ws, '.smalti/foo.json')`으로 resolve되는지 assert
+- 단위 테스트: `scopedFs.write('.aide/bar.json', data)` 호출 시 동일하게 rewrite 확인
+- 단위 테스트: `scopedFs.existsSync('.aide/dir')` — rewrite 확인
+- 통합 테스트: MCP 프로토콜로 `smalti_invoke_tool` 호출 시 legacy path plugin이 정상 데이터 반환
+
+### AC-2: Sandbox alias 동등성 (P0)
+
+**조건**: `sandbox.ts`의 `resolveWorkspaceRel()`과 `server.js`의 path resolution이 동일한 입력에 대해  
+**결과**: 동일한 출력 경로를 생성합니다.  
+**검증 방법**:
+- 속성 기반 테스트: 랜덤 경로 패턴(`'.aide/x'`, `'./.aide/y'`, `'a/.aide/z'`, `'normal/path'`)에 대해 양쪽 구현의 결과가 동일한지 비교
+- 비rewrite 대상 경로(`.aide/`가 첫 번째 세그먼트가 아닌 경우)도 동일하게 통과하는지 확인
+
+### AC-3: Migration 멱등성 (P1)
+
+**조건**: `migrateAideToSmalti()`를 N회(N >= 2) 연속 호출할 때  
+**결과**: 1회 호출과 동일한 파일 시스템 상태를 생성하며, 에러 없이 완료됩니다.  
+**검증 방법**:
+- `migrate-aide-data.ts`: (a) `~/.aide` 존재 → 1회 호출 → 성공 → 2회 호출 → `skipped: 'no-aide-dir'`
+- `migrate-aide-workspace.ts`: 동일 패턴
+- `migrate-aide-userdata.ts`: 동일 패턴
+
+### AC-4: 부분 실패 복구 (P1)
+
+**조건**: merge 도중 일부 파일만 이동된 상태에서 프로세스가 재시작될 때  
+**결과**: 재실행 시 나머지 파일이 정상적으로 머지되며, 이미 이동된 파일은 dest-wins 정책에 따라 유지됩니다.
+
+### AC-5: MCP global config 마이그레이션 (P1)
+
+**조건**: `~/.claude.json`, `~/.gemini/settings.json`, `~/.codex/config.toml`에 `aide` 엔트리가 존재할 때  
+**결과**: `smalti` 엔트리로 교체되며, 다른 MCP 서버 설정은 보존됩니다.
+
+### AC-6: CDN 캐시 연속성 (P2)
+
+**조건**: `~/.aide/cdn-cache/` 캐시 파일이 마이그레이션 후  
+**결과**: `smalti-cdn://` 요청 시 캐시 히트로 서빙됩니다.
+
+### AC-7: server.js 문서 정확성 (P2)
+
+**조건**: `tools/list` description이  
+**결과**: `.smalti/settings.json`, `Smalti` 브랜드를 표시합니다.
+
+### AC-8: 회귀 방지 테스트 존재 (P0)
+
+**결과**: `pnpm test`에 migration 관련 테스트 스위트가 포함되며 모든 AC의 핵심 시나리오를 커버합니다.
+
+---
+
+## 4. 설계 원칙
+
+### 4.1 멱등성
+
+모든 마이그레이션 함수는 N회 호출 시 1회 호출과 동일한 결과를 보장합니다.
+
+- **marker 파일** (`<target>/.migrated-from-aide`): migration 완료 기록. marker가 존재하더라도 source(`.aide`)가 재출현한 경우 방어적으로 재머지를 시도합니다.
+- **skipped 반환**: source 부재 시 즉시 `{ migrated: false, skipped: 'no-aide-dir' }` 반환.
+- **중복 marker 방지**: marker 존재 시 다시 쓰지 않습니다.
+
+### 4.2 부분 실패 복구
+
+`mergeDirectory()`는 파일 단위 이동이며, 개별 파일 실패는 `warnings`로 기록하고 나머지 처리를 계속합니다.
+
+### 4.3 Rename-first / Merge-fallback 정책
+
+1. **Rename-first**: dest 부재 시 `fs.rename()` 단일 syscall (same-fs O(1))
+2. **EXDEV fallback**: cross-filesystem이면 `fs.cp()` + `fs.rm()`
+3. **Merge-fallback**: dest 존재 시 파일 단위 머지
+
+### 4.4 Marker 파일
+
+| marker 위치 | 의미 |
+|-------------|------|
+| `~/.smalti/.migrated-from-aide` | Home 마이그레이션 완료 |
+| `<ws>/.smalti/.migrated-from-aide` | 워크스페이스 마이그레이션 완료 |
+| `<userData>/.migrated-from-aide` | userData (aide 출처) |
+| `<userData>/.migrated-from-AIDE` | userData (AIDE 출처) |
+
+### 4.5 Back-compat 정책 (의도적 유지)
+
+| 식별자 | 유형 | drop 대상 버전 | 사유 |
+|--------|------|---------------|------|
+| `AIDE_WORKSPACE` env var | 환경변수 | v0.4.0 | server.js, terminal-handlers fallback |
+| `aide_create_plugin` 등 5개 tool alias | MCP tool 이름 | v0.4.0 | agent의 캐시된 구 이름 |
+| `aide-plugin://` 프로토콜 | Electron 커스텀 스킴 | v0.4.0 | 기존 plugin HTML 하드코딩 |
+| `aide-cdn://` 프로토콜 | Electron 커스텀 스킴 | v0.4.0 | 기존 plugin HTML 하드코딩 |
+| `window.aide` (preload API) | 전역 객체 | **무기한 유지** | 내부 + 모든 plugin 의존 |
+| `aide:file-event` 등 postMessage | iframe 프로토콜 | **무기한 유지** | plugin iframe 통신 핵심 |
+| `aide.fs`, `aide.plugin` (sandbox 전역) | Plugin sandbox API | **무기한 유지** | 모든 생성된 plugin code 의존 |
+| `.aide/` sandbox alias rewrite | Sandbox path 변환 | **무기한 유지** | 사용자 워크스페이스 구 plugin이 존재하는 한 필요 |
+
+---
+
+## 5. 구현 계획 (High-Level)
+
+### 5.1 Sandbox alias DRY refactor (선택지 D 권고)
+
+**제약**: server.js는 `?raw` import로 Vite에서 문자열로 읽혀 main process 번들에 포함되므로 TS module 직접 import 불가.
+
+**선택지 D (권고)**: server.js에 alias 로직 inline + sandbox.ts 동등성 검증 속성 테스트.
+
+### 5.2 server.js 누락 alias 즉시 패치 — **T2 완료**
+
+`scopedFs` 9개 메서드(`read`, `write`, `existsSync`, `readFileSync`, `writeFileSync`, `mkdirSync`, `readdirSync`, `statSync`, `unlinkSync`)에 alias rewrite 적용.
+
+### 5.3 마이그레이션 스크립트 보강
+
+1. home migration marker 재실행 동작 JSDoc 명시
+2. `migrateProjectMcpJson()`에서 `smalti` 키도 정리
+
+### 5.4 통합 테스트 (T4)
+
+| 테스트 파일 | 커버리지 |
+|------------|----------|
+| `src/main/__tests__/migrate-aide-data.test.ts` | AC-3, AC-4 |
+| `src/main/__tests__/migrate-aide-workspace.test.ts` | AC-3 |
+| `src/main/__tests__/migrate-aide-userdata.test.ts` | AC-3 |
+| `src/main/mcp/__tests__/server-sandbox-alias.test.ts` | AC-1, AC-2 (T2에서 일부 추가) |
+| `src/main/mcp/__tests__/config-writer-migration.test.ts` | AC-5 |
+
+### 5.5 server.js 문서 문자열 업데이트
+
+| 현재 | 수정 후 |
+|------|---------|
+| `aide_create_plugin` (CREATE_PLUGIN_DESC 내) | `smalti_create_plugin` |
+| `.aide/settings.json` | `.smalti/settings.json` |
+| `AIDE into all iframes` | `Smalti into all iframes` |
+
+`window.aide` 관련 참조는 실제 API 이름이므로 변경하지 않습니다.
+
+---
+
+## 6. 회귀 방지
+
+### 6.1 Sandbox 동등성 테스트
+
+```typescript
+const testCases = [
+  '.aide/data.json',
+  './.aide/plugins/todo/data.json',
+  'normal/path.txt',
+  '.aide',
+  '.aide/',
+  'a/.aide/nested',
+  '../.aide/escape',
+];
+
+for (const input of testCases) {
+  const tsResult = resolveWorkspaceRel('/ws', input);
+  const jsResult = serverResolveWorkspaceRel('/ws', input);
+  expect(tsResult).toBe(jsResult);
+}
+```
+
+### 6.2 CLAUDE.md Known Pitfalls 추가
+
+> **MCP server.js: sandbox alias는 sandbox.ts와 동기화 필수**  
+> `server.js`는 `?raw` import되는 standalone JS로, `sandbox.ts`의 `resolveWorkspaceRel()`을 import할 수 없습니다. server.js 내부에 동등 로직을 inline으로 유지하며, `server-sandbox-alias.test.ts`가 양쪽의 동등성을 검증합니다. `sandbox.ts`의 alias 로직을 변경할 때는 반드시 server.js의 inline 로직도 함께 업데이트하십시오.
+
+---
+
+## 7. 비범위 (Out of Scope)
+
+### 7.1 기존 plugin source code의 `.aide/` hardcode 일괄 rewrite
+
+사용자 워크스페이스 plugin의 JS 소스 직접 수정은 제외. sandbox alias가 런타임에 처리하므로 불필요.
+
+### 7.2 `window.aide` → `window.smalti` rename
+
+renderer 전체, plugin iframe, global.d.ts 등 60+ 변경 발생. 별도 프로젝트.
+
+### 7.3 Legacy productName 복원
+
+Electron `productName` 변경은 `migrateAideUserData()`로 이미 처리.
+
+### 7.4 CI/CD 파이프라인의 aide 참조 정리
+
+별도 진행.

--- a/src/main/ipc/workspace-handlers.ts
+++ b/src/main/ipc/workspace-handlers.ts
@@ -49,7 +49,10 @@ function nextColor(counter: number): string {
 
 /**
  * Migration: remove smalti-generated entries from {workspace}/.mcp.json.
- * If only smalti entries remain, delete the file entirely.
+ * Removes both 'aide' (legacy) and 'smalti' keys from mcpServers.
+ * smalti is passed via --mcp-config per-invocation, so workspace-level
+ * registration causes duplicate spawns.
+ * If no other servers remain, delete the file entirely.
  */
 export function migrateProjectMcpJson(workspacePath: string): void {
   const mcpPath = nodePath.join(workspacePath, '.mcp.json');
@@ -58,24 +61,28 @@ export function migrateProjectMcpJson(workspacePath: string): void {
     const raw = fs.readFileSync(mcpPath, 'utf-8');
     const config = JSON.parse(raw);
     if (!config.mcpServers || typeof config.mcpServers !== 'object') return;
-    if (!('aide' in config.mcpServers)) return;
+    if (!('aide' in config.mcpServers) && !('smalti' in config.mcpServers)) return;
 
+    // Remove legacy 'aide' entry
     delete config.mcpServers.aide;
+    // Remove 'smalti' entry — smalti is passed via --mcp-config per invocation,
+    // so workspace-level registration would cause duplicate spawns.
+    delete config.mcpServers.smalti;
 
     if (Object.keys(config.mcpServers).length === 0) {
       // No other servers — check if there are top-level keys besides mcpServers
       const topKeys = Object.keys(config).filter((k) => k !== 'mcpServers');
       if (topKeys.length === 0) {
         fs.unlinkSync(mcpPath);
-        console.log('[smalti] Removed legacy .mcp.json (smalti-only)');
+        console.log('[smalti] Removed legacy .mcp.json (aide+smalti entries only)');
       } else {
         delete config.mcpServers;
         fs.writeFileSync(mcpPath, JSON.stringify(config, null, 2));
-        console.log('[smalti] Removed aide entry and empty mcpServers from .mcp.json');
+        console.log('[smalti] Removed aide/smalti entries and empty mcpServers from .mcp.json');
       }
     } else {
       fs.writeFileSync(mcpPath, JSON.stringify(config, null, 2));
-      console.log('[smalti] Removed aide entry from .mcp.json (other servers preserved)');
+      console.log('[smalti] Removed aide/smalti entries from .mcp.json (other servers preserved)');
     }
   } catch {
     // Corrupt or unreadable — leave it alone

--- a/src/main/mcp/server.js
+++ b/src/main/mcp/server.js
@@ -60,6 +60,26 @@ function resolvePluginDir(pluginName) {
   return null;
 }
 
+/**
+ * Resolve a workspace-relative path, rewriting a leading `.aide/` segment to
+ * `.smalti/` so legacy plugins (v0.1.x) that hardcode `.aide/` as their data
+ * directory transparently see the migrated location.
+ *
+ * Only the first path segment is rewritten — `.aide/` buried inside a deeper
+ * path (e.g. `a/.aide/x`) is left untouched because that cannot be a workspace
+ * root data directory.
+ *
+ * Mirrors src/main/plugin/sandbox.ts resolveWorkspaceRel exactly.
+ * TODO(T3): unify with src/main/plugin/sandbox.ts resolveWorkspaceRel
+ */
+function resolveWorkspaceRel(ws, fp) {
+  // v0.1.x compat: pre-rebrand plugins hardcode `.aide/` as a workspace data
+  // dir. Rewrite first segment to `.smalti/` so legacy plugins see migrated
+  // data without needing regeneration.
+  var normalized = fp.replace(/^(\.\/?)?\.aide(\/|$)/, "$1.smalti$2");
+  return path.resolve(ws, normalized);
+}
+
 function invokePluginTool(pluginName, toolName, args) {
   const resolved = resolvePluginDir(pluginName);
   if (!resolved) throw new Error("Plugin not found: " + pluginName);
@@ -75,15 +95,15 @@ function invokePluginTool(pluginName, toolName, args) {
   function assertRead() { if (!hasFsRead) throw new Error("Permission denied: fs:read not granted"); }
   function assertWrite() { if (!hasFsWrite) throw new Error("Permission denied: fs:write not granted"); }
   var scopedFs = {
-    read: function(fp) { assertRead(); var a = path.resolve(ws, fp); assertInWs(a); return fs.readFileSync(a, "utf-8"); },
-    write: function(fp, c) { assertWrite(); var a = path.resolve(ws, fp); assertInWs(a); fs.writeFileSync(a, c); },
-    existsSync: function(fp) { var a = path.resolve(ws, fp); assertInWs(a); return fs.existsSync(a); },
-    readFileSync: function(fp, enc) { assertRead(); var a = path.resolve(ws, fp); assertInWs(a); return enc ? fs.readFileSync(a, enc) : fs.readFileSync(a); },
-    writeFileSync: function(fp, c) { assertWrite(); var a = path.resolve(ws, fp); assertInWs(a); fs.writeFileSync(a, c); },
-    mkdirSync: function(fp, opts) { assertWrite(); var a = path.resolve(ws, fp); assertInWs(a); fs.mkdirSync(a, opts); },
-    readdirSync: function(fp, opts) { assertRead(); var a = path.resolve(ws, fp); assertInWs(a); return fs.readdirSync(a, opts); },
-    statSync: function(fp) { var a = path.resolve(ws, fp); assertInWs(a); return fs.statSync(a); },
-    unlinkSync: function(fp) { assertWrite(); var a = path.resolve(ws, fp); assertInWs(a); fs.unlinkSync(a); }
+    read: function(fp) { assertRead(); var a = resolveWorkspaceRel(ws, fp); assertInWs(a); return fs.readFileSync(a, "utf-8"); },
+    write: function(fp, c) { assertWrite(); var a = resolveWorkspaceRel(ws, fp); assertInWs(a); fs.writeFileSync(a, c); },
+    existsSync: function(fp) { var a = resolveWorkspaceRel(ws, fp); assertInWs(a); return fs.existsSync(a); },
+    readFileSync: function(fp, enc) { assertRead(); var a = resolveWorkspaceRel(ws, fp); assertInWs(a); return enc ? fs.readFileSync(a, enc) : fs.readFileSync(a); },
+    writeFileSync: function(fp, c) { assertWrite(); var a = resolveWorkspaceRel(ws, fp); assertInWs(a); fs.writeFileSync(a, c); },
+    mkdirSync: function(fp, opts) { assertWrite(); var a = resolveWorkspaceRel(ws, fp); assertInWs(a); fs.mkdirSync(a, opts); },
+    readdirSync: function(fp, opts) { assertRead(); var a = resolveWorkspaceRel(ws, fp); assertInWs(a); return fs.readdirSync(a, opts); },
+    statSync: function(fp) { var a = resolveWorkspaceRel(ws, fp); assertInWs(a); return fs.statSync(a); },
+    unlinkSync: function(fp) { assertWrite(); var a = resolveWorkspaceRel(ws, fp); assertInWs(a); fs.unlinkSync(a); }
   };
   var sandboxRequire = function(id) {
     if (id === "path") return path;
@@ -202,7 +222,7 @@ Sandbox Environment:
 - aide.files.reveal(path) / aide.files.select(path) / aide.files.refresh() → control the FILES tab (no-op in MCP context, functional in Electron UI)
 - aide.plugins.emit(event, data) → broadcast event to other plugins (no-op in MCP context)
 - No network access, no child_process, no other Node.js modules
-- An index.html is auto-generated for iframe rendering. Pass the optional 'html' parameter to aide_create_plugin to provide a custom UI in one step.
+- An index.html is auto-generated for iframe rendering. Pass the optional 'html' parameter to smalti_create_plugin to provide a custom UI in one step.
 
 HTML UI (iframe) Event API:
 Plugin iframes receive FILES tab events via postMessage from the Smalti renderer.
@@ -238,7 +258,7 @@ Invoking backend tools from iframe:
       document.getElementById('preview').src = URL.createObjectURL(blob);
     });
 
-eventBindings (.aide/settings.json): controls backend tool invocation on file events only — separate from iframe postMessage.
+eventBindings (.smalti/settings.json): controls backend tool invocation on file events only — separate from iframe postMessage.
   Example: { "eventBindings": { "file:clicked": [{ "plugin": "my-plugin", "tool": "on-file-clicked", "args": {} }] } }
 
 Theme Support (REQUIRED):
@@ -316,7 +336,7 @@ function getBuiltinTools() {
           code: { type: "string", description: "Complete plugin source code (CommonJS module)" },
           permissions: { type: "array", items: { type: "string" }, description: "Required permissions: fs:read, fs:write, network, process" },
           tools: { type: "array", description: "Tool definitions the plugin exposes", items: { type: "object", properties: { name: { type: "string" }, description: { type: "string" }, parameters: { type: "object" } } } },
-          html: { type: "string", description: "Optional custom index.html for the plugin iframe UI. If omitted, a default UI is auto-generated. The window.aide shim (on, invoke, emit, theme) is automatically injected by AIDE into all iframes — you do not need to include it manually." },
+          html: { type: "string", description: "Optional custom index.html for the plugin iframe UI. If omitted, a default UI is auto-generated. The window.aide shim (on, invoke, emit, theme) is automatically injected by Smalti into all iframes — you do not need to include it manually." },
           fileAssociations: { type: "array", items: { type: "string" }, description: "File extensions or glob patterns this plugin handles (e.g. [\".html\", \".css\", \"*.json\"]). Used to associate the plugin with file types in the file tree." }
         },
         required: ["name", "description", "code"]

--- a/src/main/mcp/server.js
+++ b/src/main/mcp/server.js
@@ -258,6 +258,11 @@ Invoking backend tools from iframe:
       document.getElementById('preview').src = URL.createObjectURL(blob);
     });
 
+Workspace data path convention:
+- Plugin data files MUST be stored under <workspace>/.smalti/ (NOT .aide/).
+- Default path pattern: '.smalti/<plugin-name>.json' or '.smalti/<plugin-name>.<key>.json'.
+- Legacy plugins that hardcode '.aide/' still work (sandbox auto-rewrites to .smalti/), but new plugins should use .smalti/ directly to keep API responses (e.g. echoed filePath fields) consistent with disk reality.
+
 eventBindings (.smalti/settings.json): controls backend tool invocation on file events only — separate from iframe postMessage.
   Example: { "eventBindings": { "file:clicked": [{ "plugin": "my-plugin", "tool": "on-file-clicked", "args": {} }] } }
 

--- a/src/main/migrate-aide-data.ts
+++ b/src/main/migrate-aide-data.ts
@@ -20,6 +20,14 @@
  * Marker (~/.smalti/.migrated-from-aide) records that migration has run, so
  * future launches don't redo the merge.
  *
+ * Marker re-run policy:
+ *   - If the marker exists AND ~/.aide is absent: skip entirely (idempotent).
+ *   - If the marker exists BUT ~/.aide has reappeared (e.g. user restored a
+ *     backup or another tool recreated it): the merge path runs defensively
+ *     so any new files in ~/.aide are moved to ~/.smalti. The marker is NOT
+ *     rewritten in this case (it already exists). This ensures partial-failure
+ *     recovery works across process restarts without double-writing the marker.
+ *
  * Failures are surfaced via the returned MigrateResult AND a console.warn so
  * post-mortem debugging is possible (the previous copy-only version swallowed
  * delete errors silently and left ~/.aide on disk).

--- a/tests/unit/config-writer-migration.test.ts
+++ b/tests/unit/config-writer-migration.test.ts
@@ -1,0 +1,285 @@
+/**
+ * AC-5: MCP global config migration tests.
+ *
+ * Covers cases not already tested in mcp-config-write.test.ts and
+ * unregister-smalti-claude-global.test.ts:
+ *
+ *   1. ~/.claude.json — aide entry deleted, other servers preserved (via writeMcpConfig).
+ *   2. ~/.gemini/settings.json — aide → smalti replacement, other servers preserved.
+ *   3. ~/.codex/config.toml — aide section → smalti section, other sections + array
+ *      values preserved (TOML alternation safety: args = ["x"] must survive).
+ *   4. removeTomlSection TOML alternation: adjacent section with array value not corrupted.
+ *
+ * Uses vi.mock to sandbox HOME and Electron app so no real config files are touched.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+let sandboxHome: string;
+
+vi.mock('../../src/main/utils/home', () => ({
+  getHome: () => sandboxHome,
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name === 'userData')
+        return path.join(sandboxHome, 'Library', 'Application Support', 'Smalti');
+      return sandboxHome;
+    },
+  },
+}));
+
+vi.mock('../../src/main/mcp/server.js?raw', () => ({
+  default: '#!/usr/bin/env node\n// stub\n',
+}));
+
+async function loadConfigWriter() {
+  return await import('../../src/main/mcp/config-writer');
+}
+
+// ── shared setup ────────────────────────────────────────────────────────────
+
+function makeCodexConfig(...sections: string[]): string {
+  return sections.join('\n\n');
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+describe('config-writer migration — AC-5', () => {
+  beforeEach(() => {
+    sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cfg-migration-test-'));
+    fs.mkdirSync(
+      path.join(sandboxHome, 'Library', 'Application Support', 'Smalti'),
+      { recursive: true },
+    );
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    fs.rmSync(sandboxHome, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  // ── 1. ~/.claude.json: aide removed, other server preserved ─────────────
+
+  describe('~/.claude.json', () => {
+    it('removes aide entry and preserves other servers when writeMcpConfig runs', async () => {
+      const claudePath = path.join(sandboxHome, '.claude.json');
+      fs.writeFileSync(
+        claudePath,
+        JSON.stringify(
+          {
+            mcpServers: {
+              aide: { command: 'node', args: ['/old/aide-mcp-server.js'] },
+              sentry: { command: 'sentry-mcp', args: ['--port', '3000'] },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      const { writeMcpConfig } = await loadConfigWriter();
+      writeMcpConfig(path.join(sandboxHome, 'workspace'));
+
+      const cfg = JSON.parse(fs.readFileSync(claudePath, 'utf-8'));
+      expect(cfg.mcpServers.aide).toBeUndefined();
+      expect(cfg.mcpServers.sentry).toBeDefined();
+      expect(cfg.mcpServers.sentry.command).toBe('sentry-mcp');
+    });
+
+    it('removes both aide and smalti entries via unregisterSmaltiFromJsonConfig', async () => {
+      const claudePath = path.join(sandboxHome, '.claude.json');
+      fs.writeFileSync(
+        claudePath,
+        JSON.stringify({
+          mcpServers: {
+            aide: { command: 'node', args: ['/old'] },
+            smalti: { command: 'node', args: ['/new'] },
+            other: { command: 'py', args: ['run.py'] },
+          },
+        }),
+      );
+
+      const { unregisterSmaltiFromJsonConfig } = await loadConfigWriter();
+      unregisterSmaltiFromJsonConfig(claudePath);
+
+      const cfg = JSON.parse(fs.readFileSync(claudePath, 'utf-8'));
+      expect(cfg.mcpServers.aide).toBeUndefined();
+      expect(cfg.mcpServers.smalti).toBeUndefined();
+      expect(cfg.mcpServers.other).toBeDefined();
+    });
+  });
+
+  // ── 2. ~/.gemini/settings.json: aide → smalti, other servers preserved ──
+
+  describe('~/.gemini/settings.json', () => {
+    it('replaces aide entry with smalti entry, preserves other servers', async () => {
+      const geminiPath = path.join(sandboxHome, '.gemini', 'settings.json');
+      fs.mkdirSync(path.dirname(geminiPath), { recursive: true });
+      fs.writeFileSync(
+        geminiPath,
+        JSON.stringify(
+          {
+            mcpServers: {
+              aide: { command: 'node', args: ['/old/aide-mcp-server.js'] },
+              another: { command: 'bun', args: ['serve.ts'] },
+            },
+            theme: 'dark',
+          },
+          null,
+          2,
+        ),
+      );
+
+      const { writeMcpConfig } = await loadConfigWriter();
+      writeMcpConfig(path.join(sandboxHome, 'workspace'));
+
+      const cfg = JSON.parse(fs.readFileSync(geminiPath, 'utf-8'));
+      expect(cfg.mcpServers.aide).toBeUndefined();
+      expect(cfg.mcpServers.smalti).toBeDefined();
+      expect(cfg.mcpServers.smalti.args[0]).toContain('smalti-mcp-server.js');
+      expect(cfg.mcpServers.another).toBeDefined();
+      expect(cfg.mcpServers.another.command).toBe('bun');
+      // Top-level non-mcpServers key preserved
+      expect(cfg.theme).toBe('dark');
+    });
+
+    it('creates settings.json if absent and registers smalti entry', async () => {
+      const geminiPath = path.join(sandboxHome, '.gemini', 'settings.json');
+      expect(fs.existsSync(geminiPath)).toBe(false);
+
+      const { writeMcpConfig } = await loadConfigWriter();
+      writeMcpConfig(path.join(sandboxHome, 'workspace'));
+
+      const cfg = JSON.parse(fs.readFileSync(geminiPath, 'utf-8'));
+      expect(cfg.mcpServers.smalti).toBeDefined();
+      expect(cfg.mcpServers.aide).toBeUndefined();
+    });
+  });
+
+  // ── 3. ~/.codex/config.toml: aide section → smalti, other sections survive
+
+  describe('~/.codex/config.toml', () => {
+    it('replaces [mcp_servers.aide] with [mcp_servers.smalti], preserves other sections', async () => {
+      const codexPath = path.join(sandboxHome, '.codex', 'config.toml');
+      fs.mkdirSync(path.dirname(codexPath), { recursive: true });
+      fs.writeFileSync(
+        codexPath,
+        makeCodexConfig(
+          '[mcp_servers.aide]\ncommand = "node"\nargs = ["/old/aide-mcp-server.js"]',
+          '[mcp_servers.other]\ncommand = "python"\nargs = ["other.py"]',
+        ),
+      );
+
+      const { writeMcpConfig } = await loadConfigWriter();
+      writeMcpConfig(path.join(sandboxHome, 'workspace'));
+
+      const content = fs.readFileSync(codexPath, 'utf-8');
+      expect(content).not.toContain('[mcp_servers.aide]');
+      expect(content).toContain('[mcp_servers.smalti]');
+      expect(content).toContain('[mcp_servers.other]');
+      expect(content).toContain('python');
+    });
+
+    // ── 4. TOML alternation safety: args = ["x"] adjacent to aide section ──
+    //
+    // CLAUDE.md pitfall: `[^[]*` regex stops at first `[` inside array values.
+    // The current removeTomlSection uses line-by-line parsing to avoid this.
+    // Verify that `args = ["server.js"]` in the neighbouring section is intact.
+
+    it('preserves args = ["..."] array values in sections adjacent to removed [mcp_servers.aide]', async () => {
+      const codexPath = path.join(sandboxHome, '.codex', 'config.toml');
+      fs.mkdirSync(path.dirname(codexPath), { recursive: true });
+      // The adjacent section has an array value with `[` inside — this is what
+      // a naive character-class regex would break on.
+      fs.writeFileSync(
+        codexPath,
+        [
+          '[mcp_servers.aide]',
+          'command = "node"',
+          'args = ["/old/server.js"]',
+          '',
+          '[mcp_servers.keep]',
+          'command = "deno"',
+          'args = ["run", "--allow-all", "server.js"]',
+        ].join('\n'),
+      );
+
+      const { writeMcpConfig } = await loadConfigWriter();
+      writeMcpConfig(path.join(sandboxHome, 'workspace'));
+
+      const content = fs.readFileSync(codexPath, 'utf-8');
+      // aide section gone
+      expect(content).not.toContain('[mcp_servers.aide]');
+      // keep section fully intact
+      expect(content).toContain('[mcp_servers.keep]');
+      expect(content).toContain('command = "deno"');
+      expect(content).toContain('args = ["run", "--allow-all", "server.js"]');
+    });
+
+    it('handles config.toml with only [mcp_servers.aide] — produces valid smalti-only file', async () => {
+      const codexPath = path.join(sandboxHome, '.codex', 'config.toml');
+      fs.mkdirSync(path.dirname(codexPath), { recursive: true });
+      fs.writeFileSync(
+        codexPath,
+        '[mcp_servers.aide]\ncommand = "node"\nargs = ["/old/aide-mcp-server.js"]\n',
+      );
+
+      const { writeMcpConfig } = await loadConfigWriter();
+      writeMcpConfig(path.join(sandboxHome, 'workspace'));
+
+      const content = fs.readFileSync(codexPath, 'utf-8');
+      expect(content).not.toContain('[mcp_servers.aide]');
+      expect(content).toContain('[mcp_servers.smalti]');
+    });
+
+    it('creates config.toml if absent and writes [mcp_servers.smalti]', async () => {
+      const codexPath = path.join(sandboxHome, '.codex', 'config.toml');
+      expect(fs.existsSync(codexPath)).toBe(false);
+
+      const { writeMcpConfig } = await loadConfigWriter();
+      writeMcpConfig(path.join(sandboxHome, 'workspace'));
+
+      const content = fs.readFileSync(codexPath, 'utf-8');
+      expect(content).toContain('[mcp_servers.smalti]');
+    });
+
+    it('preserves sub-sections like [mcp_servers.aide.env] when removing aide (line-by-line safety)', async () => {
+      const codexPath = path.join(sandboxHome, '.codex', 'config.toml');
+      fs.mkdirSync(path.dirname(codexPath), { recursive: true });
+      fs.writeFileSync(
+        codexPath,
+        [
+          '[mcp_servers.aide]',
+          'command = "node"',
+          'args = ["/old/server.js"]',
+          '',
+          '[mcp_servers.aide.env]',
+          'AIDE_WORKSPACE = "/projects/mine"',
+          '',
+          '[mcp_servers.unrelated]',
+          'command = "go"',
+          'args = ["run", "main.go"]',
+        ].join('\n'),
+      );
+
+      const { writeMcpConfig } = await loadConfigWriter();
+      writeMcpConfig(path.join(sandboxHome, 'workspace'));
+
+      const content = fs.readFileSync(codexPath, 'utf-8');
+      // Both aide and aide.env must be gone
+      expect(content).not.toContain('[mcp_servers.aide]');
+      expect(content).not.toContain('[mcp_servers.aide.env]');
+      // Unrelated section must survive
+      expect(content).toContain('[mcp_servers.unrelated]');
+      expect(content).toContain('command = "go"');
+      // New smalti section present
+      expect(content).toContain('[mcp_servers.smalti]');
+    });
+  });
+});

--- a/tests/unit/migrate-aide-data.test.ts
+++ b/tests/unit/migrate-aide-data.test.ts
@@ -140,4 +140,51 @@ describe('migrateAideToSmalti', () => {
     expect(result.skipped).toBe('no-aide-dir');
     expect(result.deletedLegacy).toBeUndefined();
   });
+
+  // ── AC-4: partial-failure recovery ──────────────────────────────────────────
+  // ~/.aide has a, b, c. Only a exists in ~/.smalti already (conflict).
+  // Migration must move b and c, keep a as the dest version.
+
+  it('partial-failure recovery: moves b,c when only a conflicts with dest', async () => {
+    await fsp.mkdir(aideDir);
+    await fsp.mkdir(smaltiDir);
+    await fsp.writeFile(path.join(aideDir, 'a.json'), 'aide-a');
+    await fsp.writeFile(path.join(aideDir, 'b.json'), 'b-content');
+    await fsp.writeFile(path.join(aideDir, 'c.json'), 'c-content');
+    // dest already has 'a' — it wins
+    await fsp.writeFile(path.join(smaltiDir, 'a.json'), 'smalti-a');
+
+    const result = await migrateAideToSmalti();
+
+    expect(result.migrated).toBe(true);
+    expect(result.mode).toBe('merged');
+    expect(result.deletedLegacy).toBe(true);
+
+    // dest version preserved for conflicting file
+    expect(await fsp.readFile(path.join(smaltiDir, 'a.json'), 'utf-8')).toBe('smalti-a');
+    // non-conflicting files moved over
+    expect(await fsp.readFile(path.join(smaltiDir, 'b.json'), 'utf-8')).toBe('b-content');
+    expect(await fsp.readFile(path.join(smaltiDir, 'c.json'), 'utf-8')).toBe('c-content');
+    // source removed
+    expect(fs.existsSync(aideDir)).toBe(false);
+  });
+
+  // ── AC-3: marker present but ~/.aide reappeared → defensive re-merge ────────
+
+  it('re-merges when marker exists but ~/.aide has reappeared, marker preserved', async () => {
+    // Simulate: prior migration wrote marker, then ~/.aide recreated externally
+    await fsp.mkdir(smaltiDir, { recursive: true });
+    await fsp.writeFile(marker, '2026-01-01T00:00:00Z');
+    await fsp.mkdir(aideDir);
+    await fsp.writeFile(path.join(aideDir, 'reappeared.json'), 'new-data');
+
+    const result = await migrateAideToSmalti();
+
+    expect(result.migrated).toBe(true);
+    expect(result.mode).toBe('merged');
+    expect(fs.existsSync(path.join(smaltiDir, 'reappeared.json'))).toBe(true);
+    expect(fs.existsSync(aideDir)).toBe(false);
+    // Existing marker timestamp untouched (merge branch does not overwrite)
+    expect(await fsp.readFile(marker, 'utf-8')).toBe('2026-01-01T00:00:00Z');
+  });
 });

--- a/tests/unit/server-sandbox-alias.test.ts
+++ b/tests/unit/server-sandbox-alias.test.ts
@@ -1,0 +1,563 @@
+/**
+ * Tests for the `.aide/` → `.smalti/` path alias in the MCP server's
+ * scopedFs (server.js invokePluginTool). Mirrors the same cases tested for
+ * sandbox.ts in sandbox-aide-alias.test.ts — the two implementations must be
+ * semantically equivalent.
+ *
+ * Unit tests: extract resolveWorkspaceRel from server.js via vm and verify
+ * all 7 alias cases match sandbox.ts behaviour.
+ *
+ * Integration test: spawn server.js as a child process with a temp workspace
+ * containing a legacy plugin that hardcodes `.aide/` paths, and verify the
+ * alias rewrites transparently resolve to `.smalti/` data.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as vm from 'node:vm';
+import { execFileSync } from 'node:child_process';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract and evaluate the resolveWorkspaceRel function from server.js.
+ * We match only that function so we don't trigger the stdin listener.
+ */
+function loadResolveWorkspaceRel(): (ws: string, fp: string) => string {
+  const serverSource = fs.readFileSync(
+    path.resolve(__dirname, '../../src/main/mcp/server.js'),
+    'utf-8',
+  );
+
+  const match = serverSource.match(/function resolveWorkspaceRel\b[\s\S]*?\n\}/);
+  if (!match) {
+    throw new Error(
+      'resolveWorkspaceRel not found in server.js — has the function been added yet?',
+    );
+  }
+
+  const sandbox = { path, module: { exports: {} as Record<string, unknown> }, exports: {} };
+  const code = `${match[0]}\nmodule.exports = resolveWorkspaceRel;`;
+  vm.runInNewContext(code, sandbox);
+  return sandbox.module.exports as unknown as (ws: string, fp: string) => string;
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests — resolveWorkspaceRel alias cases
+// ---------------------------------------------------------------------------
+
+const WS = '/workspace/myproject';
+
+describe('server.js resolveWorkspaceRel — .aide alias (unit)', () => {
+  let resolveWorkspaceRel: (ws: string, fp: string) => string;
+
+  beforeEach(() => {
+    resolveWorkspaceRel = loadResolveWorkspaceRel();
+  });
+
+  it('rewrites .aide/file to .smalti/file', () => {
+    expect(resolveWorkspaceRel(WS, '.aide/agent-todos.json')).toBe(
+      path.resolve(WS, '.smalti', 'agent-todos.json'),
+    );
+  });
+
+  it('rewrites bare .aide to .smalti', () => {
+    expect(resolveWorkspaceRel(WS, '.aide')).toBe(path.resolve(WS, '.smalti'));
+  });
+
+  it('rewrites ./.aide/x to .smalti/x', () => {
+    expect(resolveWorkspaceRel(WS, './.aide/x')).toBe(
+      path.resolve(WS, '.smalti', 'x'),
+    );
+  });
+
+  it('leaves .smalti/ paths unchanged', () => {
+    expect(resolveWorkspaceRel(WS, '.smalti/x')).toBe(
+      path.resolve(WS, '.smalti', 'x'),
+    );
+  });
+
+  it('does not rewrite .aide in a non-root segment', () => {
+    expect(resolveWorkspaceRel(WS, 'a/.aide/x')).toBe(
+      path.resolve(WS, 'a', '.aide', 'x'),
+    );
+  });
+
+  it('leaves plugin paths without .aide unchanged', () => {
+    expect(resolveWorkspaceRel(WS, 'plugins/agent-todo-board/index.html')).toBe(
+      path.resolve(WS, 'plugins', 'agent-todo-board', 'index.html'),
+    );
+  });
+
+  it('does not rewrite identifiers without a leading dot-aide pattern', () => {
+    expect(resolveWorkspaceRel(WS, 'aide-foo')).toBe(
+      path.resolve(WS, 'aide-foo'),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scopedFs alias coverage — each of the 9 methods rewrites .aide/ input
+// ---------------------------------------------------------------------------
+// These tests use the invokePluginTool path end-to-end via a minimal plugin
+// so that each scopedFs method's alias rewrite is exercised in isolation.
+// ---------------------------------------------------------------------------
+
+describe('server.js scopedFs — .aide/ alias per method', () => {
+  let tmpDir: string;
+  let wsDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smalti-scopedfs-test-'));
+    wsDir = path.join(tmpDir, 'workspace');
+    fs.mkdirSync(path.join(wsDir, '.smalti'), { recursive: true });
+
+    // Plugin directory lives at <ws>/.smalti/plugins/<name>
+    const pluginDir = path.join(wsDir, '.smalti', 'plugins', 'alias-test');
+    fs.mkdirSync(path.join(pluginDir, 'src'), { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, 'plugin.spec.json'),
+      JSON.stringify({
+        id: 'plugin-alias-test',
+        name: 'alias-test',
+        description: 'scopedFs alias coverage',
+        version: '0.1.0',
+        permissions: ['fs:read', 'fs:write'],
+        entryPoint: 'src/index.js',
+        tools: [{ name: 'run', description: 'run', parameters: { type: 'object', properties: {} } }],
+      }),
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, 'tool.json'),
+      JSON.stringify({
+        pluginId: 'plugin-alias-test',
+        pluginName: 'alias-test',
+        version: '0.1.0',
+        tools: [{ name: 'run', description: 'run', parameters: { type: 'object', properties: {} } }],
+      }),
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Helper: write plugin code, invoke 'run', return stdout JSON result. */
+  function runPlugin(code: string): unknown {
+    const serverPath = path.resolve(__dirname, '../../src/main/mcp/server.js');
+    const pluginDir = path.join(wsDir, '.smalti', 'plugins', 'alias-test');
+    fs.writeFileSync(path.join(pluginDir, 'src', 'index.js'), code);
+
+    const request =
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'smalti_invoke_tool',
+          arguments: { plugin_name: 'alias-test', tool_name: 'run', args: {} },
+        },
+      }) + '\n';
+
+    const stdout = execFileSync(process.execPath, [serverPath], {
+      cwd: wsDir,
+      env: { ...process.env, SMALTI_WORKSPACE: wsDir },
+      input: request,
+      encoding: 'utf-8',
+      timeout: 5000,
+    });
+
+    const lines = stdout.trim().split('\n').filter(Boolean);
+    const response = JSON.parse(lines[lines.length - 1]);
+    if (response.error) throw new Error(`MCP error: ${JSON.stringify(response.error)}`);
+    return JSON.parse(response.result.content[0].text);
+  }
+
+  it('read: .aide/data.txt → resolves to .smalti/data.txt', () => {
+    fs.writeFileSync(path.join(wsDir, '.smalti', 'data.txt'), 'hello-read');
+    const result = runPlugin(`
+      "use strict";
+      const fs = require('fs');
+      module.exports = {
+        invoke: function() { return fs.read('.aide/data.txt'); }
+      };
+    `);
+    expect(result).toBe('hello-read');
+  });
+
+  it('write: .aide/out.txt → writes to .smalti/out.txt', () => {
+    const result = runPlugin(`
+      "use strict";
+      const fs = require('fs');
+      module.exports = {
+        invoke: function() { fs.write('.aide/out.txt', 'written'); return 'ok'; }
+      };
+    `);
+    expect(result).toBe('ok');
+    expect(fs.readFileSync(path.join(wsDir, '.smalti', 'out.txt'), 'utf-8')).toBe('written');
+  });
+
+  it('existsSync: .aide/x.txt → checks .smalti/x.txt', () => {
+    fs.writeFileSync(path.join(wsDir, '.smalti', 'x.txt'), '1');
+    const result = runPlugin(`
+      "use strict";
+      const fs = require('fs');
+      module.exports = {
+        invoke: function() { return fs.existsSync('.aide/x.txt'); }
+      };
+    `);
+    expect(result).toBe(true);
+  });
+
+  it('readFileSync: .aide/r.json → reads .smalti/r.json', () => {
+    fs.writeFileSync(path.join(wsDir, '.smalti', 'r.json'), '{"v":42}');
+    const result = runPlugin(`
+      "use strict";
+      const fs = require('fs');
+      module.exports = {
+        invoke: function() { return JSON.parse(fs.readFileSync('.aide/r.json', 'utf-8')); }
+      };
+    `);
+    expect((result as { v: number }).v).toBe(42);
+  });
+
+  it('writeFileSync: .aide/wf.txt → writes to .smalti/wf.txt', () => {
+    const result = runPlugin(`
+      "use strict";
+      const fs = require('fs');
+      module.exports = {
+        invoke: function() { fs.writeFileSync('.aide/wf.txt', 'wf-content'); return 'ok'; }
+      };
+    `);
+    expect(result).toBe('ok');
+    expect(fs.readFileSync(path.join(wsDir, '.smalti', 'wf.txt'), 'utf-8')).toBe('wf-content');
+  });
+
+  it('mkdirSync: .aide/newdir → creates .smalti/newdir', () => {
+    const result = runPlugin(`
+      "use strict";
+      const fs = require('fs');
+      module.exports = {
+        invoke: function() { fs.mkdirSync('.aide/newdir', { recursive: true }); return 'ok'; }
+      };
+    `);
+    expect(result).toBe('ok');
+    expect(fs.existsSync(path.join(wsDir, '.smalti', 'newdir'))).toBe(true);
+  });
+
+  it('readdirSync: .aide/ → lists .smalti/ entries', () => {
+    fs.writeFileSync(path.join(wsDir, '.smalti', 'entry-a.txt'), 'a');
+    fs.writeFileSync(path.join(wsDir, '.smalti', 'entry-b.txt'), 'b');
+    const result = runPlugin(`
+      "use strict";
+      const fs = require('fs');
+      module.exports = {
+        invoke: function() { return fs.readdirSync('.aide/'); }
+      };
+    `) as string[];
+    expect(result).toContain('entry-a.txt');
+    expect(result).toContain('entry-b.txt');
+  });
+
+  it('statSync: .aide/stat.txt → stats .smalti/stat.txt', () => {
+    fs.writeFileSync(path.join(wsDir, '.smalti', 'stat.txt'), 'stat-me');
+    const result = runPlugin(`
+      "use strict";
+      const fs = require('fs');
+      module.exports = {
+        invoke: function() { var s = fs.statSync('.aide/stat.txt'); return { isFile: s.isFile() }; }
+      };
+    `) as { isFile: boolean };
+    expect(result.isFile).toBe(true);
+  });
+
+  it('unlinkSync: .aide/del.txt → deletes .smalti/del.txt', () => {
+    fs.writeFileSync(path.join(wsDir, '.smalti', 'del.txt'), 'delete-me');
+    const result = runPlugin(`
+      "use strict";
+      const fs = require('fs');
+      module.exports = {
+        invoke: function() { fs.unlinkSync('.aide/del.txt'); return 'ok'; }
+      };
+    `);
+    expect(result).toBe('ok');
+    expect(fs.existsSync(path.join(wsDir, '.smalti', 'del.txt'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Boundary escape — alias rewrite must not loosen workspace boundary check
+// ---------------------------------------------------------------------------
+
+describe('server.js scopedFs — boundary check survives alias rewrite', () => {
+  let tmpDir: string;
+  let wsDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smalti-boundary-test-'));
+    wsDir = path.join(tmpDir, 'workspace');
+    fs.mkdirSync(path.join(wsDir, '.smalti'), { recursive: true });
+
+    const pluginDir = path.join(wsDir, '.smalti', 'plugins', 'escape-test');
+    fs.mkdirSync(path.join(pluginDir, 'src'), { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, 'plugin.spec.json'),
+      JSON.stringify({
+        id: 'plugin-escape-test',
+        name: 'escape-test',
+        description: 'boundary escape test',
+        version: '0.1.0',
+        permissions: ['fs:read'],
+        entryPoint: 'src/index.js',
+        tools: [{ name: 'run', description: 'run', parameters: { type: 'object', properties: {} } }],
+      }),
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, 'tool.json'),
+      JSON.stringify({
+        pluginId: 'plugin-escape-test',
+        pluginName: 'escape-test',
+        version: '0.1.0',
+        tools: [{ name: 'run', description: 'run', parameters: { type: 'object', properties: {} } }],
+      }),
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('rejects .aide/../../escape path even after alias rewrite', () => {
+    const serverPath = path.resolve(__dirname, '../../src/main/mcp/server.js');
+    // Write a secret outside workspace to ensure we are not accidentally reading it
+    fs.writeFileSync(path.join(tmpDir, 'secret.txt'), 'outside-workspace');
+
+    const pluginCode = `
+      "use strict";
+      const fs = require('fs');
+      module.exports = {
+        invoke: function() {
+          // After alias rewrite, resolves to <ws>/.smalti/../../escape = outside ws
+          return fs.read('.aide/../../secret.txt');
+        }
+      };
+    `;
+    fs.writeFileSync(
+      path.join(wsDir, '.smalti', 'plugins', 'escape-test', 'src', 'index.js'),
+      pluginCode,
+    );
+
+    const request =
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'smalti_invoke_tool',
+          arguments: { plugin_name: 'escape-test', tool_name: 'run', args: {} },
+        },
+      }) + '\n';
+
+    const stdout = execFileSync(process.execPath, [serverPath], {
+      cwd: wsDir,
+      env: { ...process.env, SMALTI_WORKSPACE: wsDir },
+      input: request,
+      encoding: 'utf-8',
+      timeout: 5000,
+    });
+
+    const lines = stdout.trim().split('\n').filter(Boolean);
+    const response = JSON.parse(lines[lines.length - 1]);
+    // The server must return an error, not the secret content
+    expect(response.error).toBeDefined();
+    expect(JSON.stringify(response.error)).toMatch(/[Aa]ccess denied|outside workspace/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration test — invokePluginTool applies alias end-to-end
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal fake plugin in a temp workspace, spawn server.js with that
+ * workspace as cwd (so PLUGINS_DIR = wsDir/.smalti/plugins), send a JSON-RPC
+ * smalti_invoke_tool call, and assert the legacy `.aide/` path in the plugin
+ * code is transparently resolved to `.smalti/` data.
+ */
+describe('server.js invokePluginTool — .aide alias integration', () => {
+  let tmpDir: string;
+  let wsDir: string;
+
+  const SAMPLE_DATA = JSON.stringify({
+    version: 2,
+    tasks: [{ id: 't1', title: 'hello' }],
+  });
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smalti-mcp-test-'));
+    wsDir = path.join(tmpDir, 'workspace');
+
+    // Post-rebrand data lives at `.smalti/`
+    fs.mkdirSync(path.join(wsDir, '.smalti'), { recursive: true });
+    fs.writeFileSync(
+      path.join(wsDir, '.smalti', 'agent-todos.agent-todos.json'),
+      SAMPLE_DATA,
+    );
+
+    // PLUGINS_DIR = safeCwd()/.smalti/plugins → cwd is set to wsDir when spawning
+    const pluginDir = path.join(wsDir, '.smalti', 'plugins', 'test-plugin');
+    fs.mkdirSync(path.join(pluginDir, 'src'), { recursive: true });
+
+    const spec = {
+      id: 'plugin-test',
+      name: 'test-plugin',
+      description: 'Test plugin',
+      version: '0.1.0',
+      permissions: ['fs:read'],
+      entryPoint: 'src/index.js',
+      tools: [
+        {
+          name: 'read-todos',
+          description: 'Read todos via legacy .aide/ path',
+          parameters: { type: 'object', properties: {} },
+        },
+      ],
+    };
+    fs.writeFileSync(
+      path.join(pluginDir, 'plugin.spec.json'),
+      JSON.stringify(spec, null, 2),
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, 'tool.json'),
+      JSON.stringify(
+        { pluginId: spec.id, pluginName: spec.name, version: spec.version, tools: spec.tools },
+        null,
+        2,
+      ),
+    );
+
+    // Plugin code hardcodes the PRE-rebrand `.aide/` path
+    const pluginCode = `"use strict";
+const fs = require('fs');
+module.exports = {
+  name: 'test-plugin',
+  version: '0.1.0',
+  tools: [],
+  invoke: function(toolName, args) {
+    if (toolName === 'read-todos') {
+      // Legacy hardcoded path — alias rewrite must translate this to .smalti/
+      const content = fs.readFileSync('.aide/agent-todos.agent-todos.json', 'utf-8');
+      return JSON.parse(content);
+    }
+    throw new Error('Unknown tool: ' + toolName);
+  }
+};
+`;
+    fs.writeFileSync(path.join(pluginDir, 'src', 'index.js'), pluginCode);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reads .smalti/ data when plugin hardcodes .aide/ path', () => {
+    const serverPath = path.resolve(__dirname, '../../src/main/mcp/server.js');
+
+    const request =
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'smalti_invoke_tool',
+          arguments: { plugin_name: 'test-plugin', tool_name: 'read-todos', args: {} },
+        },
+      }) + '\n';
+
+    let stdout: string;
+    try {
+      stdout = execFileSync(process.execPath, [serverPath], {
+        // cwd = wsDir so that PLUGINS_DIR = wsDir/.smalti/plugins
+        cwd: wsDir,
+        env: {
+          ...process.env,
+          SMALTI_WORKSPACE: wsDir,
+        },
+        input: request,
+        encoding: 'utf-8',
+        timeout: 5000,
+      });
+    } catch (err: unknown) {
+      const e = err as { stdout?: string; stderr?: string; message?: string };
+      throw new Error(
+        `server.js process failed:\nstdout: ${e.stdout ?? ''}\nstderr: ${e.stderr ?? ''}\n${e.message ?? ''}`,
+      );
+    }
+
+    const lines = stdout.trim().split('\n').filter(Boolean);
+    expect(lines.length).toBeGreaterThan(0);
+    const response = JSON.parse(lines[lines.length - 1]);
+
+    expect(response.error, `unexpected error: ${JSON.stringify(response.error)}`).toBeUndefined();
+    expect(response.result).toBeDefined();
+
+    const resultText = response.result.content[0].text;
+    const parsed = JSON.parse(resultText);
+    expect(parsed.tasks).toEqual([{ id: 't1', title: 'hello' }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Equivalence test — server.js resolveWorkspaceRel must match sandbox.ts
+// ---------------------------------------------------------------------------
+
+/**
+ * AC-2: Regex equivalence between sandbox.ts resolveWorkspaceRel() and the
+ * inline copy in server.js. Both files use the same replace() pattern —
+ * extracting the regex literal from each source and comparing them catches
+ * any future drift without needing to execute TypeScript-typed code in vm.
+ */
+describe('resolveWorkspaceRel equivalence — sandbox.ts vs server.js (AC-2)', () => {
+  it('sandbox.ts and server.js use the same .aide alias regex', () => {
+    const sandboxSource = fs.readFileSync(
+      path.resolve(__dirname, '../../src/main/plugin/sandbox.ts'),
+      'utf-8',
+    );
+    const serverSource = fs.readFileSync(
+      path.resolve(__dirname, '../../src/main/mcp/server.js'),
+      'utf-8',
+    );
+
+    // Extract the replace() regex from each file.
+    // Both should contain: .replace(/^(\.\/?)?\.aide(\/|$)/, ...)
+    const sandboxMatch = sandboxSource.match(/filePath\.replace\(([^,]+),/);
+    const serverMatch = serverSource.match(/fp\.replace\(([^,]+),/);
+
+    expect(sandboxMatch).not.toBeNull();
+    expect(serverMatch).not.toBeNull();
+
+    const sandboxRegex = sandboxMatch![1].trim();
+    const serverRegex = serverMatch![1].trim();
+    expect(serverRegex).toBe(sandboxRegex);
+  });
+
+  it('server.js resolveWorkspaceRel produces correct alias outputs for all expected inputs', () => {
+    const resolve = loadResolveWorkspaceRel();
+    const cases: Array<[string, string]> = [
+      ['.aide/data.json', path.resolve(WS, '.smalti', 'data.json')],
+      ['./.aide/plugins/todo/data.json', path.resolve(WS, '.smalti', 'plugins', 'todo', 'data.json')],
+      ['normal/path.txt', path.resolve(WS, 'normal', 'path.txt')],
+      ['.aide', path.resolve(WS, '.smalti')],
+      ['.aide/', path.resolve(WS, '.smalti')],
+      ['a/.aide/nested', path.resolve(WS, 'a', '.aide', 'nested')],
+      ['.smalti/data.json', path.resolve(WS, '.smalti', 'data.json')],
+      ['aide-foo', path.resolve(WS, 'aide-foo')],
+    ];
+    for (const [input, expected] of cases) {
+      expect(resolve(WS, input)).toBe(expected);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug fix**: MCP server (`src/main/mcp/server.js`) now applies the `.aide/` → `.smalti/` alias rewrite that v0.2.2 added to `src/main/plugin/sandbox.ts`. Without this, every plugin call routed through MCP (Claude/Gemini/Codex agents) saw `.aide/` resolve to a missing directory — the agent-todo-board kanban with 86 tasks was reported as empty for users upgrading from v0.1.x.
- **Migration redesign**: Audited the three migration scripts (home, userData, workspace) plus their callers and ratified the design in `docs/spec/migration-prd.md`. PRD maps 19 surface areas, defines 8 acceptance criteria, and pins back-compat retention vs. drop policy.
- **Test coverage**: +23 tests (637 → 660). New suites cover MCP sandbox alias (per-method + boundary + sandbox.ts equivalence), Claude/Gemini/Codex global config migration including TOML array preservation, and home migration partial-failure / marker-resurrected source.
- **Supplementary cleanup**: migrateProjectMcpJson now strips both aide and smalti keys from workspace .mcp.json (smalti is delivered per-invocation via --mcp-config; a workspace-level entry causes duplicate spawns). server.js doc strings updated for brand consistency. CLAUDE.md Known Pitfalls documents the duplicated sandbox.

## Root cause

Two sandbox implementations exist because src/main/mcp/server.js is loaded as a standalone JS via ?raw import and cannot consume TS modules. The v0.2.2 hotfix patched sandbox.ts (Electron in-app plugin invoke) but left server.js (MCP plugin invoke) untouched. The alias logic is now inlined in both places, with a property-based equivalence test asserting the two regex literals match.

## Verification

- pnpm test — 74 files / 660 passed / 0 failed / 3 skipped
- pnpm lint — no new errors
- End-to-end smoke: spawning the patched server.js and invoking plugin_agent-todo-board_get_board with the legacy default .aide/agent-todos.agent-todos.json path returns the expected 86 tasks (done 69 / todo 14 / in_progress 2 / in-progress 1) from .smalti/.

## Test plan

- [ ] Open the smalti app, confirm the kanban panel shows existing tasks (not empty)
- [ ] From inside an in-app terminal, invoke a Claude/Gemini/Codex agent and call the agent-todo-board tools — verify reads/writes hit .smalti/agent-todos.agent-todos.json even though plugins still hardcode .aide/
- [ ] Run pnpm test locally — should be 660 passed
- [ ] Spot-check docs/spec/migration-prd.md for accuracy against the actual code paths

## Out of scope

- Rewriting .aide/ hardcodes inside user-installed plugin source code (sandbox alias handles this at runtime)
- window.aide, aide:* postMessage protocol, aide.fs/aide.plugin sandbox identifiers — intentionally retained per PRD §4.5
- Long-term DRY consolidation of the duplicated sandbox logic (would require Vite plugin to inject shared code into the ?raw bundle); guarded by the equivalence test for now

🤖 Generated with [Claude Code](https://claude.com/claude-code)