### PR TITLE
style(ui): switch primary font to Cascadia Mono

### DIFF
--- a/src/renderer/lib/xterm-cache.ts
+++ b/src/renderer/lib/xterm-cache.ts
@@ -26,7 +26,7 @@ export function getOrCreate(sessionId: string, theme: ITheme): CachedTerminal {
 
   const term = new Terminal({
     theme,
-    fontFamily: "'JetBrainsMono Nerd Font Mono', 'JetBrainsMono NF', 'MesloLGS NF', 'JetBrains Mono', 'IBM Plex Mono', Menlo, Monaco, 'Symbols Nerd Font Mono', monospace",
+    fontFamily: "'Cascadia Mono', 'CaskaydiaCove Nerd Font Mono', 'JetBrainsMono Nerd Font Mono', 'JetBrainsMono NF', 'MesloLGS NF', 'JetBrains Mono', 'IBM Plex Mono', Menlo, Monaco, 'Symbols Nerd Font Mono', monospace",
     fontSize: 13,
     unicodeVersion: '11',
     cursorBlink: true,

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -99,7 +99,7 @@ html, body, #root {
 }
 
 body {
-  font-family: 'JetBrains Mono', 'IBM Plex Mono', monospace;
+  font-family: 'Cascadia Mono', 'JetBrains Mono', 'IBM Plex Mono', monospace;
   background: var(--background);
   color: var(--text-primary);
 }
@@ -214,7 +214,7 @@ body {
 }
 
 .drag-drop-overlay__text {
-  font-family: 'JetBrains Mono', 'IBM Plex Mono', monospace;
+  font-family: 'Cascadia Mono', 'JetBrains Mono', 'IBM Plex Mono', monospace;
   font-size: 12px;
   color: var(--accent);
   opacity: 0.9;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -53,7 +53,7 @@ module.exports = {
         'smalti-ink-950':  '#0A0B10',
       },
       fontFamily: {
-        mono: ['JetBrains Mono', 'IBM Plex Mono', 'monospace'],
+        mono: ['Cascadia Mono', 'JetBrains Mono', 'IBM Plex Mono', 'monospace'],
       },
     },
   },


### PR DESCRIPTION
## Summary
Make **Cascadia Mono** the primary monospace font across the UI and terminal, keeping JetBrains Mono / IBM Plex Mono as fallbacks (neither is bundled — the app relies on the system font) so text still renders where Cascadia Mono is absent. Cascadia Mono ships with Windows 11.

## Changes
- `tailwind.config.js` — prepend `'Cascadia Mono'` to `fontFamily.mono` (drives every `font-mono` UI element, ~19 components)
- `global.css` — `body` + drag-drop overlay `font-family`
- `xterm-cache.ts` — terminal `fontFamily`: `'Cascadia Mono'` first, with the Nerd Font glyph fallbacks (`CaskaydiaCove` / `Symbols Nerd Font Mono`) kept so Powerline/Nerd Font glyphs still render

## Test Plan
- [x] `pnpm lint` clean
- [ ] Visual: confirm UI + terminal render in Cascadia Mono on Windows 11; verify Nerd Font glyphs still display in the terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)