### PR TITLE
fix(workspace): serialize setActive to stop tabs leaking across switches

### DIFF
--- a/src/renderer/stores/workspace-store.ts
+++ b/src/renderer/stores/workspace-store.ts
@@ -18,7 +18,7 @@ interface WorkspaceState {
   addWorkspace: (workspace: WorkspaceInfo) => void;
   removeWorkspace: (id: string) => void;
   renameWorkspace: (id: string, name: string) => void;
-  setActive: (id: string | null) => void;
+  setActive: (id: string | null) => Promise<void>;
   toggleNav: () => void;
   setSidePanelTab: (tab: SidePanelTab) => void;
   setSelectedFilePath: (path: string | null) => void;
@@ -26,24 +26,20 @@ interface WorkspaceState {
   loadWorkspaces: () => Promise<void>;
 }
 
-export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
-  workspaces: [],
-  activeWorkspaceId: null,
-  recentProjects: [],
-  navExpanded: true,
-  sidePanelTab: 'files',
-  selectedFilePath: null,
-  setSidePanelTab: (tab) => set({ sidePanelTab: tab ?? 'files' }),
-  setSelectedFilePath: (path) => set({ selectedFilePath: path }),
-  addWorkspace: (workspace) =>
-    set((state) => ({ workspaces: [...state.workspaces, workspace] })),
-  removeWorkspace: (id) =>
-    set((state) => ({ workspaces: state.workspaces.filter((w) => w.id !== id) })),
-  renameWorkspace: (id, name) =>
-    set((state) => ({
-      workspaces: state.workspaces.map((w) => (w.id === id ? { ...w, name } : w)),
-    })),
-  setActive: async (id) => {
+export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
+  // Serialize workspace activation. setActive() runs several awaits (workspace
+  // open, plugin list, restoreSession's PTY spawns) before it commits the new
+  // `activeWorkspaceId` at the very end. Two overlapping calls — a double-click,
+  // a re-render double-fire, or a fast second switch — would otherwise BOTH read
+  // the same stale `prevId`, cache/persist the wrong workspace's layout, and
+  // leave `layout` desynced from `activeWorkspaceId`: the departing workspace's
+  // live tabs stay rendered under the newly-activated one (worse on Windows,
+  // where slow ConPTY spawns widen the race). Chaining each activation after the
+  // previous one guarantees every call observes the prior call's committed
+  // `activeWorkspaceId` as its `prevId`.
+  let activationChain: Promise<void> = Promise.resolve();
+
+  const activate = async (id: string | null): Promise<void> => {
     const prevId = get().activeWorkspaceId;
     if (id && id !== prevId) {
       // 1. Save departing workspace state (to disk and in-memory cache). PTYs are NOT killed.
@@ -96,27 +92,54 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       await usePluginStore.getState().loadPlugins();
     }
     set({ activeWorkspaceId: id });
-  },
-  toggleNav: () => set((state) => ({ navExpanded: !state.navExpanded })),
-  loadRecent: (projects) => set({ recentProjects: projects.slice(0, 5) }),
-  loadWorkspaces: async () => {
-    const [workspaces, recent] = await Promise.all([
-      window.aide.workspace.list(),
-      window.aide.workspace.recent(),
-    ]);
-    set({ workspaces, recentProjects: recent.slice(0, 5) });
+  };
 
-    // Auto-open the most recently accessed workspace on app launch.
-    // Only fires when no workspace is active yet (i.e. fresh boot, not after
-    // user has navigated away). The recent list is ordered newest-first, and
-    // we verify the workspace still exists in the workspaces list before
-    // activating to avoid resurrecting a deleted project.
-    if (!get().activeWorkspaceId && recent.length > 0) {
-      const mostRecent = recent[0];
-      const stillExists = workspaces.some((w) => w.id === mostRecent.id);
-      if (stillExists) {
-        await get().setActive(mostRecent.id);
+  return {
+    workspaces: [],
+    activeWorkspaceId: null,
+    recentProjects: [],
+    navExpanded: true,
+    sidePanelTab: 'files',
+    selectedFilePath: null,
+    setSidePanelTab: (tab) => set({ sidePanelTab: tab ?? 'files' }),
+    setSelectedFilePath: (path) => set({ selectedFilePath: path }),
+    addWorkspace: (workspace) =>
+      set((state) => ({ workspaces: [...state.workspaces, workspace] })),
+    removeWorkspace: (id) =>
+      set((state) => ({ workspaces: state.workspaces.filter((w) => w.id !== id) })),
+    renameWorkspace: (id, name) =>
+      set((state) => ({
+        workspaces: state.workspaces.map((w) => (w.id === id ? { ...w, name } : w)),
+      })),
+    setActive: (id) => {
+      // Queue behind any in-flight activation so prevId is always read after the
+      // previous switch has committed activeWorkspaceId. The chain keeps running
+      // even if one activation rejects.
+      const run = activationChain.then(() => activate(id));
+      activationChain = run.catch(() => { /* swallow so the chain survives */ });
+      return run;
+    },
+    toggleNav: () => set((state) => ({ navExpanded: !state.navExpanded })),
+    loadRecent: (projects) => set({ recentProjects: projects.slice(0, 5) }),
+    loadWorkspaces: async () => {
+      const [workspaces, recent] = await Promise.all([
+        window.aide.workspace.list(),
+        window.aide.workspace.recent(),
+      ]);
+      set({ workspaces, recentProjects: recent.slice(0, 5) });
+
+      // Auto-open the most recently accessed workspace on app launch.
+      // Only fires when no workspace is active yet (i.e. fresh boot, not after
+      // user has navigated away). The recent list is ordered newest-first, and
+      // we verify the workspace still exists in the workspaces list before
+      // activating to avoid resurrecting a deleted project.
+      if (!get().activeWorkspaceId && recent.length > 0) {
+        const mostRecent = recent[0];
+        const stillExists = workspaces.some((w) => w.id === mostRecent.id);
+        if (stillExists) {
+          await get().setActive(mostRecent.id);
+        }
       }
-    }
-  },
-}));
+    },
+  };
+});

--- a/tests/unit/workspace-switch-serialization.test.ts
+++ b/tests/unit/workspace-switch-serialization.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Regression test for the "tabs follow into the new workspace" bug.
+ *
+ * Bug (intermittent, Windows-prone because slow ConPTY spawns widen the race):
+ * switching from a workspace WITH tabs to one WITHOUT tabs sometimes left the
+ * departing workspace's LIVE tabs rendered under the new workspace (both in the
+ * main terminal area and the WorkspaceNav sidebar).
+ *
+ * Root cause: setActive() is async and unguarded. It reads
+ *   const prevId = get().activeWorkspaceId
+ * at the start but only commits `set({ activeWorkspaceId: id })` at the very end,
+ * after several awaits. When two setActive() calls overlap, the second reads a
+ * STALE prevId — so it saves/caches the wrong workspace's layout under the wrong
+ * key, desyncing `layout` from `activeWorkspaceId`.
+ *
+ * Fix: serialize setActive() so a second call cannot begin until the first has
+ * committed activeWorkspaceId. Then every call observes the correct prevId.
+ *
+ * This test overlaps two switches (ws-1 -> ws-2, then ws-1 -> ws-3 fired before
+ * the first resolves) and asserts the departing workspace each call persists is
+ * correct. Without serialization the second call still sees prevId === 'ws-1',
+ * so the snapshot for 'ws-2' is never written.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useWorkspaceStore } from '../../src/renderer/stores/workspace-store';
+import { useLayoutStore, createPane } from '../../src/renderer/stores/layout-store';
+import { useTerminalStore } from '../../src/renderer/stores/terminal-store';
+import { usePluginStore } from '../../src/renderer/stores/plugin-store';
+import type { SavedSession } from '../../src/types/ipc';
+
+describe('workspace-store.setActive — concurrent switch serialization', () => {
+  const savedWorkspaceIds: string[] = [];
+
+  beforeEach(() => {
+    savedWorkspaceIds.length = 0;
+
+    vi.stubGlobal('window', {
+      aide: {
+        workspace: {
+          open: vi.fn().mockResolvedValue(undefined),
+          list: vi.fn().mockResolvedValue([]),
+          recent: vi.fn().mockResolvedValue([]),
+        },
+        plugin: {
+          list: vi.fn().mockResolvedValue([]),
+          activate: vi.fn().mockResolvedValue(undefined),
+          deactivate: vi.fn().mockResolvedValue(undefined),
+          onChanged: vi.fn(() => () => { /* unsub */ }),
+        },
+        session: {
+          // No saved session for any workspace — the destination workspaces are
+          // "empty", matching the user's repro (switch into a tab-less workspace).
+          load: vi.fn().mockResolvedValue(null),
+          save: vi.fn(async (session: SavedSession) => {
+            savedWorkspaceIds.push(session.workspaceId);
+          }),
+        },
+        terminal: { spawn: vi.fn().mockResolvedValue({ ok: true, sessionId: 'sess-1' }) },
+      },
+    });
+
+    // Start already inside ws-1, which has a live shell tab.
+    const liveTab = { id: 'tab-A', type: 'shell' as const, sessionId: 'sess-A', title: '$ shell' };
+    const pane = createPane([liveTab], liveTab.id);
+    useLayoutStore.setState({ layout: pane, focusedPaneId: pane.id });
+    useTerminalStore.setState({ tabs: [liveTab], activeTabId: liveTab.id, dropdownOpen: false, workspaceTabs: {} });
+    usePluginStore.setState({ plugins: [], loading: false, error: null, generating: false, generateError: null });
+    useWorkspaceStore.setState({
+      workspaces: [
+        { id: 'ws-1', name: 'A', path: '/tmp/a' },
+        { id: 'ws-2', name: 'B', path: '/tmp/b' },
+        { id: 'ws-3', name: 'C', path: '/tmp/c' },
+      ],
+      activeWorkspaceId: 'ws-1',
+      recentProjects: [],
+      navExpanded: true,
+      sidePanelTab: 'files',
+    } as Parameters<typeof useWorkspaceStore.setState>[0]);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('second overlapping switch observes the first committed activeWorkspaceId as its prevId', async () => {
+    const setActive = useWorkspaceStore.getState().setActive;
+
+    // Fire two switches back-to-back without awaiting the first — this is the
+    // overlap a double-click / re-render double-fire produces.
+    const p1 = setActive('ws-2');
+    const p2 = setActive('ws-3');
+    await Promise.all([p1, p2]);
+
+    // The first switch leaves ws-1 -> must persist ws-1.
+    expect(savedWorkspaceIds).toContain('ws-1');
+    // The second switch leaves ws-2 (the workspace the first switch entered).
+    // Without serialization it reads the stale prevId 'ws-1' and never saves ws-2.
+    expect(savedWorkspaceIds).toContain('ws-2');
+
+    // End state must be self-consistent: active workspace is the last target and
+    // its (empty) layout carries none of ws-1's live tabs.
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe('ws-3');
+    const tabs = useLayoutStore.getState().getAllPanes().flatMap((p) => p.tabs);
+    expect(tabs.find((t) => t.sessionId === 'sess-A')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes an intermittent bug where switching from a workspace **with** tabs to one **without** tabs left the departing workspace's **live** tabs rendered under the new workspace — visible in both the main terminal area and the WorkspaceNav sidebar. More frequent on Windows because slow ConPTY spawns widen the race.

## Root cause
`workspace-store.setActive()` is async and unguarded. It reads `prevId = get().activeWorkspaceId` at the start but only commits `set({ activeWorkspaceId: id })` at the very end, after several awaits (`workspace.open`, `plugin.list`, `restoreSession`'s PTY spawns). When two calls overlap (double-click, a re-render double-fire, or a fast second switch), the second call reads a **stale `prevId`**, caches/persists the wrong workspace's layout under the wrong key, and desyncs `layout` from `activeWorkspaceId`. The sidebar derives the active workspace's tabs from the live `layout`, so the stale layout surfaces in both places, with real live-PTY tabs.

## Fix
Serialize `setActive()` through a promise chain so a second call cannot begin until the previous one has committed `activeWorkspaceId`. Every activation then observes the correct `prevId`. No behavior change for non-overlapping switches.

## Test
Adds `workspace-switch-serialization.test.ts`, which overlaps two switches and asserts the second persists the correct departing workspace. It fails before the fix (both calls read `prevId = 'ws-1'`, so `'ws-2'` is never saved) and passes after.

## Test Plan
- [x] New regression test passes; fails without the fix
- [x] `pnpm lint` passes
- [x] `pnpm test` — 658 passed (the lone `native-read-tree.test.ts` `EPERM symlink` failure is a Windows symlink-privilege environment constraint, unrelated)
- [ ] Manual: on Windows, rapidly switch from a tab-heavy workspace into an empty one and confirm no tabs carry over (main area + sidebar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)