### PR TITLE
perf(workspace): parallel + optimistic PTY restore on workspace entry

### DIFF
--- a/src/renderer/stores/layout-store.ts
+++ b/src/renderer/stores/layout-store.ts
@@ -702,14 +702,23 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
     // previous session where layout and activePlugins drifted apart.
     const activePluginSet = new Set(session.activePlugins ?? []);
 
-    async function rebuildNode(node: SerializableLayoutNode): Promise<LayoutNode> {
+    // Build the layout tree synchronously with shell/agent tabs in a
+    // 'spawning' state, collecting a spawn job per tab. The layout is committed
+    // immediately (below) so the workspace renders without blocking on any PTY;
+    // the slow part (ConPTY spawn / agent resume) then runs in parallel and each
+    // tab's sessionId is attached as its spawn resolves. This mirrors
+    // spawnTabInBackground for new tabs — restoring no longer serially awaits K
+    // spawns before showing anything.
+    interface SpawnJob { tabId: string; isAgent: boolean; agentId?: string; agentSessionId?: string }
+    const spawnJobs: SpawnJob[] = [];
+
+    function buildNode(node: SerializableLayoutNode): LayoutNode {
       if ('direction' in node && 'children' in node) {
         const split = node as SerializableSplitLayout;
-        const children = await Promise.all(split.children.map(rebuildNode));
         return {
           id: split.id,
           direction: split.direction,
-          children,
+          children: split.children.map(buildNode),
           sizes: split.sizes,
         } as SplitLayout;
       }
@@ -737,43 +746,25 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
           useTerminalStore.getState().addTab(tab);
           if (savedTab.isActive) activeTabId = tab.id;
         } else {
-          // shell or agent — spawn new PTY
-          let sessionId: string | null = null;
-          const isAgent = savedTab.type === 'agent';
-          const agentResult = await window.aide.terminal.spawn({
-            shell: savedTab.agentId || undefined,
-            cwd: wsPath,
-            agentType: isAgent ? (savedTab.agentId as 'claude' | 'gemini' | 'codex' | undefined) : undefined,
-            resumeSessionId: savedTab.agentSessionId,
-            continueSession: isAgent && !savedTab.agentSessionId,
+          // shell or agent — render now in 'spawning' state; the PTY is spawned
+          // in parallel below and its sessionId attached when it resolves.
+          const tab: TerminalTab = {
+            id: savedTab.id,
+            type: savedTab.type,
+            agentId: savedTab.agentId,
+            agentSessionId: savedTab.agentSessionId,
+            title: savedTab.title,
+            spawnState: 'spawning',
+          };
+          tabs.push(tab);
+          useTerminalStore.getState().addTab(tab);
+          spawnJobs.push({
+            tabId: savedTab.id,
+            isAgent: savedTab.type === 'agent',
+            agentId: savedTab.agentId,
+            agentSessionId: savedTab.agentSessionId,
           });
-          if (agentResult.ok) {
-            sessionId = agentResult.sessionId;
-          } else {
-            // agent not installed or spawn failed — fall back to plain shell
-            console.warn('[smalti] Session restore: agent spawn failed, falling back to shell', agentResult.error);
-            const shellResult = await window.aide.terminal.spawn({ cwd: wsPath });
-            if (shellResult.ok) {
-              sessionId = shellResult.sessionId;
-            } else {
-              console.warn('[smalti] Session restore: shell spawn also failed, skipping tab', shellResult.error);
-              restoreFailCount++;
-            }
-          }
-
-          if (sessionId) {
-            const tab: TerminalTab = {
-              id: savedTab.id,
-              type: savedTab.type,
-              agentId: savedTab.agentId,
-              agentSessionId: savedTab.agentSessionId,
-              sessionId,
-              title: savedTab.title,
-            };
-            tabs.push(tab);
-            useTerminalStore.getState().addTab(tab);
-            if (savedTab.isActive) activeTabId = tab.id;
-          }
+          if (savedTab.isActive) activeTabId = tab.id;
         }
       }
 
@@ -788,8 +779,44 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
       return { id: savedPane.id, tabs, activeTabId } as Pane;
     }
 
-    const restoredLayout = await rebuildNode(session.layout);
-    set({ layout: restoredLayout, focusedPaneId: session.focusedPaneId });
+    // Commit the layout up front so the workspace appears instantly.
+    const builtLayout = buildNode(session.layout);
+    set({ layout: builtLayout, focusedPaneId: session.focusedPaneId });
+
+    // Spawn every saved PTY in parallel; attach each sessionId as it resolves,
+    // or mark the tab failed (PaneView renders the state) if spawn fails.
+    await Promise.all(
+      spawnJobs.map(async (job) => {
+        let sessionId: string | null = null;
+        const agentResult = await window.aide.terminal.spawn({
+          shell: job.agentId || undefined,
+          cwd: wsPath,
+          agentType: job.isAgent ? (job.agentId as 'claude' | 'gemini' | 'codex' | undefined) : undefined,
+          resumeSessionId: job.agentSessionId,
+          continueSession: job.isAgent && !job.agentSessionId,
+        });
+        if (agentResult.ok) {
+          sessionId = agentResult.sessionId;
+        } else {
+          // agent not installed or spawn failed — fall back to plain shell
+          console.warn('[smalti] Session restore: agent spawn failed, falling back to shell', agentResult.error);
+          const shellResult = await window.aide.terminal.spawn({ cwd: wsPath });
+          if (shellResult.ok) {
+            sessionId = shellResult.sessionId;
+          } else {
+            console.warn('[smalti] Session restore: shell spawn also failed', shellResult.error);
+            restoreFailCount++;
+          }
+        }
+
+        if (sessionId) {
+          get().updateTabSessionId(job.tabId, sessionId);
+          useTerminalStore.getState().updateTabSession(job.tabId, sessionId);
+        } else {
+          get().markTabSpawnFailed(job.tabId);
+        }
+      }),
+    );
 
     // Restore active plugins — await so registry is settled before loadPlugins() runs
     await Promise.allSettled(

--- a/tests/unit/restore-session-parallel.test.ts
+++ b/tests/unit/restore-session-parallel.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression test for slow workspace entry (restoreSession).
+ *
+ * Before: restoreSession respawned each saved tab's PTY one-by-one with
+ * `await terminal.spawn()` inside a for-loop, and only committed the layout
+ * AFTER every spawn resolved. On Windows each ConPTY spawn is slow, so a
+ * workspace with K tabs blocked for the SUM of K serial spawns before anything
+ * rendered.
+ *
+ * After: the layout is committed immediately with tabs in a 'spawning' state
+ * (optimistic render), and all PTYs are spawned in parallel; each tab's
+ * sessionId is attached as its spawn resolves.
+ *
+ * The two deferred-spawn assertions below fail on the old code:
+ *  - parallel dispatch: old code calls spawn once and awaits it, so only 1
+ *    call is observed while spawns are pending (new code dispatches all).
+ *  - optimistic render: old code leaves the layout untouched until every spawn
+ *    resolves, so the restored tabs are absent while spawns are pending.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useWorkspaceStore } from '../../src/renderer/stores/workspace-store';
+import { useLayoutStore, createPane } from '../../src/renderer/stores/layout-store';
+import { useTerminalStore } from '../../src/renderer/stores/terminal-store';
+import { usePluginStore } from '../../src/renderer/stores/plugin-store';
+import type { TerminalSpawnResult } from '../../src/types/ipc';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 10));
+
+describe('layout-store.restoreSession — parallel + optimistic spawn', () => {
+  let pending: Array<{ resolve: (v: TerminalSpawnResult) => void }>;
+
+  beforeEach(() => {
+    pending = [];
+
+    vi.stubGlobal('window', {
+      aide: {
+        session: {
+          load: vi.fn().mockResolvedValue({
+            version: 1,
+            workspaceId: 'ws-1',
+            savedAt: 1,
+            layout: {
+              id: 'pane-1',
+              tabs: [
+                { id: 't1', type: 'shell', title: '$ a', isActive: true },
+                { id: 't2', type: 'shell', title: '$ b', isActive: false },
+              ],
+              activeTabId: 't1',
+            },
+            focusedPaneId: 'pane-1',
+            activePlugins: [],
+            sidePanelTab: 'files',
+          }),
+          save: vi.fn().mockResolvedValue(undefined),
+        },
+        terminal: {
+          spawn: vi.fn(() => {
+            const d = deferred<TerminalSpawnResult>();
+            pending.push(d);
+            return d.promise;
+          }),
+        },
+        plugin: { activate: vi.fn().mockResolvedValue(undefined) },
+      },
+    });
+
+    const pane = createPane();
+    useLayoutStore.setState({ layout: pane, focusedPaneId: pane.id });
+    useTerminalStore.setState({ tabs: [], activeTabId: null, dropdownOpen: false, workspaceTabs: {} });
+    usePluginStore.setState({ plugins: [], loading: false, error: null, generating: false, generateError: null });
+    useWorkspaceStore.setState({
+      workspaces: [{ id: 'ws-1', name: 'A', path: '/tmp/a' }],
+      activeWorkspaceId: 'ws-1',
+      recentProjects: [],
+      navExpanded: true,
+      sidePanelTab: 'files',
+    } as Parameters<typeof useWorkspaceStore.setState>[0]);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('commits the layout immediately and spawns all tabs in parallel', async () => {
+    const done = useLayoutStore.getState().restoreSession('ws-1');
+    await flush(); // let session.load resolve + synchronous layout build + spawn dispatch
+
+    // Optimistic render: both tabs are already present, in 'spawning' state,
+    // before any spawn has resolved.
+    const tabs = useLayoutStore.getState().getAllPanes().flatMap((p) => p.tabs);
+    expect(tabs.map((t) => t.id).sort()).toEqual(['t1', 't2']);
+    expect(tabs.every((t) => t.spawnState === 'spawning' && !t.sessionId)).toBe(true);
+
+    // Parallel dispatch: both spawns were fired without waiting for the first.
+    expect((window.aide.terminal.spawn as ReturnType<typeof vi.fn>).mock.calls.length).toBe(2);
+    expect(pending.length).toBe(2);
+
+    // Resolve spawns out of order; sessionIds attach and 'spawning' clears.
+    pending[1].resolve({ ok: true, sessionId: 'sess-2' });
+    pending[0].resolve({ ok: true, sessionId: 'sess-1' });
+    await done;
+
+    const after = useLayoutStore.getState().getAllPanes().flatMap((p) => p.tabs);
+    const t1 = after.find((t) => t.id === 't1');
+    const t2 = after.find((t) => t.id === 't2');
+    expect(t1?.sessionId).toBe('sess-1');
+    expect(t2?.sessionId).toBe('sess-2');
+    expect(after.every((t) => !t.spawnState)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Entering a workspace with saved tabs was slow. `restoreSession()` respawned each tab's PTY one-by-one with `await terminal.spawn()` in a for-loop and committed the layout only **after every spawn resolved**. On Windows each ConPTY spawn is slow (agent tabs also run a synchronous PATH walk in `resolveWindowsExecutable` + agent resume), so a pane with K tabs blocked for the **sum of K serial spawns** before anything rendered.

## Fix
`restoreSession()` now:
- builds the layout synchronously with shell/agent tabs in a `spawning` state and **commits it up front**, so the workspace renders instantly (same optimistic pattern as `spawnTabInBackground` for new tabs);
- spawns every saved PTY **in parallel** (`Promise.all`) and attaches each `sessionId` via `updateTabSessionId` as it resolves, or `markTabSpawnFailed` on failure (PaneView shows the state instead of silently dropping the tab).

Perceived entry time drops from *sum-of-serial-spawns* to ~*one spawn*. `restoreSession` still awaits all spawns before resolving, so the (now serialized) `setActive` captures live tabs in `saveWorkspaceTabs` — no loss if the user switches away mid-restore.

## Test
Adds `restore-session-parallel.test.ts`, which drives `restoreSession` with deferred spawns and asserts (a) the layout is committed with `spawning` tabs **before** any spawn resolves and (b) all spawns are dispatched in parallel. Both assertions fail on the old serial/late-commit code.

## Test Plan
- [x] New regression test passes; fails on old code (verified RED→GREEN)
- [x] `pnpm lint` clean
- [x] `pnpm test` — 659 passed (lone failure `native-read-tree.test.ts` `EPERM symlink` is a Windows symlink-privilege env constraint, unrelated)
- [ ] Manual on Windows: enter a workspace with several tabs and confirm it renders immediately, tabs fill in as PTYs come up

🤖 Generated with [Claude Code](https://claude.com/claude-code)