### PR TITLE
docs: post-v0.3.1 wrap — wiki ingest + TRD migration drift fix

### DIFF
--- a/docs/spec/TRD.md
+++ b/docs/spec/TRD.md
@@ -207,7 +207,7 @@ interface ToolRegistry {
 
 #### 2.5 Plugin Workspace Isolation
 
-플러그인은 **워크스페이스 단위로만** 관리된다. 글로벌 플러그인 개념은 없으며, 모든 플러그인은 `{workspace}/.aide/plugins/`에 저장된다. smalti는 프로젝트 루트에 어떠한 파일도 생성하지 않는다 (예: `.mcp.json` 미생성 — MCP 서버는 spawn 시점의 cwd에서 플러그인 경로를 유도).
+플러그인은 **워크스페이스 단위로만** 관리된다. 글로벌 플러그인 개념은 없으며, 모든 플러그인은 `{workspace}/.smalti/plugins/`에 저장된다 (v0.2.x 이전의 `.aide/plugins/` 경로는 `migrate-aide-workspace.ts`가 자동 마이그레이션). smalti는 프로젝트 루트에 어떠한 파일도 생성하지 않는다 (예: `.mcp.json` 미생성 — MCP 서버는 spawn 시점의 cwd에서 플러그인 경로를 유도).
 
 **워크스페이스 전환 시 플러그인 갱신 흐름**:
 
@@ -244,7 +244,7 @@ Main: refreshPlugins(ws-b)
 
 **설계 원칙**:
 - 발신자(emitter)는 반환값을 받지 않는다 — 응답이 필요하면 수신 플러그인이 발신 플러그인으로 별도 emit
-- 바인딩은 `.aide/settings.json`에 선언적으로 정의
+- 바인딩은 `.smalti/settings.json`에 선언적으로 정의 (v0.1.x plugin이 hardcode한 `.aide/settings.json`은 sandbox alias로 자동 rewrite — [[mcp-server-sandbox-duplication]] 참조)
 - 권한(`pluginPermissions`)도 같은 파일에서 관리
 - 워크스페이스 스코프 내 로컬 + 글로벌 플러그인 간 통신 가능
 
@@ -605,6 +605,8 @@ aide/
 - 파일시스템 접근은 `plugin.spec.json`의 permissions에 따라 제한
 - 네트워크/프로세스 접근은 명시적 허용 필요
 - 실행 시간 및 메모리 제한 적용
+- **Sandbox는 두 곳에 구현되어 있다** — Electron 앱 내부 plugin invoke 경로의 `src/main/plugin/sandbox.ts` (renderer → main → vm)와 외부 MCP agent 호출 경로의 `src/main/mcp/server.js` (stdio JSON-RPC → 자체 vm). server.js는 `?raw` import되는 standalone JS이므로 sandbox.ts의 TypeScript 모듈을 import할 수 없어 sandbox 로직이 inline으로 복제된다. 두 구현 사이의 의미 차이는 `tests/unit/server-sandbox-alias.test.ts`의 동등성 속성 테스트가 회귀를 차단한다. 자세한 배경은 [[mcp-server-sandbox-duplication]] 참조.
+- v0.1.x plugin이 hardcode한 workspace-relative `.aide/` 경로는 양쪽 sandbox 모두 `resolveWorkspaceRel()`로 `.smalti/`로 자동 alias rewrite한다 (PR #143, v0.3.1). Plugin source code 자체의 `.aide/` 문자열은 사용자 워크스페이스 산물이므로 자동 수정하지 않으며 — runtime alias로 처리한다.
 
 ### Rust Native Module
 - fs-handlers의 path traversal 가드: `isExcluded()` 및 절대 경로 정규화로 워크스페이스 루트 외부 접근 차단

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -10,6 +10,7 @@
 - [[rust-core-migration]] — Phase 0+1 완료: chokidar → Rust notify, fs ops → Rust aide-core+napi
 
 ## Debugging
+- [[mcp-server-sandbox-duplication]] — MCP server.js와 plugin/sandbox.ts가 plugin sandbox를 중복 구현, v0.2.2 alias 동기화 누락으로 칸반 데이터 안 보인 P0 버그(v0.3.1 수정)
 - [[eperm-uv-cwd-bugfix]] — pty 스폰/plugin:list EPERM 에러, process.cwd() 미검증 원인 및 수정
 - [[main-process-cpu-home-watcher-bugfix]] — DMG idle CPU 127% 이슈, fallback cwd로 HOME 전체를 감시하던 chokidar watcher 라이프사이클 재설계
 

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -13,6 +13,7 @@
 2026-04-17 [ingest] Created [[app-settings-persistence]] — 테마 + 윈도우 해상도 저장/복원, aide-app-settings electron-store 추가 (PR #54)
 2026-04-22 [ingest] Created [[rust-core-migration]] — promoted from ideation after PRs #90/#91/#92/#93/#94 merged (Phase 0 spike + Phase 1 readTree/fsops/watcher swap)
 2026-04-24 [update] Cross-ref cleanup: [[rebrand-partide]] and [[rebrand-wnide]] marked as historical (SUPERSEDED), [[rebrand-smalti]] elevated as current candidate. Bidirectional `related` frontmatter links restored. `rust-core-migration` crate naming discussion updated to reference smalti.
+2026-05-02 [ingest] Created [[mcp-server-sandbox-duplication]] — v0.2.2 alias가 sandbox.ts에만 적용되고 server.js에는 빠져 칸반 데이터 안 보인 P0 버그, v0.3.1에서 alias inline 복제 + 동등성 속성 테스트로 회귀 가드 (PR #143, release v0.3.1)
 2026-04-24 [update] E4: docs/wiki brand sweep — formerly AIDE brand references migrated to smalti, code identifiers preserved.
 2026-04-25 [update] D6 follow-up: renderer-side user-visible strings (Welcome/EmptyState hero `> aide_` → `> smalti_`, TitleBar label, PermissionBanner EPERM message) migrated to smalti. Guard test [[../../tests/unit/brand-renderer-strings.test.ts]] added.
 2026-04-25 [update] Live theme application: re-aliased legacy `--background`/`--surface`/`--accent` CSS variables in `global.css` to smalti palette C values for both dark and light. All existing `aide-*` Tailwind classes now render with the new palette without component churn.

--- a/docs/wiki/mcp-server-sandbox-duplication.md
+++ b/docs/wiki/mcp-server-sandbox-duplication.md
@@ -1,0 +1,74 @@
+---
+title: "MCP server.js sandbox duplicates plugin/sandbox.ts"
+category: debugging
+tags: [mcp, sandbox, plugin, migration, ?raw-import, dry]
+created: 2026-05-02
+updated: 2026-05-02
+related: [[plugin-scope-local-only]], [[rust-core-migration]]
+---
+
+# MCP server.js sandbox duplicates plugin/sandbox.ts
+
+Plugin sandbox 로직이 두 곳에 중복 구현되어 있고, 둘 사이의 동기화가 깨졌을 때 사용자 데이터가 사라진 것처럼 보이는 P0 버그가 발생했다. v0.3.1에서 alias를 양쪽에 정렬하고 동등성 속성 테스트로 회귀를 차단했다.
+
+## 증상
+
+v0.1.x 시절 만들어진 plugin이 hardcode한 `<workspace>/.aide/...` 경로를 MCP를 거쳐 호출하면 빈 데이터가 반환되거나 빈 파일이 새로 생성되었다. 같은 plugin을 Electron 앱 내부 iframe에서 호출하면 정상 동작했다. 본 사용자는 agent-todo-board 칸반에 86개 task가 저장되어 있었지만 Claude/Gemini/Codex agent가 호출할 때마다 0건 또는 새로 생성된 빈 보드를 봤다.
+
+## 재현 경로
+
+1. v0.1.x 워크스페이스에서 만든 plugin이 `const DEFAULT_FILE = '.aide/<name>.json';` 류로 데이터 파일 경로를 hardcode (예: `.smalti/plugins/agent-todo-board/src/index.js`)
+2. v0.2.0 리브랜드 후 워크스페이스 데이터가 `<ws>/.smalti/`로 이동(`migrate-aide-workspace.ts`로 자동 마이그레이션)
+3. Plugin은 여전히 코드 안에서 `.aide/`를 들고 있음 — plugin source는 사용자 워크스페이스 산물이라 일괄 rewrite 불가
+4. Electron 앱 내부의 iframe→`src/main/plugin/sandbox.ts` 경로는 v0.2.2 핫픽스(commit `af12c95`)가 추가한 `resolveWorkspaceRel()`이 `.aide/` → `.smalti/` 자동 alias rewrite ✅
+5. MCP를 거치는 외부 agent 호출(Claude/Gemini/Codex)은 `src/main/mcp/server.js`의 별도 sandbox 구현을 거치는데, 이 쪽엔 alias가 없음 ❌
+6. 결과적으로 `.aide/...` 경로가 `path.resolve(ws, fp)`로 그대로 풀려 존재하지 않는 디렉토리를 시도, 또는 새 빈 파일을 생성함
+
+## 근본 원인
+
+**Plugin sandbox 로직이 두 파일에 독립적으로 구현되어 있다.**
+
+| 구현 위치 | 사용 경로 | v0.2.2 alias 적용 |
+|----------|----------|-------------------|
+| `src/main/plugin/sandbox.ts` | Electron renderer → main → vm context (앱 내부 plugin invoke) | ✅ `resolveWorkspaceRel()` |
+| `src/main/mcp/server.js` | MCP stdio JSON-RPC → 자체 vm context (Claude/Gemini/Codex MCP plugin invoke) | ❌ 누락 |
+
+중복이 발생한 구조적 이유는 빌드 시스템 제약이다. `server.js`는 `src/main/mcp/config-writer.ts`가 `?raw` import로 읽어 standalone JS로 `~/.smalti/smalti-mcp-server.js`에 dump한다. 따라서 TypeScript module(`sandbox.ts`)을 import할 수 없다. v0.2.2 핫픽스가 sandbox.ts에만 alias를 추가하고 server.js의 동일 로직을 빠뜨려도 빌드/타입 시스템이 이를 잡지 못한다.
+
+## 수정 (v0.3.1, PR #143)
+
+1. **Inline 복제**: `server.js`에 동일 의미의 `resolveWorkspaceRel(ws, fp)`를 inline으로 추가하고, `scopedFs`의 모든 9개 fs 메서드(`read`, `write`, `existsSync`, `readFileSync`, `writeFileSync`, `mkdirSync`, `readdirSync`, `statSync`, `unlinkSync`)에서 `path.resolve(ws, fp)` 직전에 호출.
+
+2. **동등성 속성 테스트**: `tests/unit/server-sandbox-alias.test.ts`에 양쪽 sandbox의 regex 리터럴을 소스에서 직접 추출해 문자열 비교하는 테스트, 그리고 8개 입력 케이스(`.aide/x`, `./.aide/y`, `a/.aide/z`, 절대 경로, mid-segment 등)에 대해 양쪽 함수 결과가 동일한지 검증하는 테스트 추가. 한쪽 regex가 변경되면 CI에서 즉시 실패.
+
+3. **Workspace boundary 안전성**: alias rewrite는 `assertInWs()` 이전에 적용. `.aide/../../escape` 같은 탈출 시도가 alias 후에도 boundary check에 걸리는지 별도 테스트로 검증.
+
+4. **CLAUDE.md "Known Pitfalls"** 항목 추가:
+
+   > **MCP server.js: sandbox alias는 sandbox.ts와 동기화 필수**
+   > server.js는 `?raw` import되는 standalone JS로, sandbox.ts의 `resolveWorkspaceRel()`을 import할 수 없다. server.js 내부에 동등 로직을 inline으로 유지하며 `tests/unit/server-sandbox-alias.test.ts`가 양쪽의 동등성을 검증한다. sandbox.ts의 alias 로직을 변경할 때는 반드시 server.js의 inline 로직도 함께 업데이트할 것.
+
+## 재발 방지
+
+- **테스트 회귀 가드**: `pnpm test`가 동등성을 매번 검증. 한쪽 regex 변경 시 즉시 실패.
+- **CLAUDE.md 명시화**: 향후 sandbox 변경 작업자가 두 파일을 함께 봐야 한다는 규약을 텍스트로 박음.
+- **새 plugin generator 가이드**: `server.js`의 `CREATE_PLUGIN_DESC`에 워크스페이스 데이터 경로 컨벤션(`<workspace>/.smalti/...`) 명시. 새 plugin은 `.aide/` hardcode를 시작부터 안 하도록 LLM 가이드.
+
+## 비범위 (PRD §7.1)
+
+- **Plugin source의 `.aide/` hardcode 일괄 rewrite는 수행하지 않음.** Plugin 소스는 사용자 워크스페이스 산물이며, 자동 수정은 의도하지 않은 부작용(주석 내 참조, 문자열 리터럴 등)을 일으킬 수 있다. Sandbox alias가 런타임에 투명하게 처리하므로 소스 수정은 불필요.
+- **`window.aide`, `aide:file-event`, `aide.fs` 등 API 식별자는 무기한 유지.** 이들은 plugin iframe 통신 프로토콜 + preload contextBridge API + sandbox 전역의 일부이며, rename은 모든 기존 plugin HTML을 깨뜨린다. PRD §4.5에 명시.
+
+## 장기 정리 (선택)
+
+DRY 위반은 동등성 테스트가 가드하지만 코드 자체는 여전히 두 곳에 있다. 더 깔끔한 해소 방법은:
+
+- **Vite plugin으로 빌드 시 alias 코드를 server.js에 주입**: `?raw` import 결과 문자열을 후처리해 sandbox.ts의 함수를 prepend. 빌드 파이프라인 복잡도 증가 — 현재는 비범위(PRD §5.1 선택지 D 채택).
+
+## 관련 파일
+
+- `src/main/plugin/sandbox.ts` — Electron 앱 내부 plugin sandbox + `resolveWorkspaceRel()` 원본
+- `src/main/mcp/server.js` — MCP standalone sandbox + alias inline 복제본 (v0.3.1)
+- `tests/unit/server-sandbox-alias.test.ts` — 23개 테스트, 동등성 속성 테스트 포함
+- `docs/spec/migration-prd.md` — Migration PRD (19 surface areas, 8 ACs, back-compat 정책)
+- PR [#143](https://github.com/Achelous1/smalti/pull/143) (fix), v0.3.1 release commit `44bfb83`


### PR DESCRIPTION
## Summary

Doc-only follow-up to the v0.3.1 release ([#144](https://github.com/Achelous1/aide/pull/144)). Captures the sandbox duplication incident in the LLM wiki and brings TRD into sync with the post-rebrand workspace layout that has been live since v0.2.0 but never reflected in the spec.

## Wiki

- **New** [`docs/wiki/mcp-server-sandbox-duplication.md`](docs/wiki/mcp-server-sandbox-duplication.md) (debugging category) — symptom, reproduction path, root cause (`?raw`-imported `server.js` cannot consume `sandbox.ts`), the v0.3.1 fix (inline alias + property-based equivalence test), explicit scoped-out items (legacy plugin source rewrite, `window.aide` rename), and the long-term Vite injection alternative.
- **Updated** `docs/wiki/log.md` and `docs/wiki/index.md` to register the new page under Debugging (placed at the top of the section as the most recent significant finding).

## TRD drift fix

Three locations carried the pre-rebrand layout. All updated to current reality with back-pointers to the wiki:

| Section | Before | After |
|---|---|---|
| §2.5 Plugin Workspace Isolation | `{workspace}/.aide/plugins/` | `{workspace}/.smalti/plugins/` + note about `migrate-aide-workspace.ts` |
| §2.6 Event bindings | `.aide/settings.json` | `.smalti/settings.json` + back-pointer to `[[mcp-server-sandbox-duplication]]` |
| §Plugin Sandbox (Security) | Single sandbox described | Added paragraph explaining the two implementations (`sandbox.ts` for in-app, `server.js` for MCP) and the equivalence-test guard |

## Test plan

- [x] No code changes; `pnpm test` and `pnpm lint` not affected
- [ ] Reviewer skim — wiki page reads as a self-contained debugging postmortem (frontmatter present, cross-refs valid)
- [ ] TRD edits stay surgical (no surrounding paragraph rewording)

🤖 Generated with [Claude Code](https://claude.com/claude-code)