### PR TITLE
feat(workspace): enable New Folder button in workspace dialog

### DIFF
--- a/src/main/ipc/workspace-handlers.ts
+++ b/src/main/ipc/workspace-handlers.ts
@@ -163,7 +163,7 @@ export function registerWorkspaceHandlers(ipcMain: IpcMain): void {
 
   ipcMain.handle(IPC_CHANNELS.WORKSPACE_OPEN_DIALOG, async () => {
     const win = BrowserWindow.getFocusedWindow();
-    const result = await dialog.showOpenDialog(win!, { properties: ['openDirectory'] });
+    const result = await dialog.showOpenDialog(win!, { properties: ['openDirectory', 'createDirectory'] });
     if (result.canceled || result.filePaths.length === 0) return null;
     return result.filePaths[0];
   });
@@ -185,7 +185,7 @@ export function registerWorkspaceHandlers(ipcMain: IpcMain): void {
     const win = BrowserWindow.getFocusedWindow();
     const result = await dialog.showOpenDialog(win!, {
       title: 'Select parent directory for new project',
-      properties: ['openDirectory'],
+      properties: ['openDirectory', 'createDirectory'],
     });
     if (result.canceled || result.filePaths.length === 0) return null;
     const projectPath = nodePath.join(result.filePaths[0], projectName);


### PR DESCRIPTION
## Summary
- Add `createDirectory` to the `showOpenDialog` properties for both the workspace open dialog and the new-project parent-folder dialog.
- On macOS this surfaces the native "New Folder" button in the Finder dialog, so users can create the target directory in-place instead of pre-creating it elsewhere.

## Test plan
- [ ] Run app on macOS, click "Open Workspace" → confirm "New Folder" button visible in dialog
- [ ] Create a new folder from the dialog and select it → workspace registers correctly
- [ ] Same flow via "Create Project" path